### PR TITLE
feat(#9): Scan bytecode classes

### DIFF
--- a/src/it/successful-path/src/main/java/org/eolang/jeo/Application.java
+++ b/src/it/successful-path/src/main/java/org/eolang/jeo/Application.java
@@ -1,0 +1,8 @@
+package org.eolang.jeo;
+
+public class Application {
+
+    public static void main(String[] args) {
+        System.out.println("Hello, World!");
+    }
+}

--- a/src/it/successful-path/verify.groovy
+++ b/src/it/successful-path/verify.groovy
@@ -24,4 +24,5 @@
 String log = new File(basedir, 'build.log').text;
 log.contains("BUILD SUCCESS")
 log.contains("jeo optimization is finished successfully!")
+log.contains("Optimization candidate: Application.class")
 true

--- a/src/main/java/org/eolang/jeo/JeoMojo.java
+++ b/src/main/java/org/eolang/jeo/JeoMojo.java
@@ -42,6 +42,12 @@ import org.apache.maven.plugins.annotations.Parameter;
  * Goal which touches a timestamp file.
  *
  * @since 0.1.0
+ * @todo #9:90min Implement the optimization skeleton.
+ *  The optimization skeleton should be implemented without details. Just a sketch.
+ *  The skeleton should contain the next steps:
+ *  - Transpile all bytecode files to the eolang files (XMIR I guess).
+ *  - Invoke some XMIR optimizations (dummy for now).
+ *  - Transpile all XMIR files back to the bytecode.
  */
 @Mojo(name = "optimize", defaultPhase = LifecyclePhase.PROCESS_CLASSES)
 public final class JeoMojo extends AbstractMojo {

--- a/src/main/java/org/eolang/jeo/JeoMojo.java
+++ b/src/main/java/org/eolang/jeo/JeoMojo.java
@@ -24,9 +24,17 @@
 package org.eolang.jeo;
 
 import com.jcabi.log.Logger;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Goal which touches a timestamp file.
@@ -40,11 +48,39 @@ import org.apache.maven.plugins.annotations.Mojo;
 @Mojo(name = "optimize", defaultPhase = LifecyclePhase.PROCESS_CLASSES)
 public final class JeoMojo extends AbstractMojo {
 
+    @Parameter(property = "${project.build.outputDirectory}")
+    private File classes;
+
     /**
      * The main entry point of the plugin.
      */
     public void execute() {
+        try {
+            this.tryExecute();
+        } catch (final IOException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    /**
+     * Try to execute the plugin.
+     * @throws IOException If some I/O problem arises
+     */
+    private void tryExecute() throws IOException {
         Logger.info(this, "The first dummy implementation of jeo-maven-plugin");
+        this.bytecode().forEach(path -> Logger.info(this, "Found class: %s", path));
         Logger.info(this, "jeo optimization is finished successfully!");
+    }
+
+    /**
+     * Find all bytecode files.
+     * @return Collection of bytecode files
+     * @throws IOException If some I/O problem arises
+     */
+    private Collection<Path> bytecode() throws IOException {
+        try (final Stream<Path> walk = Files.walk(this.classes.toPath())) {
+            return walk.filter(path -> path.toString().endsWith(".class"))
+                .collect(Collectors.toList());
+        }
     }
 }

--- a/src/main/java/org/eolang/jeo/JeoMojo.java
+++ b/src/main/java/org/eolang/jeo/JeoMojo.java
@@ -34,7 +34,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -43,19 +42,21 @@ import org.apache.maven.plugins.annotations.Parameter;
  * Goal which touches a timestamp file.
  *
  * @since 0.1.0
- * @todo #5:30min Add logging for the plugin entry point.
- *  The plugin should log the entry point of the plugin. Maybe it should log the
- *  list of already compiled classes. When it will be done, remove that
- *  puzzle.
  */
 @Mojo(name = "optimize", defaultPhase = LifecyclePhase.PROCESS_CLASSES)
 public final class JeoMojo extends AbstractMojo {
 
+    /**
+     * Project compiled classes.
+     * @since 0.1.0
+     */
     @Parameter(defaultValue = "${project.build.outputDirectory}")
     private File classes;
 
     /**
      * The main entry point of the plugin.
+     *
+     * @throws MojoExecutionException If some execution problem arises
      */
     public void execute() throws MojoExecutionException {
         try {
@@ -88,7 +89,7 @@ public final class JeoMojo extends AbstractMojo {
                 "The classes directory is not set, jeo-maven-plugin does not know where to look for classes."
             );
         }
-        try (final Stream<Path> walk = Files.walk(this.classes.toPath())) {
+        try (Stream<Path> walk = Files.walk(this.classes.toPath())) {
             return walk.filter(path -> path.toString().endsWith(".class"))
                 .collect(Collectors.toList());
         }


### PR DESCRIPTION
Scan bytecode classes inside ./target/classes folder

History:
- feat(#9): Add several small methods to log bytecode classes
- feat(#9): Add ugly working implementation and integration test check
- feat(#9): remove the puzzle for #9 issue
- feat(#9): add a puzzle for the future implementation of the jeo-maven-lugin

Closes: #9


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `Application` class in `org.eolang.jeo` package with a `main` method that prints "Hello, World!"
- Added `optimize` goal to `JeoMojo` class in `org.eolang.jeo` package
- Added `bytecode` method to find all bytecode files in the project
- Added logging statements in `JeoMojo` class
- Added `classes` parameter to specify the project compiled classes directory

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->