### PR TITLE
feat(#34): Modify integration test to check if class compiled successfully

### DIFF
--- a/src/it/successful-path/pom.xml
+++ b/src/it/successful-path/pom.xml
@@ -49,6 +49,24 @@ SOFTWARE.
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <phase>
+              process-classes
+            </phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>org.eolang.jeo.Application</mainClass>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/it/successful-path/src/main/java/org/eolang/jeo/Application.java
+++ b/src/it/successful-path/src/main/java/org/eolang/jeo/Application.java
@@ -1,7 +1,6 @@
 package org.eolang.jeo;
 
 public class Application {
-
     public static void main(String[] args) {
         System.out.println("Hello, World!");
     }

--- a/src/it/successful-path/verify.groovy
+++ b/src/it/successful-path/verify.groovy
@@ -23,12 +23,22 @@
  */
 //Check logs first.
 String log = new File(basedir, 'build.log').text;
-log.contains("BUILD SUCCESS")
-log.contains("jeo optimization is finished successfully!")
-log.contains("Optimization candidate: Application.class")
-log.contains("Hello, World!")
+assert log.contains("BUILD SUCCESS")
+assert log.contains("Hello, World!")
 //Check that we have generated XMIR object file.
-//todo
-new File(basedir, 'target/it/successful-path/Application.xmir').exists()
+/**
+ * @todo #34:90min Implement XMIR generation.
+ *   XMIR generation is not implemented yet, so we can't check it.
+ *   Invert the followed assertion when XMIR generation will be implemented.
+ */
+assert !new File(basedir, 'target/jeo/objects/org/eolang/jeo/Application.xmir').exists()
 //Check that class file was changed
+/**
+ * @todo #34:90min Implement class recompilation.
+ *   Class recompilation is not implemented yet, so we can't check it.
+ *   Invert the followed assertion when class recompilation will be implemented.
+ *   Under recompilation we mean that class file should be compiled from
+ *   XMIR object file.
+ */
+assert !log.contains("Application.class was recompiled successfully.")
 true

--- a/src/it/successful-path/verify.groovy
+++ b/src/it/successful-path/verify.groovy
@@ -21,8 +21,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+//Check logs first.
 String log = new File(basedir, 'build.log').text;
 log.contains("BUILD SUCCESS")
 log.contains("jeo optimization is finished successfully!")
 log.contains("Optimization candidate: Application.class")
+log.contains("Hello, World!")
+//Check that we have generated XMIR object file.
+//todo
+new File(basedir, 'target/it/successful-path/Application.xmir').exists()
+//Check that class file was changed
 true


### PR DESCRIPTION
Modify integration test to check if compiled class was compiled successfully.
Closes: #34


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a Maven plugin to execute the Application class and verify the build success. 

### Detailed summary
- Added `exec-maven-plugin` to `pom.xml` to execute the `Application` class.
- Added assertions to check for build success and the output message.
- Added comments to indicate pending implementation for XMIR generation and class recompilation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->