### PR TITLE
feat(#41): Remove anonymouns class from XmirFootprintTest

### DIFF
--- a/src/main/java/org/eolang/jeo/XmlIR.java
+++ b/src/main/java/org/eolang/jeo/XmlIR.java
@@ -1,0 +1,32 @@
+package org.eolang.jeo;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+
+/**
+ * Intermediate representation of a class files from XMIR.
+ *
+ * @since 0.1.0
+ */
+public class XmlIR implements IR {
+
+    private final XML xml;
+
+    public XmlIR() {
+        this(new XMLDocument("<test/>"));
+    }
+
+    private XmlIR(final XML xml) {
+        this.xml = xml;
+    }
+
+    @Override
+    public XML toEO() {
+        return this.xml;
+    }
+
+    @Override
+    public byte[] toBytecode() {
+        return new byte[0];
+    }
+}

--- a/src/main/java/org/eolang/jeo/XmlIR.java
+++ b/src/main/java/org/eolang/jeo/XmlIR.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo;
 
 import com.jcabi.xml.XML;
@@ -8,14 +31,24 @@ import com.jcabi.xml.XMLDocument;
  *
  * @since 0.1.0
  */
-public class XmlIR implements IR {
+public final class XmlIR implements IR {
 
+    /**
+     * XML.
+     */
     private final XML xml;
 
-    public XmlIR() {
+    /**
+     * Constructor.
+     */
+    XmlIR() {
         this(new XMLDocument("<test/>"));
     }
 
+    /**
+     * Constructor.
+     * @param xml XML.
+     */
     private XmlIR(final XML xml) {
         this.xml = xml;
     }

--- a/src/test/java/org/eolang/jeo/XmirFootprintTest.java
+++ b/src/test/java/org/eolang/jeo/XmirFootprintTest.java
@@ -23,8 +23,6 @@
  */
 package org.eolang.jeo;
 
-import com.jcabi.xml.XML;
-import com.jcabi.xml.XMLDocument;
 import java.nio.file.Path;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
@@ -36,31 +34,13 @@ import org.junit.jupiter.api.io.TempDir;
  * Test case for {@link XmirFootprint}.
  *
  * @since 0.1.0
- * @todo #36:90min Replace anonymous class with a Fake class.
- *  We need to replace anonymous class in savesXml test method with a Fake class.
- *  For example, we can create a Fake class that implements IR interface and
- *  returns a fake XMLDocument in toEO method and an empty byte array in toBytecode method.
- *  Then we can use this Fake class in the test method and in other tests too.
  */
 final class XmirFootprintTest {
 
     @Test
     void savesXml(@TempDir final Path temp) {
         final XmirFootprint footprint = new XmirFootprint(temp);
-        footprint.apply(
-            Collections.singleton(
-                new IR() {
-                    @Override
-                    public XML toEO() {
-                        return new XMLDocument("<test/>");
-                    }
-
-                    @Override
-                    public byte[] toBytecode() {
-                        return new byte[0];
-                    }
-                })
-        );
+        footprint.apply(Collections.singleton(new XmlIR()));
         MatcherAssert.assertThat(
             "XML file was not saved",
             temp.resolve("jeo")


### PR DESCRIPTION
Remove anonymous class from XmirFootprintTest.

Closes: #41


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The PR replaces an anonymous class with a new `XmlIR` class in the `savesXml` test method of `XmirFootprintTest`.
- The `XmlIR` class implements the `IR` interface and returns a fake XMLDocument in the `toEO` method and an empty byte array in the `toBytecode` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->