### PR TITLE
feat(#39): Simple implementation of dynamic saving IR into correct places

### DIFF
--- a/src/main/java/org/eolang/jeo/BytecodeIr.java
+++ b/src/main/java/org/eolang/jeo/BytecodeIr.java
@@ -86,8 +86,7 @@ final class BytecodeIr implements IR {
 
     @Override
     public String name() {
-        //todo;
-        return null;
+        return "todo";
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/BytecodeIr.java
+++ b/src/main/java/org/eolang/jeo/BytecodeIr.java
@@ -85,6 +85,12 @@ final class BytecodeIr implements IR {
     }
 
     @Override
+    public String name() {
+        //todo;
+        return null;
+    }
+
+    @Override
     public XML toEO() {
         try (InputStream stream = new UncheckedInput(this.input).stream()) {
             final ClassPrinter printer = new ClassPrinter();

--- a/src/main/java/org/eolang/jeo/BytecodeIr.java
+++ b/src/main/java/org/eolang/jeo/BytecodeIr.java
@@ -54,6 +54,12 @@ import org.xembly.Xembler;
  *  We have to provide the simplest implementation of the next chain:
  *  bytecode -> XMIR -> bytecode
  *  Input and output bytecode should be the same.
+ * @todo #39:90min Implement BytecodeIR#name() method.
+ *  The method should return the name of the object from Bytecode.
+ *  We have to parse the Bytecode and extract the name from it.
+ *  Moreover we have to add package name to the name of the object.
+ *  Remove this puzzle when the method is ready.
+ *  Don't forget about unit tests.
  */
 @ToString
 @SuppressWarnings({
@@ -86,7 +92,7 @@ final class BytecodeIr implements IR {
 
     @Override
     public String name() {
-        return "todo";
+        return "org.eolang.jeo.Application";
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/IR.java
+++ b/src/main/java/org/eolang/jeo/IR.java
@@ -33,6 +33,12 @@ import com.jcabi.xml.XML;
 public interface IR {
 
     /**
+     * Name of the class or an object.
+     * @return Name.
+     */
+    String name();
+
+    /**
      * Convert to EOlang XML representation (XMIR).
      * @return XML.
      */

--- a/src/main/java/org/eolang/jeo/XmirFootprint.java
+++ b/src/main/java/org/eolang/jeo/XmirFootprint.java
@@ -23,7 +23,7 @@
  */
 package org.eolang.jeo;
 
-import com.jcabi.xml.XML;
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -53,33 +53,24 @@ final class XmirFootprint implements Boost {
 
     @Override
     public Collection<IR> apply(final Collection<IR> representations) {
-        representations.stream().map(IR::toEO).forEach(this::tryToSave);
+        representations.stream().forEach(this::tryToSave);
         return representations;
     }
 
     /**
      * Try to save XML to the target folder.
-     * @param xml XML to save.
-     * @todo #36:90min Hardcoded XMIR path.
-     *  The XMIR path is hardcoded in the tryToSave method.
-     *  It should be flexible and related to the Java class name.
-     *  For example, if the class is org.eolang.jeo.Dummy,
-     *  the XMIR path should be org/eolang/jeo/Dummy.xmir.
-     *  if the class is org.eolang.jeo.Fake, the XMIR path should be
-     *  org/eolang/jeo/Fake.xmir and so on.
+     * @param representation XML to save.
      */
-    private void tryToSave(final XML xml) {
+    private void tryToSave(final IR representation) {
+        final String name = representation.name();
         final Path path = this.target.resolve("jeo")
             .resolve("xmir")
-            .resolve("org")
-            .resolve("eolang")
-            .resolve("jeo")
-            .resolve("Application.xmir");
+            .resolve(String.format("%s.xmir", name.replace('.', File.separatorChar)));
         try {
             Files.createDirectories(path.getParent());
             Files.write(
                 path,
-                xml.toString().getBytes(StandardCharsets.UTF_8),
+                representation.toString().getBytes(StandardCharsets.UTF_8),
                 StandardOpenOption.CREATE_NEW
             );
         } catch (final IOException exception) {

--- a/src/main/java/org/eolang/jeo/XmirIR.java
+++ b/src/main/java/org/eolang/jeo/XmirIR.java
@@ -71,7 +71,7 @@ public final class XmirIR implements IR {
 
     @Override
     public String name() {
-        return "todo";
+        return "org.eolang.jeo.Application";
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/XmirIR.java
+++ b/src/main/java/org/eolang/jeo/XmirIR.java
@@ -30,8 +30,18 @@ import com.jcabi.xml.XMLDocument;
  * Intermediate representation of a class files from XMIR.
  *
  * @since 0.1.0
+ * @todo #39:90min Add unit test for XmirIR class.
+ *  The test should check all the methods of the {@link org.eolang.jeo.XmirIR} class.
+ *  Don't forget to test corner cases.
+ *  When the test is ready, remove this puzzle.
+ * @todo #39:90min Implement XmirIR#name() method.
+ *  The method should return the name of the object from XMIR.
+ *  We have to parse the XML and extract the name from it.
+ *  You can find examples for XMIR in the EOlang repository:
+ *  https://github.com/objectionary/eo
+ *  When the method is ready, remove this puzzle.
  */
-public final class XmlIR implements IR {
+public final class XmirIR implements IR {
 
     /**
      * XML.
@@ -41,16 +51,21 @@ public final class XmlIR implements IR {
     /**
      * Constructor.
      */
-    XmlIR() {
-        this(new XMLDocument("<test/>"));
+    XmirIR() {
+        this(new XMLDocument("<xmir/>"));
     }
 
     /**
      * Constructor.
      * @param xml XML.
      */
-    private XmlIR(final XML xml) {
-        this.xml = xml;
+    private XmirIR(final XML xml) {
+        this.xml = XmirIR.xmir(xml);
+    }
+
+    @Override
+    public String name() {
+        return "todo";
     }
 
     @Override
@@ -61,5 +76,11 @@ public final class XmlIR implements IR {
     @Override
     public byte[] toBytecode() {
         return new byte[0];
+    }
+
+
+    private static XML xmir(final XML xml) {
+        new Schema(xml).check();
+        return xml;
     }
 }

--- a/src/main/java/org/eolang/jeo/XmirIR.java
+++ b/src/main/java/org/eolang/jeo/XmirIR.java
@@ -25,6 +25,12 @@ package org.eolang.jeo;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import org.xembly.Directives;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
 
 /**
  * Intermediate representation of a class files from XMIR.
@@ -52,7 +58,7 @@ public final class XmirIR implements IR {
      * Constructor.
      */
     XmirIR() {
-        this(new XMLDocument("<xmir/>"));
+        this(XmirIR.fake());
     }
 
     /**
@@ -78,9 +84,47 @@ public final class XmirIR implements IR {
         return new byte[0];
     }
 
-
+    /**
+     * Validate XMIR.
+     * @param xml XML.
+     * @return XMIR.
+     */
     private static XML xmir(final XML xml) {
         new Schema(xml).check();
         return xml;
     }
+
+    /**
+     * Fake XMIR.
+     * @return XMIR.
+     */
+    private static XML fake() {
+        try {
+            final String now = ZonedDateTime.now(ZoneOffset.UTC)
+                .format(DateTimeFormatter.ISO_INSTANT);
+            return new XMLDocument(
+                new Xembler(
+                    new Directives()
+                        .add("program")
+                        .attr("name", "Unknown")
+                        .attr("version", "0.0.0")
+                        .attr("revision", "0.0.0")
+                        .attr("dob", now)
+                        .attr("time", now)
+                        .add("listing").up()
+                        .add("errors").up()
+                        .add("sheets").up()
+                        .add("license").up()
+                        .add("metas").up()
+                        .attr("ms", System.currentTimeMillis())
+                        .add("objects")
+                        .add("o")
+                        .attr("name", "test")
+                ).xml()
+            );
+        } catch (final ImpossibleModificationException exception) {
+            throw new IllegalStateException("Can't create fake XML", exception);
+        }
+    }
+
 }

--- a/src/test/java/org/eolang/jeo/XmirFootprintTest.java
+++ b/src/test/java/org/eolang/jeo/XmirFootprintTest.java
@@ -40,7 +40,7 @@ final class XmirFootprintTest {
     @Test
     void savesXml(@TempDir final Path temp) {
         final XmirFootprint footprint = new XmirFootprint(temp);
-        footprint.apply(Collections.singleton(new XmlIR()));
+        footprint.apply(Collections.singleton(new XmirIR()));
         MatcherAssert.assertThat(
             "XML file was not saved",
             temp.resolve("jeo")


### PR DESCRIPTION
Save IR files into correct places according with package information.

Closes: #39


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing the `name()` method in the `IR` interface and its implementations. 

### Detailed summary
- Added `name()` method in `IR` interface.
- Implemented `name()` method in `BytecodeIr` and `XmirIR` classes.
- Updated `tryToSave()` method in `XmirFootprint` class to use the `name()` method of `IR` objects.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->