### PR TITLE
feat(#50): implement BytecodeIR#name() method

### DIFF
--- a/src/main/java/org/eolang/jeo/BytecodeIr.java
+++ b/src/main/java/org/eolang/jeo/BytecodeIr.java
@@ -56,12 +56,6 @@ import org.xembly.Xembler;
  *  We have to provide the simplest implementation of the next chain:
  *  bytecode -> XMIR -> bytecode
  *  Input and output bytecode should be the same.
- * @todo #39:90min Implement BytecodeIR#name() method.
- *  The method should return the name of the object from Bytecode.
- *  We have to parse the Bytecode and extract the name from it.
- *  Moreover we have to add package name to the name of the object.
- *  Remove this puzzle when the method is ready.
- *  Don't forget about unit tests.
  */
 @ToString
 @SuppressWarnings({

--- a/src/main/java/org/eolang/jeo/BytecodeIr.java
+++ b/src/main/java/org/eolang/jeo/BytecodeIr.java
@@ -98,7 +98,7 @@ final class BytecodeIr implements IR {
             final ClassName name = new ClassName();
             new ClassReader(new UncheckedInput(this.input).stream()).accept(name, 0);
             return name.asString();
-        } catch (IOException ex) {
+        } catch (final IOException ex) {
             throw new IllegalStateException(
                 String.format("Can't parse bytecode '%s'", this.input),
                 ex
@@ -132,33 +132,60 @@ final class BytecodeIr implements IR {
         return new UncheckedBytes(new BytesOf(this.input)).asBytes();
     }
 
+    /**
+     * Class name.
+     *
+     * @since 0.1.0
+     */
     private class ClassName extends ClassVisitor {
 
+        /**
+         * Atomic reference to store class name.
+         */
         private final AtomicReference<String> bag;
 
+        /**
+         * Constructor.
+         */
         ClassName() {
             this(new AtomicReference<>());
         }
 
-
+        /**
+         * Constructor.
+         * @param bag Atomic reference to store class name.
+         */
         ClassName(final AtomicReference<String> bag) {
             this(Opcodes.ASM9, bag);
         }
 
+        /**
+         * Constructor.
+         * @param api ASM API version.
+         * @param bag Atomic reference to store class name.
+         */
         private ClassName(final int api, final AtomicReference<String> bag) {
             super(api);
             this.bag = bag;
         }
 
         @Override
-        public void visit(final int version, final int access, final String name,
-            final String signature, final String superName,
+        public void visit(
+            final int version,
+            final int access,
+            final String name,
+            final String signature,
+            final String supername,
             final String[] interfaces
         ) {
             this.bag.set(name.replace('/', '.'));
-            super.visit(version, access, name, signature, superName, interfaces);
+            super.visit(version, access, name, signature, supername, interfaces);
         }
 
+        /**
+         * Get class name.
+         * @return Class name.
+         */
         String asString() {
             final String last = this.bag.get();
             if (Objects.isNull(last)) {

--- a/src/test/java/org/eolang/jeo/BytecodeIrTest.java
+++ b/src/test/java/org/eolang/jeo/BytecodeIrTest.java
@@ -63,4 +63,19 @@ final class BytecodeIrTest {
             Matchers.equalTo(actual)
         );
     }
+
+    @Test
+    void retrievesName() {
+        final ResourceOf input = new ResourceOf(BytecodeIrTest.METHOD_BYTE);
+        final String actual = new BytecodeIr(input).name();
+        final String expected = "org.eolang.jeo.MethodByte";
+        MatcherAssert.assertThat(
+            String.format(
+                "The name should be retrieved without exceptions and equal to the expected '%s'",
+                expected
+            ),
+            actual,
+            Matchers.equalTo(expected)
+        );
+    }
 }


### PR DESCRIPTION
Implement BytecodeIR#name() method.
Closes: #50


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added a new test method `retrievesName()` in the `BytecodeIrTest` class.
- Implemented the `name()` method in the `BytecodeIr` class.
- Added a private inner class `ClassName` in the `BytecodeIr` class to extract the name from the bytecode.
- Updated the `name()` method to parse the bytecode and return the name of the object from the bytecode.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->