### PR TITLE
feat(#64): Remove duplicatin between Optimization and BytecodeTranspilation

### DIFF
--- a/src/main/java/org/eolang/jeo/BytecodeClasses.java
+++ b/src/main/java/org/eolang/jeo/BytecodeClasses.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo;
 
 import java.io.IOException;
@@ -9,18 +32,31 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.BytecodeRepresentation;
 
-public class BytecodeClasses {
-
+/**
+ * Project compiled classes.
+ *
+ * @since 0.1.0
+ */
+public final class BytecodeClasses {
 
     /**
      * Project compiled classes.
      */
-    private final Path classes;
+    private final Path classpath;
 
+    /**
+     * Constructor.
+     * @param classes Folder with compiled classes.
+     */
     public BytecodeClasses(final Path classes) {
-        this.classes = classes;
+        this.classpath = classes;
     }
 
+    /**
+     * Get all bytecode files as a collection of {@link org.eolang.jeo.Representation}.
+     * @return Collection of {@link org.eolang.jeo.Representation}
+     * @throws IOException If some I/O problem arises.
+     */
     public Collection<BytecodeRepresentation> bytecode() throws IOException {
         return this.classes()
             .stream()
@@ -34,20 +70,20 @@ public class BytecodeClasses {
      * @throws java.io.IOException If some I/O problem arises
      */
     private Collection<Path> classes() throws IOException {
-        if (Objects.isNull(this.classes)) {
+        if (Objects.isNull(this.classpath)) {
             throw new IllegalStateException(
                 "The classes directory is not set, jeo-maven-plugin does not know where to look for classes."
             );
         }
-        if (!Files.exists(this.classes)) {
+        if (!Files.exists(this.classpath)) {
             throw new IllegalStateException(
                 String.format(
                     "The classes directory '%s' does not exist, jeo-maven-plugin does not know where to look for classes.",
-                    this.classes
+                    this.classpath
                 )
             );
         }
-        try (Stream<Path> walk = Files.walk(this.classes)) {
+        try (Stream<Path> walk = Files.walk(this.classpath)) {
             return walk.filter(path -> path.toString().endsWith(".class"))
                 .collect(Collectors.toList());
         }

--- a/src/main/java/org/eolang/jeo/BytecodeClasses.java
+++ b/src/main/java/org/eolang/jeo/BytecodeClasses.java
@@ -1,0 +1,55 @@
+package org.eolang.jeo;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.eolang.jeo.representation.BytecodeRepresentation;
+
+public class BytecodeClasses {
+
+
+    /**
+     * Project compiled classes.
+     */
+    private final Path classes;
+
+    public BytecodeClasses(final Path classes) {
+        this.classes = classes;
+    }
+
+    public Collection<BytecodeRepresentation> bytecode() throws IOException {
+        return this.classes()
+            .stream()
+            .map(BytecodeRepresentation::new)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Find all bytecode files.
+     * @return Collection of bytecode files
+     * @throws java.io.IOException If some I/O problem arises
+     */
+    private Collection<Path> classes() throws IOException {
+        if (Objects.isNull(this.classes)) {
+            throw new IllegalStateException(
+                "The classes directory is not set, jeo-maven-plugin does not know where to look for classes."
+            );
+        }
+        if (!Files.exists(this.classes)) {
+            throw new IllegalStateException(
+                String.format(
+                    "The classes directory '%s' does not exist, jeo-maven-plugin does not know where to look for classes.",
+                    this.classes
+                )
+            );
+        }
+        try (Stream<Path> walk = Files.walk(this.classes)) {
+            return walk.filter(path -> path.toString().endsWith(".class"))
+                .collect(Collectors.toList());
+        }
+    }
+}

--- a/src/main/java/org/eolang/jeo/Improvement.java
+++ b/src/main/java/org/eolang/jeo/Improvement.java
@@ -39,7 +39,9 @@ public interface Improvement {
      * @param representations IRs to optimize.
      * @return Optimized IRs.
      */
-    Collection<Representation> apply(Collection<Representation> representations);
+    Collection<? extends Representation> apply(
+        Collection<? extends Representation> representations
+    );
 
     /**
      * Mock improvement.
@@ -69,7 +71,9 @@ public interface Improvement {
         }
 
         @Override
-        public Collection<Representation> apply(final Collection<Representation> representations) {
+        public Collection<Representation> apply(
+            final Collection<? extends Representation> representations
+        ) {
             this.all.addAll(representations);
             return Collections.unmodifiableCollection(representations);
         }
@@ -91,7 +95,9 @@ public interface Improvement {
      */
     class Dummy implements Improvement {
         @Override
-        public Collection<Representation> apply(final Collection<Representation> representations) {
+        public Collection<Representation> apply(
+            final Collection<? extends Representation> representations
+        ) {
             return Collections.unmodifiableCollection(representations);
         }
     }

--- a/src/main/java/org/eolang/jeo/Optimization.java
+++ b/src/main/java/org/eolang/jeo/Optimization.java
@@ -28,11 +28,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collection;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.eolang.jeo.representation.BytecodeRepresentation;
 
 /**
  * Optimization by using the EO language.
@@ -68,10 +63,7 @@ final class Optimization {
      */
     void apply() throws IOException {
         this.improvements.apply(
-            this.bytecode()
-                .stream()
-                .map(BytecodeRepresentation::new)
-                .collect(Collectors.toList())
+            new BytecodeClasses(this.classes).bytecode()
         ).forEach(this::recompile);
     }
 
@@ -102,23 +94,6 @@ final class Optimization {
             );
         } catch (final IOException exception) {
             throw new IllegalStateException(String.format("Can't recompile '%s'", name), exception);
-        }
-    }
-
-    /**
-     * Find all bytecode files.
-     * @return Collection of bytecode files
-     * @throws IOException If some I/O problem arises
-     */
-    private Collection<Path> bytecode() throws IOException {
-        if (Objects.isNull(this.classes)) {
-            throw new IllegalStateException(
-                "The classes directory is not set, jeo-maven-plugin does not know where to look for classes."
-            );
-        }
-        try (Stream<Path> walk = Files.walk(this.classes)) {
-            return walk.filter(path -> path.toString().endsWith(".class"))
-                .collect(Collectors.toList());
         }
     }
 }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementLogged.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementLogged.java
@@ -40,7 +40,9 @@ import org.eolang.jeo.Representation;
  */
 public final class ImprovementLogged implements Improvement {
     @Override
-    public Collection<Representation> apply(final Collection<Representation> representations) {
+    public Collection<Representation> apply(
+        final Collection<? extends Representation> representations
+    ) {
         representations.forEach(
             ir -> Logger.info(this, "Optimization candidate: %s", ir)
         );

--- a/src/main/java/org/eolang/jeo/improvement/Improvements.java
+++ b/src/main/java/org/eolang/jeo/improvement/Improvements.java
@@ -59,12 +59,14 @@ public final class Improvements implements Improvement {
     }
 
     @Override
-    public Collection<Representation> apply(final Collection<Representation> representations) {
-        final Collection<Representation> result;
+    public Collection<? extends Representation> apply(
+        final Collection<? extends Representation> representations
+    ) {
+        final Collection<? extends Representation> result;
         if (this.all.isEmpty()) {
             result = Collections.emptyList();
         } else {
-            Collection<Representation> res = representations;
+            Collection<? extends Representation> res = representations;
             for (final Improvement current : this.all) {
                 res = current.apply(res);
             }

--- a/src/main/java/org/eolang/jeo/improvement/XmirFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/XmirFootprint.java
@@ -56,7 +56,9 @@ public final class XmirFootprint implements Improvement {
     }
 
     @Override
-    public Collection<Representation> apply(final Collection<? extends Representation> representations) {
+    public Collection<Representation> apply(
+        final Collection<? extends Representation> representations
+    ) {
         return representations.stream()
             .map(Representation::toEO)
             .map(XmirRepresentation::new)

--- a/src/main/java/org/eolang/jeo/improvement/XmirFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/XmirFootprint.java
@@ -56,7 +56,7 @@ public final class XmirFootprint implements Improvement {
     }
 
     @Override
-    public Collection<Representation> apply(final Collection<Representation> representations) {
+    public Collection<Representation> apply(final Collection<? extends Representation> representations) {
         return representations.stream()
             .map(Representation::toEO)
             .map(XmirRepresentation::new)

--- a/src/main/java/org/eolang/jeo/representation/BytecodeTranspilation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeTranspilation.java
@@ -24,12 +24,8 @@
 package org.eolang.jeo.representation;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collection;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import org.eolang.jeo.BytecodeClasses;
 import org.eolang.jeo.improvement.XmirFootprint;
 
 /**
@@ -74,35 +70,7 @@ public class BytecodeTranspilation {
      */
     public void transpile() throws IOException {
         new XmirFootprint(this.target).apply(
-            this.bytecode()
-                .stream()
-                .map(BytecodeRepresentation::new)
-                .collect(Collectors.toList())
+            new BytecodeClasses(this.classes).bytecode()
         );
-    }
-
-    /**
-     * Find all bytecode files.
-     * @return Collection of bytecode files
-     * @throws java.io.IOException If some I/O problem arises
-     */
-    private Collection<Path> bytecode() throws IOException {
-        if (Objects.isNull(this.classes)) {
-            throw new IllegalStateException(
-                "The classes directory is not set, jeo-maven-plugin does not know where to look for classes."
-            );
-        }
-        if (!Files.exists(this.classes)) {
-            throw new IllegalStateException(
-                String.format(
-                    "The classes directory '%s' does not exist, jeo-maven-plugin does not know where to look for classes.",
-                    this.classes
-                )
-            );
-        }
-        try (Stream<Path> walk = Files.walk(this.classes)) {
-            return walk.filter(path -> path.toString().endsWith(".class"))
-                .collect(Collectors.toList());
-        }
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/BytecodeTranspilation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeTranspilation.java
@@ -32,12 +32,6 @@ import org.eolang.jeo.improvement.XmirFootprint;
  * Transpilation of the bytecode to the EO.
  *
  * @since 0.1.0
- * @todo #58:30min Duplicate between BytecodeTranspilation and Optimization.
- *  Both classes do the same thing, but in different ways. We need to
- *  refactor them to use the same approach. When it's done, remove this
- *  puzzle. Classes:
- *  - {@link org.eolang.jeo.representation.BytecodeTranspilation}
- *  - {@link org.eolang.jeo.Optimization}
  */
 public class BytecodeTranspilation {
 


### PR DESCRIPTION
Remove code duplication between Optimization and BytecodeTranspilation.

Closes: #64


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the code by changing the method signature to accept a collection of any subtype of `Representation` instead of only `Representation` objects. 

### Detailed summary
- Updated method signatures in `XmirFootprint`, `ImprovementLogged`, `Improvements`, `Improvement`, `Mock`, `Dummy`, `Optimization`, `BytecodeTranspilation`, and `BytecodeClasses` classes to accept `Collection<? extends Representation>` instead of `Collection<Representation>`.
- Refactored `bytecode()` method in `Optimization` and `BytecodeTranspilation` classes to use `BytecodeClasses` class for finding bytecode files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->