### PR TITLE
feat(#70): Remove duplication between Optimization and EoToBytecode classes

### DIFF
--- a/src/main/java/org/eolang/jeo/EoToBytecodeMojo.java
+++ b/src/main/java/org/eolang/jeo/EoToBytecodeMojo.java
@@ -23,16 +23,12 @@
  */
 package org.eolang.jeo;
 
-import com.jcabi.log.Logger;
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.eolang.jeo.improvement.BytecodeFootprint;
 
 /**
  * Converts EO to bytecode.
@@ -64,38 +60,7 @@ public final class EoToBytecodeMojo extends AbstractMojo {
 
     @Override
     public void execute() {
-        new EoObjects(this.target.toPath())
-            .objects()
-            .forEach(this::recompile);
-    }
-
-    /**
-     * Recompile the Intermediate Representation.
-     * @param representation Intermediate Representation to recompile.
-     */
-    private void recompile(final Representation representation) {
-        final String name = representation.name();
-        try {
-            final byte[] bytecode = representation.toBytecode();
-            final String[] subpath = name.split("\\.");
-            subpath[subpath.length - 1] = String.format("%s.class", subpath[subpath.length - 1]);
-            final Path path = Paths.get(this.classes.toString(), subpath);
-            Logger.info(
-                this,
-                "Recompiling '%s', bytecode instance '%s', bytes to save '%s'",
-                path,
-                representation.getClass(),
-                bytecode.length
-            );
-            Files.createDirectories(path.getParent());
-            Files.write(path, bytecode);
-            Logger.info(
-                this,
-                "%s was recompiled successfully.",
-                path.getFileName().toString()
-            );
-        } catch (final IOException exception) {
-            throw new IllegalStateException(String.format("Can't recompile '%s'", name), exception);
-        }
+        new BytecodeFootprint(this.classes.toPath())
+            .apply(new EoObjects(this.target.toPath()).objects());
     }
 }

--- a/src/main/java/org/eolang/jeo/JeoMojo.java
+++ b/src/main/java/org/eolang/jeo/JeoMojo.java
@@ -30,6 +30,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.eolang.jeo.improvement.BytecodeFootprint;
 import org.eolang.jeo.improvement.ImprovementLogged;
 import org.eolang.jeo.improvement.Improvements;
 import org.eolang.jeo.improvement.XmirFootprint;
@@ -69,7 +70,8 @@ public final class JeoMojo extends AbstractMojo {
                 this.classes.toPath(),
                 new Improvements(
                     new ImprovementLogged(),
-                    new XmirFootprint(this.target.toPath())
+                    new XmirFootprint(this.target.toPath()),
+                    new BytecodeFootprint(this.classes.toPath())
                 )
             ).apply();
         } catch (final IllegalStateException | IOException exception) {

--- a/src/main/java/org/eolang/jeo/Optimization.java
+++ b/src/main/java/org/eolang/jeo/Optimization.java
@@ -23,11 +23,8 @@
  */
 package org.eolang.jeo;
 
-import com.jcabi.log.Logger;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Optimization by using the EO language.
@@ -64,36 +61,6 @@ final class Optimization {
     void apply() throws IOException {
         this.improvements.apply(
             new BytecodeClasses(this.classes).bytecode()
-        ).forEach(this::recompile);
-    }
-
-    /**
-     * Recompile the Intermediate Representation.
-     * @param representation Intermediate Representation to recompile.
-     */
-    private void recompile(final Representation representation) {
-        final String name = representation.name();
-        try {
-            final byte[] bytecode = representation.toBytecode();
-            final String[] subpath = name.split("\\.");
-            subpath[subpath.length - 1] = String.format("%s.class", subpath[subpath.length - 1]);
-            final Path path = Paths.get(this.classes.toString(), subpath);
-            Logger.info(
-                this,
-                "Recompiling '%s', bytecode instance '%s', bytes to save '%s'",
-                path,
-                representation.getClass(),
-                bytecode.length
-            );
-            Files.createDirectories(path.getParent());
-            Files.write(path, bytecode);
-            Logger.info(
-                this,
-                "%s was recompiled successfully.",
-                path.getFileName().toString()
-            );
-        } catch (final IOException exception) {
-            throw new IllegalStateException(String.format("Can't recompile '%s'", name), exception);
-        }
+        );
     }
 }

--- a/src/main/java/org/eolang/jeo/improvement/BytecodeFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/BytecodeFootprint.java
@@ -38,10 +38,17 @@ import org.eolang.jeo.Representation;
  *
  * @since 0.1.0
  */
-public class BytecodeFootprint implements Improvement {
+public final class BytecodeFootprint implements Improvement {
 
+    /**
+     * Where to save the bytecode classes.
+     */
     private final Path classes;
 
+    /**
+     * Constructor.
+     * @param target Where to save the bytecode classes.
+     */
     public BytecodeFootprint(final Path target) {
         this.classes = target;
     }

--- a/src/main/java/org/eolang/jeo/improvement/BytecodeFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/BytecodeFootprint.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.improvement;
+
+import com.jcabi.log.Logger;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Collections;
+import org.eolang.jeo.Improvement;
+import org.eolang.jeo.Representation;
+
+/**
+ * Footprint of the representations as bytecode classes.
+ *
+ * @since 0.1.0
+ */
+public class BytecodeFootprint implements Improvement {
+
+    private final Path classes;
+
+    public BytecodeFootprint(final Path target) {
+        this.classes = target;
+    }
+
+    @Override
+    public Collection<? extends Representation> apply(
+        final Collection<? extends Representation> representations
+    ) {
+        representations.forEach(this::recompile);
+        return Collections.unmodifiableCollection(representations);
+    }
+
+    /**
+     * Recompile the Intermediate Representation.
+     * @param representation Intermediate Representation to recompile.
+     */
+    private void recompile(final Representation representation) {
+        final String name = representation.name();
+        try {
+            final byte[] bytecode = representation.toBytecode();
+            final String[] subpath = name.split("\\.");
+            subpath[subpath.length - 1] = String.format("%s.class", subpath[subpath.length - 1]);
+            final Path path = Paths.get(this.classes.toString(), subpath);
+            Logger.info(
+                this,
+                "Recompiling '%s', bytecode instance '%s', bytes to save '%s'",
+                path,
+                representation.getClass(),
+                bytecode.length
+            );
+            Files.createDirectories(path.getParent());
+            Files.write(path, bytecode);
+            Logger.info(
+                this,
+                "%s was recompiled successfully.",
+                path.getFileName().toString()
+            );
+        } catch (final IOException exception) {
+            throw new IllegalStateException(String.format("Can't recompile '%s'", name), exception);
+        }
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/XmirObject.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirObject.java
@@ -69,7 +69,7 @@ public final class XmirObject {
                         .attr("revision", "0.0.0")
                         .attr("dob", now)
                         .attr("time", now)
-                        .add("listing").up()
+                        .add("listing").set(this.base64MockListing()).up()
                         .add("errors").up()
                         .add("sheets").up()
                         .add("license").up()
@@ -83,5 +83,13 @@ public final class XmirObject {
         } catch (final ImpossibleModificationException exception) {
             throw new IllegalStateException("Can't create fake XML", exception);
         }
+    }
+
+    /**
+     * Bytecode listing in Base64.
+     * @return Base64 listing.
+     */
+    private String base64MockListing() {
+        return "yv66vgAAADQAIgoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCQAIAAkHAAoMAAsADAEAEGphdmEvbGFuZy9TeXN0ZW0BAANvdXQBABVMamF2YS9pby9QcmludFN0cmVhbTsIAA4BAA1IZWxsbywgV29ybGQhCgAQABEHABIMABMAFAEAE2phdmEvaW8vUHJpbnRTdHJlYW0BAAdwcmludGxuAQAVKExqYXZhL2xhbmcvU3RyaW5nOylWBwAWAQAab3JnL2VvbGFuZy9qZW8vQXBwbGljYXRpb24BAARDb2RlAQAPTGluZU51bWJlclRhYmxlAQASTG9jYWxWYXJpYWJsZVRhYmxlAQAEdGhpcwEAHExvcmcvZW9sYW5nL2plby9BcHBsaWNhdGlvbjsBAARtYWluAQAWKFtMamF2YS9sYW5nL1N0cmluZzspVgEABGFyZ3MBABNbTGphdmEvbGFuZy9TdHJpbmc7AQAKU291cmNlRmlsZQEAEEFwcGxpY2F0aW9uLmphdmEAIQAVAAIAAAAAAAIAAQAFAAYAAQAXAAAALwABAAEAAAAFKrcAAbEAAAACABgAAAAGAAEAAAADABkAAAAMAAEAAAAFABoAGwAAAAkAHAAdAAEAFwAAADcAAgABAAAACbIABxINtgAPsQAAAAIAGAAAAAoAAgAAAAUACAAGABkAAAAMAAEAAAAJAB4AHwAAAAEAIAAAAAIAIQ==";
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/XmirObject.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirObject.java
@@ -69,7 +69,7 @@ public final class XmirObject {
                         .attr("revision", "0.0.0")
                         .attr("dob", now)
                         .attr("time", now)
-                        .add("listing").set(this.base64MockListing()).up()
+                        .add("listing").set(this.mockListing()).up()
                         .add("errors").up()
                         .add("sheets").up()
                         .add("license").up()
@@ -89,7 +89,19 @@ public final class XmirObject {
      * Bytecode listing in Base64.
      * @return Base64 listing.
      */
-    private String base64MockListing() {
-        return "yv66vgAAADQAIgoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCQAIAAkHAAoMAAsADAEAEGphdmEvbGFuZy9TeXN0ZW0BAANvdXQBABVMamF2YS9pby9QcmludFN0cmVhbTsIAA4BAA1IZWxsbywgV29ybGQhCgAQABEHABIMABMAFAEAE2phdmEvaW8vUHJpbnRTdHJlYW0BAAdwcmludGxuAQAVKExqYXZhL2xhbmcvU3RyaW5nOylWBwAWAQAab3JnL2VvbGFuZy9qZW8vQXBwbGljYXRpb24BAARDb2RlAQAPTGluZU51bWJlclRhYmxlAQASTG9jYWxWYXJpYWJsZVRhYmxlAQAEdGhpcwEAHExvcmcvZW9sYW5nL2plby9BcHBsaWNhdGlvbjsBAARtYWluAQAWKFtMamF2YS9sYW5nL1N0cmluZzspVgEABGFyZ3MBABNbTGphdmEvbGFuZy9TdHJpbmc7AQAKU291cmNlRmlsZQEAEEFwcGxpY2F0aW9uLmphdmEAIQAVAAIAAAAAAAIAAQAFAAYAAQAXAAAALwABAAEAAAAFKrcAAbEAAAACABgAAAAGAAEAAAADABkAAAAMAAEAAAAFABoAGwAAAAkAHAAdAAEAFwAAADcAAgABAAAACbIABxINtgAPsQAAAAIAGAAAAAoAAgAAAAUACAAGABkAAAAMAAEAAAAJAB4AHwAAAAEAIAAAAAIAIQ==";
+    private static String mockListing() {
+        return String.join(
+            "",
+            "yv66vgAAADQAIgoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCQAIAAk",
+            "HAAoMAAsADAEAEGphdmEvbGFuZy9TeXN0ZW0BAANvdXQBABVMamF2YS9pby9QcmludFN0cmVhbTsIAA4BAA1",
+            "IZWxsbywgV29ybGQhCgAQABEHABIMABMAFAEAE2phdmEvaW8vUHJpbnRTdHJlYW0BAAdwcmludGxuAQAVKEx",
+            "qYXZhL2xhbmcvU3RyaW5nOylWBwAWAQAab3JnL2VvbGFuZy9qZW8vQXBwbGljYXRpb24BAARDb2RlAQAPTGl",
+            "uZU51bWJlclRhYmxlAQASTG9jYWxWYXJpYWJsZVRhYmxlAQAEdGhpcwEAHExvcmcvZW9sYW5nL2plby9BcHB",
+            "saWNhdGlvbjsBAARtYWluAQAWKFtMamF2YS9sYW5nL1N0cmluZzspVgEABGFyZ3MBABNbTGphdmEvbGFuZy9",
+            "TdHJpbmc7AQAKU291cmNlRmlsZQEAEEFwcGxpY2F0aW9uLmphdmEAIQAVAAIAAAAAAAIAAQAFAAYAAQAXAAA",
+            "ALwABAAEAAAAFKrcAAbEAAAACABgAAAAGAAEAAAADABkAAAAMAAEAAAAFABoAGwAAAAkAHAAdAAEAFwAAADc",
+            "AAgABAAAACbIABxINtgAPsQAAAAIAGAAAAAoAAgAAAAUACAAGABkAAAAMAAEAAAAJAB4AHwAAAAEAIAAAAAI",
+            "AIQ=="
+        );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/XmirObject.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirObject.java
@@ -69,7 +69,7 @@ public final class XmirObject {
                         .attr("revision", "0.0.0")
                         .attr("dob", now)
                         .attr("time", now)
-                        .add("listing").set(this.mockListing()).up()
+                        .add("listing").set(XmirObject.mockListing()).up()
                         .add("errors").up()
                         .add("sheets").up()
                         .add("license").up()

--- a/src/test/java/org/eolang/jeo/improvement/BytecodeFootprintTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/BytecodeFootprintTest.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.improvement;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import org.eolang.jeo.representation.BytecodeRepresentation;
+import org.eolang.jeo.representation.XmirObject;
+import org.eolang.jeo.representation.XmirRepresentation;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.io.FileMatchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test case for {@link BytecodeFootprint}.
+ *
+ * @since 0.1.0
+ */
+class BytecodeFootprintTest {
+
+    @Test
+    void appliesSuccessfully(@TempDir Path temp) {
+        final String expected = "jeo.xmir.Fake";
+        new BytecodeFootprint(temp)
+            .apply(
+                Collections.singleton(
+                    new XmirRepresentation(new XmirObject(expected))
+                )
+            );
+        MatcherAssert.assertThat(
+            String.format(
+                "Bytecode file was not saved for the representation with the name '%s'",
+                expected
+            ),
+            temp.resolve("jeo")
+                .resolve("xmir")
+                .resolve("Fake.class")
+                .toFile(),
+            FileMatchers.anExistingFile()
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/improvement/BytecodeFootprintTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/BytecodeFootprintTest.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.improvement;
 
 import java.nio.file.Path;
 import java.util.Collections;
-import org.eolang.jeo.representation.BytecodeRepresentation;
 import org.eolang.jeo.representation.XmirObject;
 import org.eolang.jeo.representation.XmirRepresentation;
 import org.hamcrest.MatcherAssert;
@@ -41,14 +40,11 @@ import org.junit.jupiter.api.io.TempDir;
 class BytecodeFootprintTest {
 
     @Test
-    void appliesSuccessfully(@TempDir Path temp) {
+    void appliesSuccessfully(@TempDir final Path temp) {
         final String expected = "jeo.xmir.Fake";
-        new BytecodeFootprint(temp)
-            .apply(
-                Collections.singleton(
-                    new XmirRepresentation(new XmirObject(expected))
-                )
-            );
+        new BytecodeFootprint(temp).apply(
+            Collections.singleton(new XmirRepresentation(new XmirObject(expected)))
+        );
         MatcherAssert.assertThat(
             String.format(
                 "Bytecode file was not saved for the representation with the name '%s'",


### PR DESCRIPTION
Remove duplication between Optimization and EoToBytecodeMojo classes.

Closes: #70


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a `BytecodeFootprint` improvement to the `JeoMojo` and `EoToBytecodeMojo` classes. 

### Detailed summary
- Added `import org.eolang.jeo.improvement.BytecodeFootprint` to `JeoMojo.java`
- Added `new BytecodeFootprint(this.classes.toPath())` to the `Improvements` constructor in `JeoMojo.java`
- Added `mockListing()` method to `XmirObject.java`
- Removed `recompile()` method and added `apply()` method in `Optimization.java`
- Added `import org.eolang.jeo.improvement.BytecodeFootprint` to `EoToBytecodeMojo.java`
- Added `new BytecodeFootprint(this.classes.toPath())` to the `apply()` method in `EoToBytecodeMojo.java`
- Added `BytecodeFootprintTest.java` and `BytecodeFootprint.java` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->