### PR TITLE
feat(#69): Add unit test for EoObjects

### DIFF
--- a/src/main/java/org/eolang/jeo/EoObjects.java
+++ b/src/main/java/org/eolang/jeo/EoObjects.java
@@ -38,12 +38,6 @@ import org.eolang.jeo.representation.XmirRepresentation;
  * Reads all EO objects from the folder.
  *
  * @since 0.1.0
- * @todo #59:30min Add unit tests for EoObjects class.
- *  The unit tests should cover the next cases:
- *  - The EoObjects class should read all XML files from the folder.
- *  - The EoObjects class should return empty list if folder is empty.
- *  - The EoObjects class should throw IllegalStateException if folder doesn't exist.
- *  When the unit tests are ready, remove that puzzle.
  */
 final class EoObjects {
 

--- a/src/main/java/org/eolang/jeo/EoObjects.java
+++ b/src/main/java/org/eolang/jeo/EoObjects.java
@@ -65,8 +65,7 @@ final class EoObjects {
      * @return All objects.
      */
     Collection<XmirRepresentation> objects() {
-        final Path path = this.objectspath.resolve("jeo")
-            .resolve("xmir");
+        final Path path = this.objectspath.resolve(new XmirDefaultDirectory().toPath());
         try (Stream<Path> walk = Files.walk(path)) {
             return walk.filter(Files::isRegularFile)
                 .map(EoObjects::xml)

--- a/src/main/java/org/eolang/jeo/XmirDefaultDirectory.java
+++ b/src/main/java/org/eolang/jeo/XmirDefaultDirectory.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+
+/**
+ * Default directory for XMIR.
+ *
+ * @since 0.1.0
+ */
+public class XmirDefaultDirectory {
+
+    /**
+     * Relative folders.
+     */
+    private final String[] folders;
+
+    /**
+     * Constructor.
+     */
+    public XmirDefaultDirectory() {
+        this("jeo", "xmir");
+    }
+
+    /**
+     * Constructor.
+     * @param relative Relative folders.
+     */
+    private XmirDefaultDirectory(final String... relative) {
+        this.folders = Arrays.copyOf(relative, relative.length);
+    }
+
+    /**
+     * Convert to path.
+     * @return Relative Path.
+     */
+    public Path toPath() {
+        return Path.of("", this.folders);
+    }
+}

--- a/src/main/java/org/eolang/jeo/improvement/XmirFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/XmirFootprint.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 import org.eolang.jeo.Improvement;
 import org.eolang.jeo.Representation;
+import org.eolang.jeo.XmirDefaultDirectory;
 import org.eolang.jeo.representation.XmirRepresentation;
 
 /**
@@ -72,8 +73,7 @@ public final class XmirFootprint implements Improvement {
      */
     private void tryToSave(final Representation representation) {
         final String name = representation.name();
-        final Path path = this.target.resolve("jeo")
-            .resolve("xmir")
+        final Path path = this.target.resolve(new XmirDefaultDirectory().toPath())
             .resolve(String.format("%s.xmir", name.replace('.', File.separatorChar)));
         try {
             Files.createDirectories(path.getParent());

--- a/src/main/java/org/eolang/jeo/representation/Xmir.java
+++ b/src/main/java/org/eolang/jeo/representation/Xmir.java
@@ -25,9 +25,11 @@ package org.eolang.jeo.representation;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
+import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.UUID;
 import org.xembly.Directives;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
@@ -37,19 +39,27 @@ import org.xembly.Xembler;
  *
  * @since 0.1.0
  */
-public final class XmirObject {
+public final class Xmir {
 
     /**
      * Object name.
      */
     private final String name;
 
+    public Xmir() {
+        this(UUID.randomUUID().toString());
+    }
+
     /**
      * Constructor.
      * @param name Object name.
      */
-    public XmirObject(final String name) {
+    public Xmir(final String name) {
         this.name = name;
+    }
+
+    public byte[] bytes() {
+        return this.xml().toString().getBytes(StandardCharsets.UTF_8);
     }
 
     /**
@@ -69,7 +79,7 @@ public final class XmirObject {
                         .attr("revision", "0.0.0")
                         .attr("dob", now)
                         .attr("time", now)
-                        .add("listing").set(XmirObject.mockListing()).up()
+                        .add("listing").set(Xmir.mockListing()).up()
                         .add("errors").up()
                         .add("sheets").up()
                         .add("license").up()

--- a/src/main/java/org/eolang/jeo/representation/Xmir.java
+++ b/src/main/java/org/eolang/jeo/representation/Xmir.java
@@ -46,6 +46,9 @@ public final class Xmir {
      */
     private final String name;
 
+    /**
+     * Constructor.
+     */
     public Xmir() {
         this(UUID.randomUUID().toString());
     }
@@ -58,6 +61,10 @@ public final class Xmir {
         this.name = name;
     }
 
+    /**
+     * Convert EO object to a byte array.
+     * @return Byte array.
+     */
     public byte[] bytes() {
         return this.xml().toString().getBytes(StandardCharsets.UTF_8);
     }

--- a/src/main/java/org/eolang/jeo/representation/Xmir.java
+++ b/src/main/java/org/eolang/jeo/representation/Xmir.java
@@ -38,6 +38,10 @@ import org.xembly.Xembler;
  * XMIR representation of an EO object.
  *
  * @since 0.1.0
+ * @todo #69:30min Rename Xmir to EO.
+ *  The name Xmir is confusing. It's not clear what it means in this context.
+ *  Actually XMIR and EO interchangeably mean the same thing. So, we have to rename
+ *  Xmir to EO. When the renaming is done, remove this puzzle.
  */
 public final class Xmir {
 

--- a/src/main/java/org/eolang/jeo/representation/XmirObject.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirObject.java
@@ -56,7 +56,7 @@ public final class XmirObject {
      * Convert to XML.
      * @return XML representation of XMIR.
      */
-    XML xml() {
+    public XML xml() {
         try {
             final String now = ZonedDateTime.now(ZoneOffset.UTC)
                 .format(DateTimeFormatter.ISO_INSTANT);

--- a/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
@@ -47,7 +47,7 @@ public final class XmirRepresentation implements Representation {
      * Constructor.
      * @param object EO object as XML.
      */
-    public XmirRepresentation(final XmirObject object) {
+    public XmirRepresentation(final Xmir object) {
         this(object.xml());
     }
 

--- a/src/test/java/org/eolang/jeo/EoObjectsTest.java
+++ b/src/test/java/org/eolang/jeo/EoObjectsTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo;
 
 import java.io.IOException;

--- a/src/test/java/org/eolang/jeo/EoObjectsTest.java
+++ b/src/test/java/org/eolang/jeo/EoObjectsTest.java
@@ -1,14 +1,12 @@
 package org.eolang.jeo;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collection;
-import org.eolang.jeo.representation.XmirObject;
-import org.eolang.jeo.representation.XmirRepresentation;
+import org.eolang.jeo.representation.Xmir;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -17,23 +15,15 @@ import org.junit.jupiter.api.io.TempDir;
  *
  * @since 0.1.0
  */
-class EoObjectsTest {
+final class EoObjectsTest {
 
     @Test
     void retrievesObjectsSuccessfully(@TempDir final Path temp) throws IOException {
         final int expected = 2;
         final Path directory = temp.resolve(new XmirDefaultDirectory().toPath());
         Files.createDirectories(directory);
-        Files.write(directory.resolve("first.xmir"), new XmirObject("some object")
-            .xml()
-            .toString()
-            .getBytes(StandardCharsets.UTF_8)
-        );
-        Files.write(directory.resolve("second.xmir"), new XmirObject("some object")
-            .xml()
-            .toString()
-            .getBytes(StandardCharsets.UTF_8)
-        );
+        Files.write(directory.resolve("first.xmir"), new Xmir().bytes());
+        Files.write(directory.resolve("second.xmir"), new Xmir().bytes());
         MatcherAssert.assertThat(
             String.format("Objects were not retrieved, we expected '%d' objects", expected),
             new EoObjects(temp).objects(),
@@ -41,5 +31,22 @@ class EoObjectsTest {
         );
     }
 
+    @Test
+    void retrievesEmptyObjectsIfFolderIsEmpty(@TempDir final Path temp) throws IOException {
+        Files.createDirectories(temp.resolve(new XmirDefaultDirectory().toPath()));
+        MatcherAssert.assertThat(
+            "Objects were not retrieved, we expected empty list",
+            new EoObjects(temp).objects(),
+            Matchers.empty()
+        );
+    }
 
+    @Test
+    void throwsExceptionIfFolderDoesNotExist(@TempDir final Path temp) {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new EoObjects(temp).objects(),
+            "Exception was not thrown when folder does not exist"
+        );
+    }
 }

--- a/src/test/java/org/eolang/jeo/EoObjectsTest.java
+++ b/src/test/java/org/eolang/jeo/EoObjectsTest.java
@@ -1,0 +1,45 @@
+package org.eolang.jeo;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import org.eolang.jeo.representation.XmirObject;
+import org.eolang.jeo.representation.XmirRepresentation;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test case for {@link EoObjects}.
+ *
+ * @since 0.1.0
+ */
+class EoObjectsTest {
+
+    @Test
+    void retrievesObjectsSuccessfully(@TempDir final Path temp) throws IOException {
+        final int expected = 2;
+        final Path directory = temp.resolve(new XmirDefaultDirectory().toPath());
+        Files.createDirectories(directory);
+        Files.write(directory.resolve("first.xmir"), new XmirObject("some object")
+            .xml()
+            .toString()
+            .getBytes(StandardCharsets.UTF_8)
+        );
+        Files.write(directory.resolve("second.xmir"), new XmirObject("some object")
+            .xml()
+            .toString()
+            .getBytes(StandardCharsets.UTF_8)
+        );
+        MatcherAssert.assertThat(
+            String.format("Objects were not retrieved, we expected '%d' objects", expected),
+            new EoObjects(temp).objects(),
+            Matchers.hasSize(expected)
+        );
+    }
+
+
+}

--- a/src/test/java/org/eolang/jeo/XmirDefaultDirectoryTest.java
+++ b/src/test/java/org/eolang/jeo/XmirDefaultDirectoryTest.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo;
+
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link XmirDefaultDirectory}.
+ *
+ * @since 0.1.0
+ */
+final class XmirDefaultDirectoryTest {
+
+    @Test
+    void returnsDefaultDirectory() {
+        final Path actual = new XmirDefaultDirectory().toPath();
+        final Path expected = Path.of("jeo", "xmir");
+        MatcherAssert.assertThat(
+            String.format("We expect the default directory to be '%s', but was '%s'",
+                expected,
+                actual
+            ),
+            actual,
+            Matchers.equalTo(
+                expected
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/XmirDefaultDirectoryTest.java
+++ b/src/test/java/org/eolang/jeo/XmirDefaultDirectoryTest.java
@@ -40,7 +40,8 @@ final class XmirDefaultDirectoryTest {
         final Path actual = new XmirDefaultDirectory().toPath();
         final Path expected = Path.of("jeo", "xmir");
         MatcherAssert.assertThat(
-            String.format("We expect the default directory to be '%s', but was '%s'",
+            String.format(
+                "We expect the default directory to be '%s', but was '%s'",
                 expected,
                 actual
             ),

--- a/src/test/java/org/eolang/jeo/improvement/BytecodeFootprintTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/BytecodeFootprintTest.java
@@ -25,7 +25,7 @@ package org.eolang.jeo.improvement;
 
 import java.nio.file.Path;
 import java.util.Collections;
-import org.eolang.jeo.representation.XmirObject;
+import org.eolang.jeo.representation.Xmir;
 import org.eolang.jeo.representation.XmirRepresentation;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.io.FileMatchers;
@@ -43,7 +43,7 @@ class BytecodeFootprintTest {
     void appliesSuccessfully(@TempDir final Path temp) {
         final String expected = "jeo.xmir.Fake";
         new BytecodeFootprint(temp).apply(
-            Collections.singleton(new XmirRepresentation(new XmirObject(expected)))
+            Collections.singleton(new XmirRepresentation(new Xmir(expected)))
         );
         MatcherAssert.assertThat(
             String.format(

--- a/src/test/java/org/eolang/jeo/improvement/XmirFootprintTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/XmirFootprintTest.java
@@ -25,7 +25,7 @@ package org.eolang.jeo.improvement;
 
 import java.nio.file.Path;
 import java.util.Collections;
-import org.eolang.jeo.representation.XmirObject;
+import org.eolang.jeo.representation.Xmir;
 import org.eolang.jeo.representation.XmirRepresentation;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.io.FileMatchers;
@@ -45,7 +45,7 @@ final class XmirFootprintTest {
         footprint.apply(
             Collections.singleton(
                 new XmirRepresentation(
-                    new XmirObject("org.eolang.jeo.Application")
+                    new Xmir("org.eolang.jeo.Application")
                 )
             )
         );

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -37,7 +37,7 @@ class XmirRepresentationTest {
     @Test
     void retrievesName() {
         final String expected = "org.eolang.foo.Math";
-        final String actual = new XmirRepresentation(new XmirObject(expected)).name();
+        final String actual = new XmirRepresentation(new Xmir(expected)).name();
         MatcherAssert.assertThat(
             String.format(
                 "The name of the class is not retrieved correctly, we expected '%s', but got '%s'",


### PR DESCRIPTION
Add unit test for EoObjects and rename some classes.
Closes: #69


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming the `XmirObject` class to `Xmir` and updating its references throughout the codebase. 

### Detailed summary
- Renamed `XmirObject` class to `Xmir`
- Updated references to `XmirObject` in various classes to `Xmir`
- Added a new `XmirDefaultDirectory` class to provide a default directory for XMIR files
- Updated code to use the `XmirDefaultDirectory` class for file paths

> The following files were skipped due to too many changes: `src/test/java/org/eolang/jeo/EoObjectsTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->