### PR TITLE
feat(#76): Add tests for EoRepresentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,12 @@ SOFTWARE.
       <!-- version from the parent pom -->
     </dependency>
     <dependency>
+      <groupId>com.jcabi</groupId>
+      <artifactId>jcabi-matchers</artifactId>
+      <!-- version from the parent pom -->
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <!-- version from the parent pom -->

--- a/src/main/java/org/eolang/jeo/representation/Eo.java
+++ b/src/main/java/org/eolang/jeo/representation/Eo.java
@@ -86,7 +86,7 @@ public final class Eo {
                         .attr("revision", "0.0.0")
                         .attr("dob", now)
                         .attr("time", now)
-                        .add("listing").set(Eo.mockListing()).up()
+                        .add("listing").set(new HelloWorldBytecode().base64()).up()
                         .add("errors").up()
                         .add("sheets").up()
                         .add("license").up()
@@ -100,25 +100,5 @@ public final class Eo {
         } catch (final ImpossibleModificationException exception) {
             throw new IllegalStateException("Can't create fake XML", exception);
         }
-    }
-
-    /**
-     * Bytecode listing in Base64.
-     * @return Base64 listing.
-     */
-    private static String mockListing() {
-        return String.join(
-            "",
-            "yv66vgAAADQAIgoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCQAIAAk",
-            "HAAoMAAsADAEAEGphdmEvbGFuZy9TeXN0ZW0BAANvdXQBABVMamF2YS9pby9QcmludFN0cmVhbTsIAA4BAA1",
-            "IZWxsbywgV29ybGQhCgAQABEHABIMABMAFAEAE2phdmEvaW8vUHJpbnRTdHJlYW0BAAdwcmludGxuAQAVKEx",
-            "qYXZhL2xhbmcvU3RyaW5nOylWBwAWAQAab3JnL2VvbGFuZy9qZW8vQXBwbGljYXRpb24BAARDb2RlAQAPTGl",
-            "uZU51bWJlclRhYmxlAQASTG9jYWxWYXJpYWJsZVRhYmxlAQAEdGhpcwEAHExvcmcvZW9sYW5nL2plby9BcHB",
-            "saWNhdGlvbjsBAARtYWluAQAWKFtMamF2YS9sYW5nL1N0cmluZzspVgEABGFyZ3MBABNbTGphdmEvbGFuZy9",
-            "TdHJpbmc7AQAKU291cmNlRmlsZQEAEEFwcGxpY2F0aW9uLmphdmEAIQAVAAIAAAAAAAIAAQAFAAYAAQAXAAA",
-            "ALwABAAEAAAAFKrcAAbEAAAACABgAAAAGAAEAAAADABkAAAAMAAEAAAAFABoAGwAAAAkAHAAdAAEAFwAAADc",
-            "AAgABAAAACbIABxINtgAPsQAAAAIAGAAAAAoAAgAAAAUACAAGABkAAAAMAAEAAAAJAB4AHwAAAAEAIAAAAAI",
-            "AIQ=="
-        );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
@@ -31,10 +31,6 @@ import org.eolang.jeo.Representation;
  * Intermediate representation of a class files from XMIR.
  *
  * @since 0.1.0
- * @todo #39:90min Add unit test for XmirIR class.
- *  The test should check all the methods of the {@link EoRepresentation} class.
- *  Don't forget to test corner cases.
- *  When the test is ready, remove this puzzle.
  */
 public final class EoRepresentation implements Representation {
 

--- a/src/main/java/org/eolang/jeo/representation/HelloWorldBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/HelloWorldBytecode.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation;
+
+import java.util.Base64;
+
+/**
+ * Bytecode that represents a Hello World program.
+ *
+ * @since 0.1.0
+ */
+public final class HelloWorldBytecode {
+
+    /**
+     * Bytecode in Base64 form.
+     */
+    private final String encoded;
+
+    /**
+     * Constructor.
+     */
+    HelloWorldBytecode() {
+        this(HelloWorldBytecode.defaultListing());
+    }
+
+    /**
+     * Constructor.
+     * @param encoded Bytecode in Base64 form.
+     */
+    private HelloWorldBytecode(final String encoded) {
+        this.encoded = encoded;
+    }
+
+    /**
+     * Convert to bytes.
+     * @return Bytes.
+     */
+    public byte[] bytes() {
+        return Base64.getDecoder().decode(this.encoded).clone();
+    }
+
+    /**
+     * Convert to Base64.
+     * @return Base64.
+     * @checkstyle MethodNameCheck (3 lines)
+     */
+    String base64() {
+        return this.encoded;
+    }
+
+    /**
+     * Default listing of bytecode of a Hello World program.
+     * @return Listing.
+     */
+    private static String defaultListing() {
+        return String.join(
+            "",
+            "yv66vgAAADQAIgoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClWCQAIAAk",
+            "HAAoMAAsADAEAEGphdmEvbGFuZy9TeXN0ZW0BAANvdXQBABVMamF2YS9pby9QcmludFN0cmVhbTsIAA4BAA1",
+            "IZWxsbywgV29ybGQhCgAQABEHABIMABMAFAEAE2phdmEvaW8vUHJpbnRTdHJlYW0BAAdwcmludGxuAQAVKEx",
+            "qYXZhL2xhbmcvU3RyaW5nOylWBwAWAQAab3JnL2VvbGFuZy9qZW8vQXBwbGljYXRpb24BAARDb2RlAQAPTGl",
+            "uZU51bWJlclRhYmxlAQASTG9jYWxWYXJpYWJsZVRhYmxlAQAEdGhpcwEAHExvcmcvZW9sYW5nL2plby9BcHB",
+            "saWNhdGlvbjsBAARtYWluAQAWKFtMamF2YS9sYW5nL1N0cmluZzspVgEABGFyZ3MBABNbTGphdmEvbGFuZy9",
+            "TdHJpbmc7AQAKU291cmNlRmlsZQEAEEFwcGxpY2F0aW9uLmphdmEAIQAVAAIAAAAAAAIAAQAFAAYAAQAXAAA",
+            "ALwABAAEAAAAFKrcAAbEAAAACABgAAAAGAAEAAAADABkAAAAMAAEAAAAFABoAGwAAAAkAHAAdAAEAFwAAADc",
+            "AAgABAAAACbIABxINtgAPsQAAAAIAGAAAAAoAAgAAAAUACAAGABkAAAAMAAEAAAAJAB4AHwAAAAEAIAAAAAI",
+            "AIQ=="
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/EoRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/EoRepresentationTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation;
 
+import com.jcabi.matchers.XhtmlMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,24 @@ class EoRepresentationTest {
             ),
             expected,
             Matchers.equalTo(actual)
+        );
+    }
+
+    @Test
+    void returnsXmlRepresentationOfEo() {
+        MatcherAssert.assertThat(
+            "The XML representation of the EO object is not correct",
+            new EoRepresentation(new Eo("org.eolang.foo.Math")).toEO(),
+            XhtmlMatchers.hasXPath("/program[@name='org.eolang.foo.Math']")
+        );
+    }
+
+    @Test
+    void returnsBytecodeRepresentationOfEo() {
+        MatcherAssert.assertThat(
+            "The bytecode representation of the EO object is not correct",
+            new EoRepresentation(new Eo("org.eolang.foo.Bar")).toBytecode(),
+            Matchers.equalTo(new HelloWorldBytecode().bytes())
         );
     }
 }


### PR DESCRIPTION
Add tests for EoRepresentation

Closes: #76


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding unit tests for the `EoRepresentation` class. 

### Detailed summary
- Added a test to check the XML representation of the EO object.
- Added a test to check the bytecode representation of the EO object.
- Added a new class `HelloWorldBytecode` to provide the bytecode for the tests.
- Updated the `EoRepresentation` class to use the `HelloWorldBytecode` class for the bytecode representation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->