### PR TITLE
feat(#55): Add test for Base64Bytecode

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/Base64Bytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/Base64Bytecode.java
@@ -31,10 +31,6 @@ import java.util.Base64;
  * Converts bytecode to Base64 string.
  *
  * @since 0.1.0
- * @todo #37:90min Add unit test for Base64Bytecode class.
- *  The test should check all the methods of the {@link Base64Bytecode} class.
- *  Don't forget to test corner cases.
- *  When the test is ready, remove this puzzle.
  */
 class Base64Bytecode {
 

--- a/src/test/java/org/eolang/jeo/representation/Base64BytecodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/Base64BytecodeTest.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Base64Bytecode}.
+ *
+ * @since 0.1.0
+ */
+class Base64BytecodeTest {
+
+    @Test
+    void convertsToString() {
+        final byte[] bytes = {0x01, 0x02, 0x03};
+        MatcherAssert.assertThat(
+            "The string representation of the bytecode` is not correct",
+            new Base64Bytecode(bytes).asString(),
+            Matchers.equalTo("AQID")
+        );
+    }
+}


### PR DESCRIPTION
Add test for Base64Bytecode.

Closes: #55


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a unit test for the `Base64Bytecode` class.

### Detailed summary
- Added `Base64BytecodeTest` class.
- Added `convertsToString` test method to test the `asString` method of `Base64Bytecode` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->