### PR TITLE
feat(#83): Compile java classes dynamically for tests

### DIFF
--- a/src/test/java/it/JavaSourceClass.java
+++ b/src/test/java/it/JavaSourceClass.java
@@ -44,11 +44,12 @@ import org.cactoos.text.UncheckedText;
 
 /**
  * Java source class with ".java" extension.
- *
  * @since 0.1
  */
 @SuppressWarnings("JTCOP.RuleCorrectTestName")
 final class JavaSourceClass {
+
+    private final String name;
 
     /**
      * Source of Java class.
@@ -60,14 +61,15 @@ final class JavaSourceClass {
      * @param resource Resource of Java class.
      */
     JavaSourceClass(final String resource) {
-        this(new ResourceOf(resource));
+        this(JavaSourceClass.filename(resource), new ResourceOf(resource));
     }
 
     /**
      * Constructor.
      * @param java Source of Java class.
      */
-    private JavaSourceClass(final Input java) {
+    private JavaSourceClass(final String filename, final Input java) {
+        this.name = filename;
         this.java = java;
     }
 
@@ -75,11 +77,11 @@ final class JavaSourceClass {
      * Compile the Java class.
      * @return Bytecode of compiled class.
      * @todo #81:30min Compile Java class dynamically.
-     *  Currently, we don't compile Java classes dynamically.
-     *  Instead, we pass the source code directly.
-     *  This is a temporary solution. We need to compile the Java class
-     *  dynamically and pass the bytecode to the test.
-     *  When this is done, remove that puzzle from this method.
+     * Currently, we don't compile Java classes dynamically.
+     * Instead, we pass the source code directly.
+     * This is a temporary solution. We need to compile the Java class
+     * dynamically and pass the bytecode to the test.
+     * When this is done, remove that puzzle from this method.
      */
     byte[] compile() {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
@@ -90,13 +92,17 @@ final class JavaSourceClass {
             null,
             null,
             null,
-            Collections.singleton(new SourceCode(this.java))
+            Collections.singleton(new SourceCode(this.name, this.java))
         ).call();
         if (successful) {
             return manager.bytecode();
         } else {
             throw new IllegalStateException("Compilation failed.");
         }
+    }
+
+    private static String filename(final String resource) {
+        return resource.substring(resource.lastIndexOf('/') + 1);
     }
 
     private static final class BytecodeManager
@@ -106,10 +112,10 @@ final class JavaSourceClass {
         private BytecodeManager(JavaCompiler compiler) {
             this(
                 compiler.getStandardFileManager(
-                null,
-                Locale.getDefault(),
-                Charset.defaultCharset()
-            ));
+                    null,
+                    Locale.getDefault(),
+                    Charset.defaultCharset()
+                ));
         }
 
         private BytecodeManager(StandardJavaFileManager manager) {
@@ -141,11 +147,8 @@ final class JavaSourceClass {
          * Construct a SimpleJavaFileObject of the given kind and with the
          * given URI.
          */
-        SourceCode(final Input input) {
-            super(
-                URI.create(String.format("%s%s", "MethodByte", Kind.SOURCE.extension)),
-                Kind.SOURCE
-            );
+        SourceCode(final String name, final Input input) {
+            super(URI.create(name), Kind.SOURCE);
             this.src = input;
         }
 

--- a/src/test/java/it/JavaSourceClass.java
+++ b/src/test/java/it/JavaSourceClass.java
@@ -82,19 +82,9 @@ final class JavaSourceClass {
      *  When this is done, remove that puzzle from this method.
      */
     byte[] compile() {
-        return this.compileCode();
-    }
-
-    private byte[] compileCode() {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-        BytecodeFileManager manager = new BytecodeFileManager(
-            compiler.getStandardFileManager(
-                null,
-                Locale.getDefault(),
-                Charset.defaultCharset()
-            )
-        );
-        boolean compiledSuccessfully = compiler.getTask(
+        BytecodeManager manager = new BytecodeManager(compiler);
+        boolean successful = compiler.getTask(
             null,
             manager,
             null,
@@ -102,19 +92,27 @@ final class JavaSourceClass {
             null,
             Collections.singleton(new SourceCode(this.java))
         ).call();
-        if (compiledSuccessfully) {
-            final byte[] bytecode = manager.bytecode();
-            return bytecode;
+        if (successful) {
+            return manager.bytecode();
         } else {
             throw new IllegalStateException("Compilation failed.");
         }
     }
 
-    private static final class BytecodeFileManager
+    private static final class BytecodeManager
         extends ForwardingJavaFileManager<StandardJavaFileManager> {
         private AtomicReference<Bytecode> output;
 
-        BytecodeFileManager(StandardJavaFileManager manager) {
+        private BytecodeManager(JavaCompiler compiler) {
+            this(
+                compiler.getStandardFileManager(
+                null,
+                Locale.getDefault(),
+                Charset.defaultCharset()
+            ));
+        }
+
+        private BytecodeManager(StandardJavaFileManager manager) {
             super(manager);
             this.output = new AtomicReference<>();
         }

--- a/src/test/java/it/JavaToEoTest.java
+++ b/src/test/java/it/JavaToEoTest.java
@@ -30,7 +30,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
-import org.cactoos.bytes.BytesOf;
 import org.cactoos.bytes.UncheckedBytes;
 import org.cactoos.io.ResourceOf;
 import org.eolang.jeo.representation.BytecodeRepresentation;
@@ -60,6 +59,7 @@ final class JavaToEoTest {
 
     @ParameterizedTest(name = "{index} => {0}")
     @MethodSource("arguments")
+    @Disabled
     void compilesJavaAndTranspilesBytecodeToEo(final Resource resource) {
         final String eolang = resource.eolang();
         final String java = resource.java();

--- a/src/test/java/it/JavaToEoTest.java
+++ b/src/test/java/it/JavaToEoTest.java
@@ -30,8 +30,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
-import org.cactoos.bytes.UncheckedBytes;
-import org.cactoos.io.ResourceOf;
 import org.eolang.jeo.representation.BytecodeRepresentation;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;

--- a/src/test/java/it/JavaToEoTest.java
+++ b/src/test/java/it/JavaToEoTest.java
@@ -30,6 +30,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
+import org.cactoos.bytes.BytesOf;
+import org.cactoos.bytes.UncheckedBytes;
+import org.cactoos.io.ResourceOf;
 import org.eolang.jeo.representation.BytecodeRepresentation;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -57,7 +60,6 @@ final class JavaToEoTest {
 
     @ParameterizedTest(name = "{index} => {0}")
     @MethodSource("arguments")
-    @Disabled("The test is disabled because it is not ready yet, see the puzzle description above")
     void compilesJavaAndTranspilesBytecodeToEo(final Resource resource) {
         final String eolang = resource.eolang();
         final String java = resource.java();


### PR DESCRIPTION
Compile java classes dynamically for tests.

Closes: #83.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enabling the compilation of Java classes dynamically. 

### Detailed summary
- Removed the disabled status from the `compilesJavaAndTranspilesBytecodeToEo` test.
- Added import statements for various Java classes in `JavaSourceClass`.
- Modified the constructor of `JavaSourceClass` to include the filename.
- Implemented the `compile` method in `JavaSourceClass` to dynamically compile the Java class and return the bytecode.
- Added the `filename` method in `JavaSourceClass` to extract the name of the Java class from the resource path.
- Added the `BytecodeManager` class in `JavaSourceClass` to manage the compilation process and store the bytecode.
- Added the `SourceCode` class in `JavaSourceClass` to represent the Java source code.
- Added the `Bytecode` class in `JavaSourceClass` to represent the bytecode of the compiled class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->