### PR TITLE
feat(#96): Add test for ClassName

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/asm/ClassName.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/ClassName.java
@@ -31,9 +31,6 @@ import org.objectweb.asm.Opcodes;
 /**
  * Class name.
  * @since 0.1.0
- * @todo #89:30min Add unit test for ClassName class.
- *  The unit test should check that the class name is correct.
- *  When the unit test is ready remove that puzzle.
  */
 @SuppressWarnings("PMD.UseObjectForClearerAPI")
 public final class ClassName extends ClassVisitor {

--- a/src/test/java/org/eolang/jeo/representation/asm/ClassNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/ClassNameTest.java
@@ -1,0 +1,34 @@
+package org.eolang.jeo.representation.asm;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Test case for {@link ClassName}.
+ * @since 0.1.0
+ */
+class ClassNameTest {
+
+    @Test
+    void retrievesClassName() {
+        final ClassName name = new ClassName();
+        final ClassWriter writer = new ClassWriter(0);
+        writer.visit(Opcodes.ASM9,
+            Opcodes.ACC_PUBLIC,
+            "representation/asm/ClassNameTest",
+            null,
+            "java/lang/Object",
+            null
+        );
+        new ClassReader(writer.toByteArray()).accept(name, 0);
+        MatcherAssert.assertThat(
+            "Can't retrieve class name, or it's incorrect",
+            name.asString(),
+            Matchers.equalTo("representation.asm.ClassNameTest")
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/asm/package-info.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/package-info.java
@@ -21,38 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.jeo.representation.asm;
-
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.Opcodes;
-
 /**
- * Test case for {@link ClassName}.
- * @since 0.1.0
+ * This package contains tests for classes in {@link org.eolang.jeo.representation.asm} package.
  */
-class ClassNameTest {
-
-    @Test
-    void retrievesClassName() {
-        final ClassName name = new ClassName();
-        final ClassWriter writer = new ClassWriter(0);
-        writer.visit(
-            Opcodes.ASM9,
-            Opcodes.ACC_PUBLIC,
-            "representation/asm/ClassNameTest",
-            null,
-            "java/lang/Object",
-            null
-        );
-        new ClassReader(writer.toByteArray()).accept(name, 0);
-        MatcherAssert.assertThat(
-            "Can't retrieve class name, or it's incorrect",
-            name.asString(),
-            Matchers.equalTo("representation.asm.ClassNameTest")
-        );
-    }
-}
+package org.eolang.jeo.representation.asm;


### PR DESCRIPTION
Add unit test for ClassName.
Closes: #96


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a unit test for the `ClassName` class in the `org.eolang.jeo.representation.asm` package.

### Detailed summary
- Added a unit test for the `ClassName` class.
- The unit test checks that the class name is correct.
- The test retrieves the class name using the `ClassName` class and verifies it.
- The test is located in the `org.eolang.jeo.representation.asm` package.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->