### PR TITLE
feat(#95): Add Unit Test for ClassDirectives 

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/asm/ClassDirectives.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/ClassDirectives.java
@@ -71,6 +71,10 @@ public final class ClassDirectives extends ClassVisitor implements Iterable<Dire
         this(Opcodes.ASM9, new Directives(), listing);
     }
 
+    ClassDirectives() {
+        this("");
+    }
+
     /**
      * Constructor.
      * @param api ASM API version.

--- a/src/main/java/org/eolang/jeo/representation/asm/ClassDirectives.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/ClassDirectives.java
@@ -46,9 +46,6 @@ import org.xembly.Directives;
  *  Right now we just skip constructors. We should handle them in order to
  *  build correct XML representation of the class. When the method is ready
  *  remove that puzzle.
- * @todo #89:30min Add unit test for ClassDirectives class.
- *  The unit test should check that the directives are correct.
- *  When the unit test is ready remove that puzzle.
  */
 @SuppressWarnings({"PMD.UseObjectForClearerAPI", "PMD.AvoidDuplicateLiterals"})
 public final class ClassDirectives extends ClassVisitor implements Iterable<Directive> {
@@ -71,6 +68,9 @@ public final class ClassDirectives extends ClassVisitor implements Iterable<Dire
         this(Opcodes.ASM9, new Directives(), listing);
     }
 
+    /**
+     * Constructor.
+     */
     ClassDirectives() {
         this("");
     }

--- a/src/test/java/org/eolang/jeo/representation/asm/ClassDirectivesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/ClassDirectivesTest.java
@@ -37,6 +37,14 @@ import org.xembly.Xembler;
 /**
  * Test case for {@link ClassDirectives}.
  * @since 0.1.0
+ * @todo #95:30min Simplify bytecode generation for tests.
+ *  Right now we use ASM to generate bytecode for tests, which is not very
+ *  convenient. We should simplify it by using some kind of programmable API or DSL
+ *  to generate bytecode. For example, we can create several utility classes and use them in:
+ *  - {@link ClassDirectivesTest}
+ *  - {@link ClassNameTest}
+ *  And others.
+ *  When we have this, we can remove that puzzle.
  */
 class ClassDirectivesTest {
 

--- a/src/test/java/org/eolang/jeo/representation/asm/ClassDirectivesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/ClassDirectivesTest.java
@@ -42,7 +42,7 @@ class ClassDirectivesTest {
 
     @Test
     void parsesSimpleClassWithoutConstructor() throws ImpossibleModificationException {
-        ClassWriter writer = new ClassWriter(0);
+        final ClassWriter writer = new ClassWriter(0);
         writer.visit(
             Opcodes.ASM9,
             Opcodes.ACC_PUBLIC,
@@ -62,7 +62,7 @@ class ClassDirectivesTest {
 
     @Test
     void parsesSimpleClassWithMethod() throws ImpossibleModificationException {
-        ClassWriter writer = new ClassWriter(0);
+        final ClassWriter writer = new ClassWriter(0);
         writer.visit(
             Opcodes.ASM9,
             Opcodes.ACC_PUBLIC,

--- a/src/test/java/org/eolang/jeo/representation/asm/ClassDirectivesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/ClassDirectivesTest.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.asm;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link ClassDirectives}.
+ * @since 0.1.0
+ */
+class ClassDirectivesTest {
+
+    @Test
+    void parsesSimpleClassWithoutConstructor() throws ImpossibleModificationException {
+        ClassWriter writer = new ClassWriter(0);
+        writer.visit(
+            Opcodes.ASM9,
+            Opcodes.ACC_PUBLIC,
+            "Simple",
+            null,
+            "java/lang/Object",
+            null
+        );
+        final ClassDirectives directives = new ClassDirectives();
+        new ClassReader(writer.toByteArray()).accept(directives, 0);
+        MatcherAssert.assertThat(
+            "Can't parse simple class without constructor",
+            new XMLDocument(new Xembler(directives).xml()),
+            XhtmlMatchers.hasXPath("/program/objects/o[@name='class__Simple']")
+        );
+    }
+
+    @Test
+    void parsesSimpleClassWithMethod() throws ImpossibleModificationException {
+        ClassWriter writer = new ClassWriter(0);
+        writer.visit(
+            Opcodes.ASM9,
+            Opcodes.ACC_PUBLIC,
+            "WithMethod",
+            null,
+            "java/lang/Object",
+            null
+        );
+        writer.visitMethod(
+            Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
+            "main",
+            "([Ljava/lang/String;)V",
+            null,
+            null
+        );
+        final ClassDirectives directives = new ClassDirectives();
+        new ClassReader(writer.toByteArray()).accept(directives, 0);
+        MatcherAssert.assertThat(
+            "Can't parse simple class with method",
+            new XMLDocument(new Xembler(directives).xml()),
+            Matchers.allOf(
+                XhtmlMatchers.hasXPath(
+                    "/program/objects/o[@name='class__WithMethod']/o[@name='main']"
+                ),
+                XhtmlMatchers.hasXPath(
+                    "/program/objects/o[@name='class__WithMethod']/o[@name='main']/o[@base='seq']"
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
Add unit test for ClassDirectives.
Closes: #95.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding unit tests for the `ClassDirectives` class in the `jeo.representation.asm` package.

### Detailed summary
- Added `ClassDirectivesTest` class to test the `ClassDirectives` class.
- Added test cases for parsing simple classes without constructors and with methods.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->