### PR TITLE
feat(#100): add utility classes for bytecode tests

### DIFF
--- a/src/test/java/org/eolang/jeo/representation/asm/BytecodeClass.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/BytecodeClass.java
@@ -32,7 +32,7 @@ import org.objectweb.asm.Opcodes;
  * Class useful for generating bytecode for testing purposes.
  * @since 0.1.0
  */
-@SuppressWarnings("JTCOP")
+@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleCorrectTestName"})
 final class BytecodeClass {
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/asm/BytecodeClass.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/BytecodeClass.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.asm;
 
 import java.util.ArrayList;
@@ -5,33 +28,68 @@ import java.util.Collection;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
 
+/**
+ * Class useful for generating bytecode for testing purposes.
+ * @since 0.1.0
+ */
 @SuppressWarnings("JTCOP")
-public class BytecodeClass {
+final class BytecodeClass {
 
+    /**
+     * Class name.
+     */
     private final String name;
+
+    /**
+     * ASM class writer.
+     */
     private final ClassWriter writer;
 
+    /**
+     * Methods.
+     */
     private final Collection<BytecodeMethod> methods;
 
+    /**
+     * Constructor.
+     */
     BytecodeClass() {
         this("Simple");
     }
 
+    /**
+     * Constructor.
+     * @param name Class name.
+     */
     BytecodeClass(final String name) {
         this(name, new ClassWriter(0));
     }
 
+    /**
+     * Constructor.
+     * @param name Class name.
+     * @param writer ASM class writer.
+     */
     private BytecodeClass(final String name, final ClassWriter writer) {
         this.name = name;
         this.writer = writer;
         this.methods = new ArrayList<>(0);
     }
 
-    BytecodeClass withMethod(final String name) {
-        this.methods.add(new BytecodeMethod(name, this.writer));
+    /**
+     * Add method.
+     * @param mname Method name.
+     * @return This object.
+     */
+    BytecodeClass withMethod(final String mname) {
+        this.methods.add(new BytecodeMethod(mname, this.writer));
         return this;
     }
 
+    /**
+     * Generate bytecode.
+     * @return Bytecode.
+     */
     byte[] bytes() {
         this.writer.visit(
             Opcodes.ASM9,
@@ -45,17 +103,35 @@ public class BytecodeClass {
         return this.writer.toByteArray();
     }
 
+    /**
+     * Bytecode method.
+     * @since 0.1.0
+     */
+    private static final class BytecodeMethod {
 
-    private static class BytecodeMethod {
-
+        /**
+         * Method name.
+         */
         private final String name;
+
+        /**
+         * ASM class writer.
+         */
         private final ClassWriter writer;
 
+        /**
+         * Constructor.
+         * @param name Method name.
+         * @param writer ASM class writer.
+         */
         private BytecodeMethod(final String name, final ClassWriter writer) {
             this.name = name;
             this.writer = writer;
         }
 
+        /**
+         * Generate bytecode.
+         */
         void generate() {
             this.writer.visitMethod(
                 Opcodes.ACC_PUBLIC,
@@ -65,7 +141,5 @@ public class BytecodeClass {
                 null
             );
         }
-
     }
-
 }

--- a/src/test/java/org/eolang/jeo/representation/asm/BytecodeClass.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/BytecodeClass.java
@@ -1,0 +1,71 @@
+package org.eolang.jeo.representation.asm;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+
+@SuppressWarnings("JTCOP")
+public class BytecodeClass {
+
+    private final String name;
+    private final ClassWriter writer;
+
+    private final Collection<BytecodeMethod> methods;
+
+    BytecodeClass() {
+        this("Simple");
+    }
+
+    BytecodeClass(final String name) {
+        this(name, new ClassWriter(0));
+    }
+
+    private BytecodeClass(final String name, final ClassWriter writer) {
+        this.name = name;
+        this.writer = writer;
+        this.methods = new ArrayList<>(0);
+    }
+
+    BytecodeClass withMethod(final String name) {
+        this.methods.add(new BytecodeMethod(name, this.writer));
+        return this;
+    }
+
+    byte[] bytes() {
+        this.writer.visit(
+            Opcodes.ASM9,
+            Opcodes.ACC_PUBLIC,
+            this.name,
+            null,
+            "java/lang/Object",
+            null
+        );
+        this.methods.forEach(BytecodeMethod::generate);
+        return this.writer.toByteArray();
+    }
+
+
+    private static class BytecodeMethod {
+
+        private final String name;
+        private final ClassWriter writer;
+
+        private BytecodeMethod(final String name, final ClassWriter writer) {
+            this.name = name;
+            this.writer = writer;
+        }
+
+        void generate() {
+            this.writer.visitMethod(
+                Opcodes.ACC_PUBLIC,
+                this.name,
+                "()V",
+                null,
+                null
+            );
+        }
+
+    }
+
+}

--- a/src/test/java/org/eolang/jeo/representation/asm/ClassDirectivesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/ClassDirectivesTest.java
@@ -50,17 +50,8 @@ class ClassDirectivesTest {
 
     @Test
     void parsesSimpleClassWithoutConstructor() throws ImpossibleModificationException {
-        final ClassWriter writer = new ClassWriter(0);
-        writer.visit(
-            Opcodes.ASM9,
-            Opcodes.ACC_PUBLIC,
-            "Simple",
-            null,
-            "java/lang/Object",
-            null
-        );
         final ClassDirectives directives = new ClassDirectives();
-        new ClassReader(writer.toByteArray()).accept(directives, 0);
+        new ClassReader(new BytecodeClass().bytes()).accept(directives, 0);
         MatcherAssert.assertThat(
             "Can't parse simple class without constructor",
             new XMLDocument(new Xembler(directives).xml()),
@@ -70,24 +61,9 @@ class ClassDirectivesTest {
 
     @Test
     void parsesSimpleClassWithMethod() throws ImpossibleModificationException {
-        final ClassWriter writer = new ClassWriter(0);
-        writer.visit(
-            Opcodes.ASM9,
-            Opcodes.ACC_PUBLIC,
-            "WithMethod",
-            null,
-            "java/lang/Object",
-            null
-        );
-        writer.visitMethod(
-            Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
-            "main",
-            "([Ljava/lang/String;)V",
-            null,
-            null
-        );
         final ClassDirectives directives = new ClassDirectives();
-        new ClassReader(writer.toByteArray()).accept(directives, 0);
+        new ClassReader(new BytecodeClass("WithMethod").withMethod("main").bytes())
+            .accept(directives, 0);
         MatcherAssert.assertThat(
             "Can't parse simple class with method",
             new XMLDocument(new Xembler(directives).xml()),

--- a/src/test/java/org/eolang/jeo/representation/asm/ClassDirectivesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/ClassDirectivesTest.java
@@ -35,14 +35,6 @@ import org.xembly.Xembler;
 /**
  * Test case for {@link ClassDirectives}.
  * @since 0.1.0
- * @todo #95:30min Simplify bytecode generation for tests.
- *  Right now we use ASM to generate bytecode for tests, which is not very
- *  convenient. We should simplify it by using some kind of programmable API or DSL
- *  to generate bytecode. For example, we can create several utility classes and use them in:
- *  - {@link ClassDirectivesTest}
- *  - {@link ClassNameTest}
- *  And others.
- *  When we have this, we can remove that puzzle.
  */
 class ClassDirectivesTest {
 

--- a/src/test/java/org/eolang/jeo/representation/asm/ClassDirectivesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/ClassDirectivesTest.java
@@ -29,8 +29,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.Opcodes;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 

--- a/src/test/java/org/eolang/jeo/representation/asm/ClassNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/ClassNameTest.java
@@ -27,8 +27,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.Opcodes;
 
 /**
  * Test case for {@link ClassName}.
@@ -39,16 +37,8 @@ class ClassNameTest {
     @Test
     void retrievesClassName() {
         final ClassName name = new ClassName();
-        final ClassWriter writer = new ClassWriter(0);
-        writer.visit(
-            Opcodes.ASM9,
-            Opcodes.ACC_PUBLIC,
-            "representation/asm/ClassNameTest",
-            null,
-            "java/lang/Object",
-            null
-        );
-        new ClassReader(writer.toByteArray()).accept(name, 0);
+        new ClassReader(new BytecodeClass("representation/asm/ClassNameTest").bytes())
+            .accept(name, 0);
         MatcherAssert.assertThat(
             "Can't retrieve class name, or it's incorrect",
             name.asString(),


### PR DESCRIPTION
Add utility classes for bytecode generation in tests.
Closes: #100

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on simplifying bytecode generation for tests in the `org.eolang.jeo.representation.asm` package.

### Detailed summary
- Removed unnecessary imports of `org.objectweb.asm.ClassWriter` and `org.objectweb.asm.Opcodes` in `ClassNameTest.java` and `ClassDirectivesTest.java`.
- Replaced the usage of `ClassWriter` and `Opcodes` with a custom `BytecodeClass` class that simplifies bytecode generation for tests.
- Updated the code in `ClassNameTest.java` and `ClassDirectivesTest.java` to use the `BytecodeClass` class for generating bytecode.
- Added a new `BytecodeClass` class in the `org.eolang.jeo.representation.asm` package that provides a simplified API for generating bytecode for testing purposes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->