### PR TITLE
feat(#103): Print EO code in tests together with XMIR representation

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/asm/EoData.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/EoData.java
@@ -1,0 +1,107 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.asm;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.StringJoiner;
+import org.xembly.Directives;
+
+/**
+ * Data Object Directive in EO language.
+ *
+ * @since 0.1.0
+ */
+final class EoData {
+
+    /**
+     * Data.
+     */
+    private final Object data;
+
+    /**
+     * Constructor.
+     * @param data Data.
+     */
+    EoData(final Object data) {
+        this.data = data;
+    }
+
+    /**
+     * Directives.
+     * @return Directives
+     */
+    Directives directives() {
+        return new Directives().add("o")
+            .attr("base", this.type())
+            .attr("data", "bytes")
+            .set(this.value())
+            .up();
+    }
+
+    /**
+     * Value of the data.
+     * @return Value
+     */
+    private String value() {
+        final byte[] res;
+        if (this.data instanceof String) {
+            res = ((String) this.data).getBytes(StandardCharsets.UTF_8);
+        } else {
+            res = ByteBuffer
+                .allocate(Long.BYTES)
+                .putLong((int) this.data)
+                .array();
+        }
+        return EoData.bytesToHex(res);
+    }
+
+    /**
+     * Type of the data.
+     * @return Type
+     */
+    private String type() {
+        final String res;
+        if (this.data instanceof String) {
+            res = "string";
+        } else {
+            res = "int";
+        }
+        return res;
+    }
+
+    /**
+     * Bytes to HEX.
+     *
+     * @param bytes Bytes.
+     * @return Hexadecimal value as string.
+     */
+    private static String bytesToHex(final byte... bytes) {
+        final StringJoiner out = new StringJoiner(" ");
+        for (final byte bty : bytes) {
+            out.add(String.format("%02X", bty));
+        }
+        return out.toString();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/asm/MethodDirectives.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/MethodDirectives.java
@@ -23,9 +23,6 @@
  */
 package org.eolang.jeo.representation.asm;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.StringJoiner;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -138,42 +135,9 @@ public final class MethodDirectives extends MethodVisitor {
             .attr("name", new OpcodeName(opcode).asString())
             .attr("base", "opcode");
         for (final Object operand : operands) {
-            if (operand instanceof String) {
-                this.directives.add("o")
-                    .attr("base", "string")
-                    .attr("data", "bytes")
-                    .set(
-                        MethodDirectives.bytesToHex(
-                            ((String) operand).replace('/', '.')
-                                .getBytes(StandardCharsets.UTF_8)
-                        )
-                    )
-                    .up();
-            } else {
-                this.directives.add("o")
-                    .attr("base", "int")
-                    .attr("data", "bytes")
-                    .set(bytesToHex(ByteBuffer
-                        .allocate(Long.BYTES)
-                        .putLong((int) operand)
-                        .array()))
-                    .up();
-            }
+            this.directives.append(new EoData(operand).directives());
         }
         this.directives.up();
     }
-
-    /**
-     * Bytes to HEX.
-     *
-     * @param bytes Bytes.
-     * @return Hexadecimal value as string.
-     */
-    private static String bytesToHex(final byte... bytes) {
-        final StringJoiner out = new StringJoiner(" ");
-        for (final byte bty : bytes) {
-            out.add(String.format("%02X", bty));
-        }
-        return out.toString();
-    }
 }
+

--- a/src/main/java/org/eolang/jeo/representation/asm/MethodDirectives.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/MethodDirectives.java
@@ -23,6 +23,9 @@
  */
 package org.eolang.jeo.representation.asm;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.StringJoiner;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -139,16 +142,38 @@ public final class MethodDirectives extends MethodVisitor {
                 this.directives.add("o")
                     .attr("base", "string")
                     .attr("data", "bytes")
-                    .set(((String) operand).replace('/', '.'))
+                    .set(
+                        MethodDirectives.bytesToHex(
+                            ((String) operand).replace('/', '.')
+                                .getBytes(StandardCharsets.UTF_8)
+                        )
+                    )
                     .up();
             } else {
                 this.directives.add("o")
                     .attr("base", "int")
                     .attr("data", "bytes")
-                    .set(operand)
+                    .set(bytesToHex(ByteBuffer
+                        .allocate(Long.BYTES)
+                        .putLong((int) operand)
+                        .array()))
                     .up();
             }
         }
         this.directives.up();
+    }
+
+    /**
+     * Bytes to HEX.
+     *
+     * @param bytes Bytes.
+     * @return Hexadecimal value as string.
+     */
+    private static String bytesToHex(final byte... bytes) {
+        final StringJoiner out = new StringJoiner(" ");
+        for (final byte bty : bytes) {
+            out.add(String.format("%02X", bty));
+        }
+        return out.toString();
     }
 }

--- a/src/test/java/it/JavaToEoTest.java
+++ b/src/test/java/it/JavaToEoTest.java
@@ -58,6 +58,7 @@ final class JavaToEoTest {
 
     @ParameterizedTest(name = "{index} => {0}")
     @MethodSource("arguments")
+    @Disabled
     void compilesJavaAndTranspilesBytecodeToEo(final Resource resource) {
         final String eolang = resource.eolang();
         final String java = resource.java();

--- a/src/test/java/it/JavaToEoTest.java
+++ b/src/test/java/it/JavaToEoTest.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.BytecodeRepresentation;
+import org.eolang.parser.XMIR;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
@@ -57,17 +58,17 @@ final class JavaToEoTest {
 
     @ParameterizedTest(name = "{index} => {0}")
     @MethodSource("arguments")
-    @Disabled
     void compilesJavaAndTranspilesBytecodeToEo(final Resource resource) {
         final String eolang = resource.eolang();
         final String java = resource.java();
         final XML actual = new BytecodeRepresentation(new JavaSourceClass(java).compile()).toEO();
         MatcherAssert.assertThat(
             String.format(
-                "The transpiled EO code is not as expected, we compared the next files:%n%s%n%s%nReceived XML:%n%n%s%n",
+                "The transpiled EO code is not as expected, we compared the next files:%n%s%n%s%nReceived XML:%n%n%s%nEO:%n%s%n",
                 eolang,
                 java,
-                actual
+                actual,
+                new XMIR(actual).toEO()
             ),
             actual,
             Matchers.equalTo(new EoSource(eolang).parse())


### PR DESCRIPTION
Save data into XMIR according with EO requirements - in hex format.
Also I've added EO log to integration tests.

Closes: #103


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to refactor the code in the `MethodDirectives` class in the `MethodDirectives.java` file.
- It replaces the existing logic for adding directives with a new implementation using the `EoData` class.
- The `EoData` class is added to handle the creation of directives for different types of data.
- The `EoData` class provides methods to generate directives based on the type and value of the data.
- The `MethodDirectives` class now uses the `EoData` class to generate directives for each operand in the `operands` list.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->