### PR TITLE
feat(#110): Add Unit Test for Bytecode

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/asm/Bytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/Bytecode.java
@@ -33,9 +33,6 @@ import org.objectweb.asm.util.TraceClassVisitor;
 /**
  * Java bytecode.
  * @since 0.1.0
- * @todo #108:60min Add unit tests for Bytecode class.
- *  Bytecode class is not covered by unit tests.
- *  Add unit tests for Bytecode class and then remove this puzzle.
  */
 public final class Bytecode {
 

--- a/src/test/java/org/eolang/jeo/representation/asm/BytecodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/BytecodeTest.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.asm;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Bytecode}.
+ *
+ * @since 0.1.0
+ */
+class BytecodeTest {
+
+    @Test
+    void retrievesTheSameBytes() {
+        final byte[] expected = {1, 2, 3};
+        MatcherAssert.assertThat(
+            "Bytecode should remain the same as we pass to the constructor",
+            new Bytecode(expected).asBytes(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    void printsHumanReadableBytecodeDescription() {
+        MatcherAssert.assertThat(
+            "We expect correct and human-readable class description",
+            new BytecodeClass("Classname").bytecode().toString(),
+            Matchers.allOf(
+                Matchers.containsString("class version"),
+                Matchers.containsString("public class Classname")
+            )
+        );
+    }
+}


### PR DESCRIPTION
Add unit test for Bytecode class.

Closes: #110.


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

This PR focuses on adding unit tests for the `Bytecode` class in the `org.eolang.jeo.representation.asm` package.

Notable changes:
- Added `BytecodeTest` class with two test methods
- Added test for retrieving the same bytes
- Added test for printing human-readable bytecode description

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->