### PR TITLE
feat(#122): use BytecodeClass for bytecode generation from XML

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
@@ -61,6 +61,6 @@ public final class EoRepresentation implements Representation {
     @Override
     public Bytecode toBytecode() {
         new Schema(this.xml).check();
-        return new Bytecode(new XmlBytecode(this.xml).toByteArray());
+        return new XmlBytecode(this.xml).bytecode();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/asm/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/XmlBytecode.java
@@ -26,9 +26,6 @@ package org.eolang.jeo.representation.asm;
 import com.jcabi.xml.XML;
 import org.eolang.jeo.representation.asm.generation.BytecodeClass;
 import org.eolang.jeo.representation.asm.generation.BytecodeMethod;
-import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
 
 /**
  * XML to Java bytecode.
@@ -38,8 +35,7 @@ import org.objectweb.asm.Opcodes;
  *  We should use BytecodeClass instead in order to reduce code duplication between
  *  XmlBytecode and BytecodeClass implementations.
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
-public final class XmlBytecode extends ClassWriter {
+public final class XmlBytecode {
 
     /**
      * XML.
@@ -51,31 +47,15 @@ public final class XmlBytecode extends ClassWriter {
      * @param xml XML.
      */
     public XmlBytecode(final XML xml) {
-        super(ClassWriter.COMPUTE_MAXS);
         this.xml = xml;
     }
 
-    @Override
-    public byte[] toByteArray() {
-        return this.travers().asBytes();
-//        return super.toByteArray();
-    }
-
     /**
-     * Traverse XML.
+     * Traverse XML and build bytecode class.
      */
-    private Bytecode travers() {
+    public Bytecode bytecode() {
         final XmlClass clazz = new XmlClass(this.xml);
         final BytecodeClass bytecode = new BytecodeClass(clazz.name(), clazz.access());
-
-//        this.visit(
-//            new DefaultVersion().java(),
-//            clazz.access(),
-//            clazz.name(),
-//            null,
-//            "java/lang/Object",
-//            null
-//        );
         for (final XmlMethod method : clazz.methods()) {
             final BytecodeMethod bytecodeMethod = bytecode.withMethod(
                 method.name(),
@@ -85,61 +65,7 @@ public final class XmlBytecode extends ClassWriter {
             for (final XmlInstruction instruction : method.instructions()) {
                 bytecodeMethod.instruction(instruction.code(), instruction.arguments());
             }
-//            final MethodVisitor visitor = this.visitMethod(
-//                method.access(),
-//                method.name(),
-//                method.descriptor(),
-//                null,
-//                null
-//            );
-//            XmlBytecode.visitMethod(visitor, method);
-//            visitor.visitMaxs(0, 0);
-//            visitor.visitEnd();
         }
-
         return bytecode.bytecode();
-
-    }
-
-    /**
-     * Visit method.
-     * @param visitor Method visitor.
-     * @param node XML Node.
-     * @checkstyle CyclomaticComplexityCheck (100 lines)
-     */
-    private static void visitMethod(final MethodVisitor visitor, final XmlMethod node) {
-        for (final XmlInstruction instruction : node.instructions()) {
-            final int code = instruction.code();
-            final Object[] arguments = instruction.arguments();
-            switch (code) {
-                case Opcodes.GETSTATIC:
-                    visitor.visitFieldInsn(
-                        code,
-                        String.valueOf(arguments[0]),
-                        String.valueOf(arguments[1]),
-                        String.valueOf(arguments[2])
-                    );
-                    break;
-                case Opcodes.LDC:
-                    visitor.visitLdcInsn(arguments[0]);
-                    break;
-                case Opcodes.INVOKEVIRTUAL:
-                    visitor.visitMethodInsn(
-                        code,
-                        String.valueOf(arguments[0]),
-                        String.valueOf(arguments[1]),
-                        String.valueOf(arguments[2]),
-                        false
-                    );
-                    break;
-                case Opcodes.RETURN:
-                    visitor.visitInsn(Opcodes.RETURN);
-                    break;
-                default:
-                    throw new IllegalStateException(
-                        String.format("Unexpected value: %d", code)
-                    );
-            }
-        }
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/asm/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/XmlBytecode.java
@@ -30,10 +30,6 @@ import org.eolang.jeo.representation.asm.generation.BytecodeMethod;
 /**
  * XML to Java bytecode.
  * @since 0.1.0
- * @todo #115:90min Use BytecodeClass instead of ASM library.
- *  Right now we are using ASM library to generate bytecode from XML.
- *  We should use BytecodeClass instead in order to reduce code duplication between
- *  XmlBytecode and BytecodeClass implementations.
  */
 public final class XmlBytecode {
 
@@ -52,19 +48,20 @@ public final class XmlBytecode {
 
     /**
      * Traverse XML and build bytecode class.
+     * @return Bytecode.
      */
     public Bytecode bytecode() {
         final XmlClass clazz = new XmlClass(this.xml);
         final BytecodeClass bytecode = new BytecodeClass(clazz.name(), clazz.access());
-        for (final XmlMethod method : clazz.methods()) {
-            final BytecodeMethod bytecodeMethod = bytecode.withMethod(
-                method.name(),
-                method.descriptor(),
-                method.access()
+        for (final XmlMethod xmlmethod : clazz.methods()) {
+            final BytecodeMethod method = bytecode.withMethod(
+                xmlmethod.name(),
+                xmlmethod.descriptor(),
+                xmlmethod.access()
             );
-            for (final XmlInstruction instruction : method.instructions()) {
-                bytecodeMethod.instruction(instruction.code(), instruction.arguments());
-            }
+            xmlmethod.instructions()
+                .stream()
+                .forEach(inst -> method.instruction(inst.code(), inst.arguments()));
         }
         return bytecode.bytecode();
     }

--- a/src/main/java/org/eolang/jeo/representation/asm/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/XmlBytecode.java
@@ -24,6 +24,8 @@
 package org.eolang.jeo.representation.asm;
 
 import com.jcabi.xml.XML;
+import org.eolang.jeo.representation.asm.generation.BytecodeClass;
+import org.eolang.jeo.representation.asm.generation.BytecodeMethod;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -55,35 +57,48 @@ public final class XmlBytecode extends ClassWriter {
 
     @Override
     public byte[] toByteArray() {
-        this.travers();
-        return super.toByteArray();
+        return this.travers().asBytes();
+//        return super.toByteArray();
     }
 
     /**
      * Traverse XML.
      */
-    private void travers() {
+    private Bytecode travers() {
         final XmlClass clazz = new XmlClass(this.xml);
-        this.visit(
-            new DefaultVersion().java(),
-            clazz.access(),
-            clazz.name(),
-            null,
-            "java/lang/Object",
-            null
-        );
+        final BytecodeClass bytecode = new BytecodeClass(clazz.name(), clazz.access());
+
+//        this.visit(
+//            new DefaultVersion().java(),
+//            clazz.access(),
+//            clazz.name(),
+//            null,
+//            "java/lang/Object",
+//            null
+//        );
         for (final XmlMethod method : clazz.methods()) {
-            final MethodVisitor visitor = this.visitMethod(
-                method.access(),
+            final BytecodeMethod bytecodeMethod = bytecode.withMethod(
                 method.name(),
                 method.descriptor(),
-                null,
-                null
+                method.access()
             );
-            XmlBytecode.visitMethod(visitor, method);
-            visitor.visitMaxs(0, 0);
-            visitor.visitEnd();
+            for (final XmlInstruction instruction : method.instructions()) {
+                bytecodeMethod.instruction(instruction.code(), instruction.arguments());
+            }
+//            final MethodVisitor visitor = this.visitMethod(
+//                method.access(),
+//                method.name(),
+//                method.descriptor(),
+//                null,
+//                null
+//            );
+//            XmlBytecode.visitMethod(visitor, method);
+//            visitor.visitMaxs(0, 0);
+//            visitor.visitEnd();
         }
+
+        return bytecode.bytecode();
+
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/asm/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/XmlInstruction.java
@@ -90,6 +90,11 @@ final class XmlInstruction {
      * Convert hex string to human-readable string.
      * @param hex Hex string.
      * @return Human-readable string.
+     * @todo #122:90min Replace hexToString method with XmlData class.
+     *  Right now we have some duplication among XmlInstruction and XmlData.
+     *  They both implement the same logic of converting hex string to
+     *  human-readable string. We should refactor this code and remove
+     *  duplication.
      */
     private static String hexToString(final String hex) {
         return Arrays.stream(hex.split(" "))

--- a/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeClass.java
@@ -142,6 +142,7 @@ public final class BytecodeClass {
     /**
      * Add method.
      * @param mname Method name.
+     * @param descriptor Method descriptor.
      * @param modifiers Access modifiers.
      * @return This object.
      */

--- a/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeClass.java
@@ -56,6 +56,9 @@ public final class BytecodeClass {
      */
     private final Collection<BytecodeMethod> methods;
 
+    /**
+     * Access modifiers.
+     */
     private final int access;
 
     /**
@@ -174,5 +177,4 @@ public final class BytecodeClass {
             .instruction(Opcodes.RETURN)
             .up();
     }
-
 }


### PR DESCRIPTION
Use BytecodeClass for bytecode generation from XML.

Closes: #122 
____
History:
- feat(#122): use BytecodeClass instead of ASM ClassWriter
- feat(#122): simplify code in XmlBytecode
- feat(#122): remove the puzzle for the #122 issue
- feat(#122): add one more puzzle


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- This PR focuses on refactoring code in the `EoRepresentation` and `XmlInstruction` classes.
- It replaces the `toByteArray` method in `EoRepresentation` with a `bytecode` method.
- It adds a new `BytecodeClass` class to handle bytecode generation.
- It adds a new `hexToString` method in `XmlInstruction` and suggests replacing it with `XmlData` class to remove duplication.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->