### PR TITLE
feat(#124): don't move method for string decoding

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/asm/XmlData.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/XmlData.java
@@ -25,9 +25,7 @@ package org.eolang.jeo.representation.asm;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.StringJoiner;
-import java.util.stream.Collectors;
 import org.xembly.Directives;
 
 /**
@@ -105,17 +103,5 @@ final class XmlData {
             out.add(String.format("%02X", bty));
         }
         return out.toString();
-    }
-
-    /**
-     * Convert hex string to human-readable string.
-     * @param hex Hex string.
-     * @return Human-readable string.
-     */
-    static String encodeHexString(final String hex) {
-        return Arrays.stream(hex.split(" "))
-            .map(ch -> (char) Integer.parseInt(ch, 16))
-            .map(String::valueOf)
-            .collect(Collectors.joining());
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/asm/XmlData.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/XmlData.java
@@ -25,7 +25,9 @@ package org.eolang.jeo.representation.asm;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 import org.xembly.Directives;
 
 /**
@@ -103,5 +105,17 @@ final class XmlData {
             out.add(String.format("%02X", bty));
         }
         return out.toString();
+    }
+
+    /**
+     * Convert hex string to human-readable string.
+     * @param hex Hex string.
+     * @return Human-readable string.
+     */
+    static String encodeHexString(final String hex) {
+        return Arrays.stream(hex.split(" "))
+            .map(ch -> (char) Integer.parseInt(ch, 16))
+            .map(String::valueOf)
+            .collect(Collectors.joining());
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/asm/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/XmlInstruction.java
@@ -24,9 +24,7 @@
 package org.eolang.jeo.representation.asm;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.stream.Collectors;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -80,26 +78,9 @@ final class XmlInstruction {
         for (int index = 0; index < children.getLength(); ++index) {
             final Node child = children.item(index);
             if (child.getNodeName().equals("o")) {
-                res.add(XmlInstruction.hexToString(child.getTextContent()));
+                res.add(XmlData.encodeHexString(child.getTextContent()));
             }
         }
         return res.toArray();
-    }
-
-    /**
-     * Convert hex string to human-readable string.
-     * @param hex Hex string.
-     * @return Human-readable string.
-     * @todo #122:90min Replace hexToString method with XmlData class.
-     *  Right now we have some duplication among XmlInstruction and XmlData.
-     *  They both implement the same logic of converting hex string to
-     *  human-readable string. We should refactor this code and remove
-     *  duplication.
-     */
-    private static String hexToString(final String hex) {
-        return Arrays.stream(hex.split(" "))
-            .map(ch -> (char) Integer.parseInt(ch, 16))
-            .map(String::valueOf)
-            .collect(Collectors.joining());
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/asm/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/XmlInstruction.java
@@ -24,7 +24,9 @@
 package org.eolang.jeo.representation.asm;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.stream.Collectors;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -78,9 +80,23 @@ final class XmlInstruction {
         for (int index = 0; index < children.getLength(); ++index) {
             final Node child = children.item(index);
             if (child.getNodeName().equals("o")) {
-                res.add(XmlData.encodeHexString(child.getTextContent()));
+                res.add(decodeHexString(child.getTextContent()));
             }
         }
         return res.toArray();
+    }
+
+    /**
+     * Convert hex string to human-readable string.
+     * Example:
+     *  "48 65 6C 6C 6F 20 57 6F 72 6C 64 21" -> "Hello World!"
+     * @param hex Hex string.
+     * @return Human-readable string.
+     */
+    private static String decodeHexString(final String hex) {
+        return Arrays.stream(hex.split(" "))
+            .map(ch -> (char) Integer.parseInt(ch, 16))
+            .map(String::valueOf)
+            .collect(Collectors.joining());
     }
 }


### PR DESCRIPTION
I've checked the code and there is no need to move that method into XmlData because it serves different purpose.
So I just close that puzzle.

Closes: #124
____
History:
- feat(#124): rename and move the hex convertation method
- feat(#124): move static method back


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Replaced the `hexToString` method with `decodeHexString` in the `XmlInstruction` class.
- Removed duplication between `XmlInstruction` and `XmlData` classes.
- Refactored the code to improve readability and remove duplication.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->