### PR TITLE
feat(#129): Add BytecodeClassProperties Class for Bytecode Generation

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeClassProperties.java
@@ -26,6 +26,11 @@ package org.eolang.jeo.representation.asm.generation;
 import org.eolang.jeo.representation.asm.DefaultVersion;
 import org.objectweb.asm.ClassWriter;
 
+/**
+ * Class properties.
+ *
+ * @since 0.1.0
+ */
 final class BytecodeClassProperties {
 
     /**
@@ -53,7 +58,7 @@ final class BytecodeClassProperties {
      * @param access Access modifiers.
      */
     BytecodeClassProperties(final int access) {
-        this(access, null, "java/lang/Object", null);
+        this(access, null, "java/lang/Object", new String[0]);
     }
 
     /**
@@ -62,17 +67,18 @@ final class BytecodeClassProperties {
      * @param signature Signature.
      * @param supername Supername.
      * @param interfaces Interfaces.
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     private BytecodeClassProperties(
         final int access,
         final String signature,
         final String supername,
-        final String[] interfaces
+        final String... interfaces
     ) {
         this.access = access;
         this.signature = signature;
         this.supername = supername;
-        this.interfaces = interfaces;
+        this.interfaces = interfaces.clone();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeClassProperties.java
@@ -1,0 +1,93 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.asm.generation;
+
+import org.eolang.jeo.representation.asm.DefaultVersion;
+import org.objectweb.asm.ClassWriter;
+
+final class BytecodeClassProperties {
+
+    /**
+     * Access modifiers.
+     */
+    private final int access;
+
+    /**
+     * Signature.
+     */
+    private final String signature;
+
+    /**
+     * Supername.
+     */
+    private final String supername;
+
+    /**
+     * Interfaces.
+     */
+    private final String[] interfaces;
+
+    /**
+     * Constructor.
+     * @param access Access modifiers.
+     */
+    BytecodeClassProperties(final int access) {
+        this(access, null, "java/lang/Object", null);
+    }
+
+    /**
+     * Constructor.
+     * @param access Access modifiers.
+     * @param signature Signature.
+     * @param supername Supername.
+     * @param interfaces Interfaces.
+     */
+    private BytecodeClassProperties(
+        final int access,
+        final String signature,
+        final String supername,
+        final String[] interfaces
+    ) {
+        this.access = access;
+        this.signature = signature;
+        this.supername = supername;
+        this.interfaces = interfaces;
+    }
+
+    /**
+     * Start writing a class by using class writer.
+     * @param writer Class writer.
+     * @param name Class name.
+     */
+    void write(final ClassWriter writer, final String name) {
+        writer.visit(
+            new DefaultVersion().java(),
+            this.access,
+            name,
+            this.signature,
+            this.supername,
+            this.interfaces
+        );
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeMethod.java
@@ -122,7 +122,7 @@ public final class BytecodeMethod {
     /**
      * Generate bytecode.
      */
-    void generate() {
+    void write() {
         int access = 0;
         for (final int modifier : this.modifiers) {
             access |= modifier;


### PR DESCRIPTION
Add BytecodeClassProperties for bytecode generation.

Closes: #129.

____
History:
- feat(#129): Add BytecodeClassProperties Class
- feat(#129): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Renamed the `generate()` method in `BytecodeMethod` class to `write()`.
- Introduced a new `BytecodeClassProperties` class to handle class properties (access, signature, supername, interfaces).
- Removed the `DefaultVersion` import in `BytecodeClass` class.
- Updated the `BytecodeClass` class to use the `BytecodeClassProperties` class to write class properties.
- Updated the `BytecodeClass` class to use the `write()` method instead of the deprecated `generate()` method in `BytecodeMethod` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->