### PR TITLE
feat(#128): Convert Bytecode Class Properties to XMIR and Back

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesClassProperties.java
@@ -89,6 +89,17 @@ final class DirectivesClassProperties implements Iterable<Directive> {
         if (this.supername != null) {
             directives.append(new XmlData(this.supername, "supername").directives());
         }
+        if (this.interfaces != null) {
+            final Directives tuple = new Directives().add("o")
+                .attr("base", "tuple")
+                .attr("data", "tuple")
+                .attr("name", "interfaces");
+            for (final String interf : this.interfaces) {
+                tuple.append(new XmlData(interf).directives());
+            }
+            tuple.up();
+            directives.append(tuple);
+        }
         Logger.warn(
             this,
             String.format(

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesClassProperties.java
@@ -33,9 +33,6 @@ import org.xembly.Directives;
  * Class properties as Xembly directives.
  *
  * @since 0.1.0
- * @todo #112:60min Convert array into data or tuple object.
- *  Right now we just skip array of interfaces. We should convert it into
- *  data or tuple object. When the method is ready remove that puzzle.
  */
 final class DirectivesClassProperties implements Iterable<Directive> {
 

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesClassProperties.java
@@ -79,12 +79,12 @@ final class DirectivesClassProperties implements Iterable<Directive> {
     @Override
     public Iterator<Directive> iterator() {
         final Directives directives = new Directives()
-            .append(new XmlData(this.access, "access").directives());
+            .append(new DirectivesData(this.access, "access").directives());
         if (this.signature != null) {
-            directives.append(new XmlData(this.signature, "signature").directives());
+            directives.append(new DirectivesData(this.signature, "signature").directives());
         }
         if (this.supername != null) {
-            directives.append(new XmlData(this.supername, "supername").directives());
+            directives.append(new DirectivesData(this.supername, "supername").directives());
         }
         if (this.interfaces != null) {
             final Directives tuple = new Directives().add("o")
@@ -92,7 +92,7 @@ final class DirectivesClassProperties implements Iterable<Directive> {
                 .attr("data", "tuple")
                 .attr("name", "interfaces");
             for (final String interf : this.interfaces) {
-                tuple.append(new XmlData(interf).directives());
+                tuple.append(new DirectivesData(interf).directives());
             }
             tuple.up();
             directives.append(tuple);

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesClassProperties.java
@@ -23,8 +23,6 @@
  */
 package org.eolang.jeo.representation.asm;
 
-import com.jcabi.log.Logger;
-import java.util.Arrays;
 import java.util.Iterator;
 import org.xembly.Directive;
 import org.xembly.Directives;
@@ -97,13 +95,6 @@ final class DirectivesClassProperties implements Iterable<Directive> {
             tuple.up();
             directives.append(tuple);
         }
-        Logger.warn(
-            this,
-            String.format(
-                "Interfaces mapping is not implemented yet. Interfaces '%s' was skipped",
-                Arrays.toString(this.interfaces)
-            )
-        );
         return directives.iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesData.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesData.java
@@ -33,7 +33,7 @@ import org.xembly.Directives;
  *
  * @since 0.1.0
  */
-final class XmlData {
+final class DirectivesData {
 
     /**
      * Data.
@@ -49,7 +49,7 @@ final class XmlData {
      * Constructor.
      * @param data Data.
      */
-    XmlData(final Object data) {
+    DirectivesData(final Object data) {
         this(data, "");
     }
 
@@ -58,7 +58,7 @@ final class XmlData {
      * @param data Data.
      * @param name Name.
      */
-    XmlData(final Object data, final String name) {
+    DirectivesData(final Object data, final String name) {
         this.data = data;
         this.name = name;
     }
@@ -91,7 +91,7 @@ final class XmlData {
                 .putLong((int) this.data)
                 .array();
         }
-        return XmlData.bytesToHex(res);
+        return DirectivesData.bytesToHex(res);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/asm/MethodDirectives.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/MethodDirectives.java
@@ -140,7 +140,7 @@ public final class MethodDirectives extends MethodVisitor implements Iterable<Di
             .attr("name", new OpcodeName(opcode).asString())
             .attr("base", "opcode");
         for (final Object operand : operands) {
-            this.directives.append(new XmlData(operand).directives());
+            this.directives.append(new DirectivesData(operand).directives());
         }
         this.directives.up();
     }

--- a/src/main/java/org/eolang/jeo/representation/asm/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/XmlBytecode.java
@@ -52,7 +52,10 @@ public final class XmlBytecode {
      */
     public Bytecode bytecode() {
         final XmlClass clazz = new XmlClass(this.xml);
-        final BytecodeClass bytecode = new BytecodeClass(clazz.name(), clazz.properties().access());
+        final BytecodeClass bytecode = new BytecodeClass(
+            clazz.name(),
+            clazz.properties().toBytecodeProperties()
+        );
         for (final XmlMethod xmlmethod : clazz.methods()) {
             final BytecodeMethod method = bytecode.withMethod(
                 xmlmethod.name(),

--- a/src/main/java/org/eolang/jeo/representation/asm/XmlClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/XmlClassProperties.java
@@ -83,7 +83,7 @@ final class XmlClassProperties {
         return new BytecodeClassProperties(
             this.access(),
             this.signature().orElse(null),
-            this.supername().orElse(null),
+            this.supername().orElse("java/lang/Object"),
             this.interfaces()
         );
     }

--- a/src/main/java/org/eolang/jeo/representation/asm/XmlClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/XmlClassProperties.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation.asm;
 
 import com.jcabi.xml.XMLDocument;
+import org.eolang.jeo.representation.asm.generation.BytecodeClassProperties;
 import org.w3c.dom.Node;
 
 /**
@@ -52,6 +53,27 @@ final class XmlClassProperties {
      */
     int access() {
         return new HexString(this.clazz.xpath("//o[@name='access']/text()").get(0)).decodeAsInt();
+    }
+
+    String signature() {
+        return new HexString(this.clazz.xpath("//o[@name='signature']/text()").get(0)).decode();
+    }
+
+    private String supername() {
+        return new HexString(this.clazz.xpath("//o[@name='supername']/text()").get(0)).decode();
+    }
+
+    private String[] interfaces() {
+        return new String[0];
+    }
+
+    BytecodeClassProperties toBytecodeProperties() {
+        return new BytecodeClassProperties(
+            this.access(),
+            this.signature(),
+            this.supername(),
+            this.interfaces()
+        );
     }
 }
 

--- a/src/main/java/org/eolang/jeo/representation/asm/XmlClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/XmlClassProperties.java
@@ -56,7 +56,24 @@ final class XmlClassProperties {
         return new HexString(this.clazz.xpath("//o[@name='access']/text()").get(0)).decodeAsInt();
     }
 
-    Optional<String> signature() {
+    /**
+     * Convert to bytecode properties.
+     * @return Bytecode properties.
+     */
+    BytecodeClassProperties toBytecodeProperties() {
+        return new BytecodeClassProperties(
+            this.access(),
+            this.signature().orElse(null),
+            this.supername(),
+            this.interfaces()
+        );
+    }
+
+    /**
+     * Retrieve 'signature' of a class.
+     * @return Signature.
+     */
+    private Optional<String> signature() {
         return this.clazz.xpath("//o[@name='signature']/text()")
             .stream()
             .map(HexString::new)
@@ -64,28 +81,27 @@ final class XmlClassProperties {
             .findFirst();
     }
 
-    Optional<String> supername() {
+    /**
+     * Retrieve 'supername' of a class.
+     * @return Supername.
+     */
+    private String supername() {
         return this.clazz.xpath("//o[@name='supername']/text()")
             .stream()
             .map(HexString::new)
             .map(HexString::decode)
-            .findFirst();
+            .findFirst().orElse("java/lang/Object");
     }
 
-    String[] interfaces() {
+    /**
+     * Retrieve 'interfaces' of a class.
+     * @return Interfaces.
+     */
+    private String[] interfaces() {
         return this.clazz.xpath("//o[@name='interfaces']/o/text()")
             .stream()
             .map(HexString::new)
             .map(HexString::decode).toArray(String[]::new);
-    }
-
-    BytecodeClassProperties toBytecodeProperties() {
-        return new BytecodeClassProperties(
-            this.access(),
-            this.signature().orElse(null),
-            this.supername().orElse("java/lang/Object"),
-            this.interfaces()
-        );
     }
 }
 

--- a/src/main/java/org/eolang/jeo/representation/asm/XmlClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/XmlClassProperties.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation.asm;
 
 import com.jcabi.xml.XMLDocument;
+import java.util.Optional;
 import org.eolang.jeo.representation.asm.generation.BytecodeClassProperties;
 import org.w3c.dom.Node;
 
@@ -55,23 +56,34 @@ final class XmlClassProperties {
         return new HexString(this.clazz.xpath("//o[@name='access']/text()").get(0)).decodeAsInt();
     }
 
-    String signature() {
-        return new HexString(this.clazz.xpath("//o[@name='signature']/text()").get(0)).decode();
+    Optional<String> signature() {
+        return this.clazz.xpath("//o[@name='signature']/text()")
+            .stream()
+            .map(HexString::new)
+            .map(HexString::decode)
+            .findFirst();
     }
 
-    private String supername() {
-        return new HexString(this.clazz.xpath("//o[@name='supername']/text()").get(0)).decode();
+    Optional<String> supername() {
+        return this.clazz.xpath("//o[@name='supername']/text()")
+            .stream()
+            .map(HexString::new)
+            .map(HexString::decode)
+            .findFirst();
     }
 
-    private String[] interfaces() {
-        return new String[0];
+    String[] interfaces() {
+        return this.clazz.xpath("//o[@name='interfaces']/o/text()")
+            .stream()
+            .map(HexString::new)
+            .map(HexString::decode).toArray(String[]::new);
     }
 
     BytecodeClassProperties toBytecodeProperties() {
         return new BytecodeClassProperties(
             this.access(),
-            this.signature(),
-            this.supername(),
+            this.signature().orElse(null),
+            this.supername().orElse(null),
             this.interfaces()
         );
     }

--- a/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeClass.java
@@ -84,6 +84,11 @@ public final class BytecodeClass {
         this(name.replace(".", "/"), access, new ClassWriter(ClassWriter.COMPUTE_MAXS));
     }
 
+    /**
+     * Constructor.
+     * @param name Class name.
+     * @param properties Class properties.
+     */
     public BytecodeClass(final String name, final BytecodeClassProperties properties) {
         this(
             name.replace(".", "/"),
@@ -113,6 +118,7 @@ public final class BytecodeClass {
      * @param writer ASM class writer.
      * @param methods Methods.
      * @param properties Class properties.
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     public BytecodeClass(
         final String name,

--- a/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeClass.java
@@ -84,6 +84,15 @@ public final class BytecodeClass {
         this(name.replace(".", "/"), access, new ClassWriter(ClassWriter.COMPUTE_MAXS));
     }
 
+    public BytecodeClass(final String name, final BytecodeClassProperties properties) {
+        this(
+            name.replace(".", "/"),
+            new ClassWriter(ClassWriter.COMPUTE_MAXS),
+            new ArrayList<>(0),
+            properties
+        );
+    }
+
     /**
      * Constructor.
      * @param name Class name.
@@ -95,10 +104,26 @@ public final class BytecodeClass {
         final int access,
         final ClassWriter writer
     ) {
+        this(name, writer, new ArrayList<>(0), new BytecodeClassProperties(access));
+    }
+
+    /**
+     * Constructor.
+     * @param name Class name.
+     * @param writer ASM class writer.
+     * @param methods Methods.
+     * @param properties Class properties.
+     */
+    public BytecodeClass(
+        final String name,
+        final ClassWriter writer,
+        final Collection<BytecodeMethod> methods,
+        final BytecodeClassProperties properties
+    ) {
         this.name = name;
         this.writer = writer;
-        this.methods = new ArrayList<>(0);
-        this.properties = new BytecodeClassProperties(access);
+        this.methods = methods;
+        this.properties = properties;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeClassProperties.java
@@ -31,7 +31,7 @@ import org.objectweb.asm.ClassWriter;
  *
  * @since 0.1.0
  */
-final class BytecodeClassProperties {
+public final class BytecodeClassProperties {
 
     /**
      * Access modifiers.
@@ -57,7 +57,7 @@ final class BytecodeClassProperties {
      * Constructor.
      * @param access Access modifiers.
      */
-    BytecodeClassProperties(final int access) {
+    public BytecodeClassProperties(final int access) {
         this(access, null, "java/lang/Object", new String[0]);
     }
 
@@ -69,7 +69,7 @@ final class BytecodeClassProperties {
      * @param interfaces Interfaces.
      * @checkstyle ParameterNumberCheck (5 lines)
      */
-    private BytecodeClassProperties(
+    public BytecodeClassProperties(
         final int access,
         final String signature,
         final String supername,

--- a/src/test/java/org/eolang/jeo/representation/asm/DirectivesClassPropertiesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/DirectivesClassPropertiesTest.java
@@ -61,6 +61,9 @@ final class DirectivesClassPropertiesTest {
                     "   <o base=\"int\" data=\"bytes\" name=\"access\">00 00 00 00 00 00 00 01</o>\n",
                     "   <o base=\"string\" data=\"bytes\" name=\"signature\">6F 72 67 2F 65 6F 6C 61 6E 67 2F 53 6F 6D 65 43 6C 61 73 73</o>\n",
                     "   <o base=\"string\" data=\"bytes\" name=\"supername\">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>\n",
+                    "   <o base=\"tuple\" data=\"tuple\" name=\"interfaces\">\n",
+                    "      <o base=\"string\" data=\"bytes\">6F 72 67 2F 65 6F 6C 61 6E 67 2F 53 6F 6D 65 49 6E 74 65 72 66 61 63 65</o>\n",
+                    "   </o>\n",
                     "</o>\n"
                 )
             )


### PR DESCRIPTION
Convert bytecode class properties into XMIR and back to bytecode.

Closes: #128.
____

History:
- feat(#128): save interfaces into XMIR
- feat(#128): remove the puzzle description
- feat(#128): rename XmlData -> DirectivesData
- feat(#128): add constructor for BytecodeClass with required properties
- feat(#128): handle cases where we don't have some class properties
- feat(#128): set default supername
- feat(#128): fix all qulice suggestions

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Renamed `XmlData` class to `DirectivesData` in `MethodDirectives.java`.
- Updated method `bytecode()` in `XmlBytecode.java` to use `toBytecodeProperties()` method from `XmlClassProperties`.
- Added support for `interfaces` in `DirectivesClassProperties.java` by converting it into a tuple object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->