### PR TITLE
feat(#107): Save Method Parameters in XMIR

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
@@ -45,6 +45,13 @@ import org.xembly.Directives;
  *  Right now we just skip constructors. We should handle them in order to
  *  build correct XML representation of the class. When the method is ready
  *  remove that puzzle.
+ * @todo #107:30min Change method argument naming strategy.
+ *  Right now we use method argument type and index to generate method argument name.
+ *  For example for method with signature `void foo(int a, String b)` we generate
+ *  method argument names `arg__I__0` and `arg__Ljava/lang/String__1`. This is not a good way
+ *  to do it. At least it leads to errors when argument type is an array or class.
+ *  So we have to test this cases and maybe create a better strategy for arguments naming.
+ *
  */
 @SuppressWarnings({"PMD.UseObjectForClearerAPI", "PMD.AvoidDuplicateLiterals"})
 public final class DirectivesClass extends ClassVisitor implements Iterable<Directive> {

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
@@ -51,7 +51,6 @@ import org.xembly.Directives;
  *  method argument names `arg__I__0` and `arg__Ljava/lang/String__1`. This is not a good way
  *  to do it. At least it leads to errors when argument type is an array or class.
  *  So we have to test this cases and maybe create a better strategy for arguments naming.
- *
  */
 @SuppressWarnings({"PMD.UseObjectForClearerAPI", "PMD.AvoidDuplicateLiterals"})
 public final class DirectivesClass extends ClassVisitor implements Iterable<Directive> {
@@ -151,10 +150,10 @@ public final class DirectivesClass extends ClassVisitor implements Iterable<Dire
                     .up();
             }
             final Type[] arguments = Type.getArgumentTypes(descriptor);
-            for (int i = 0; i < arguments.length; i++) {
+            for (int index = 0; index < arguments.length; ++index) {
                 this.directives.add("o")
                     .attr("abstract", "")
-                    .attr("name", String.format("arg__%s__%d", arguments[i], i))
+                    .attr("name", String.format("arg__%s__%d", arguments[index], index))
                     .up();
             }
             this.directives

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
@@ -143,7 +143,15 @@ public final class DirectivesClass extends ClassVisitor implements Iterable<Dire
                     .attr("name", "args")
                     .up();
             }
-            this.directives.add("o")
+            final Type[] arguments = Type.getArgumentTypes(descriptor);
+            for (int i = 0; i < arguments.length; i++) {
+                this.directives.add("o")
+                    .attr("abstract", "")
+                    .attr("name", String.format("arg__%s__%d", arguments[i], i))
+                    .up();
+            }
+            this.directives
+                .add("o")
                 .attr("base", "seq")
                 .attr("name", "@");
             result = new DirectivesMethod(

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
@@ -146,7 +146,7 @@ public final class DirectivesClass extends ClassVisitor implements Iterable<Dire
             this.directives.add("o")
                 .attr("base", "seq")
                 .attr("name", "@");
-            result = new MethodDirectives(
+            result = new DirectivesMethod(
                 this.directives,
                 super.visitMethod(access, name, descriptor, signature, exceptions)
             );

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethod.java
@@ -40,7 +40,7 @@ import org.xembly.Directives;
  *  remove that puzzle.
  */
 @SuppressWarnings("PMD.TooManyMethods")
-public final class MethodDirectives extends MethodVisitor implements Iterable<Directive> {
+public final class DirectivesMethod extends MethodVisitor implements Iterable<Directive> {
 
     /**
      * Xembly directives.
@@ -52,7 +52,7 @@ public final class MethodDirectives extends MethodVisitor implements Iterable<Di
      * @param directives Xembly directives
      * @param visitor Method visitor
      */
-    MethodDirectives(
+    DirectivesMethod(
         final Directives directives,
         final MethodVisitor visitor
     ) {

--- a/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeInstruction.java
@@ -120,7 +120,7 @@ final class BytecodeInstruction {
         ),
 
         /**
-         * Store int value into variable #index
+         * Store int value into variable #index.
          */
         ISTORE(Opcodes.ISTORE, (visitor, arguments) ->
             visitor.visitVarInsn(Opcodes.ISTORE, (int) arguments.get(0))
@@ -139,7 +139,6 @@ final class BytecodeInstruction {
         DUP(Opcodes.DUP, (visitor, arguments) ->
             visitor.visitInsn(Opcodes.DUP)
         ),
-
 
         /**
          * Return an integer from a method.
@@ -185,8 +184,8 @@ final class BytecodeInstruction {
         ),
 
         /**
-         * Invoke instance method on object objectref and puts the result on the stack
-         * (might be void); the method is identified by method reference index in constant pool
+         * Invoke instance method on object objectref and puts the result on the stack.
+         * Might be void. The method is identified by method reference index in constant pool.
          */
         INCOKESPECIAL(Opcodes.INVOKESPECIAL, (visitor, arguments) ->
             visitor.visitMethodInsn(
@@ -198,9 +197,8 @@ final class BytecodeInstruction {
             )
         ),
 
-
         /**
-         * Create new object of type identified by class reference in constant pool index
+         * Create new object of type identified by class reference in constant pool index.
          */
         NEW(Opcodes.NEW, (visitor, arguments) ->
             visitor.visitTypeInsn(

--- a/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/generation/BytecodeInstruction.java
@@ -99,6 +99,49 @@ final class BytecodeInstruction {
         ),
 
         /**
+         * Load an int value from a local variable #index.
+         */
+        ILOAD(Opcodes.ILOAD, (visitor, arguments) ->
+            visitor.visitVarInsn(Opcodes.ILOAD, (int) arguments.get(0))
+        ),
+
+        /**
+         * Load a reference onto the stack from a local variable #index.
+         */
+        ALOAD(Opcodes.ALOAD, (visitor, arguments) ->
+            visitor.visitVarInsn(Opcodes.ALOAD, (int) arguments.get(0))
+        ),
+
+        /**
+         * Add two integers.
+         */
+        IADD(Opcodes.IADD, (visitor, arguments) ->
+            visitor.visitInsn(Opcodes.IADD)
+        ),
+
+        /**
+         * Store int value into variable #index
+         */
+        ISTORE(Opcodes.ISTORE, (visitor, arguments) ->
+            visitor.visitVarInsn(Opcodes.ISTORE, (int) arguments.get(0))
+        ),
+
+        /**
+         * Store a reference into a local variable #index.
+         */
+        ASTORE(Opcodes.ASTORE, (visitor, arguments) ->
+            visitor.visitVarInsn(Opcodes.ASTORE, (int) arguments.get(0))
+        ),
+
+        /**
+         * Duplicate the value on top of the stack.
+         */
+        DUP(Opcodes.DUP, (visitor, arguments) ->
+            visitor.visitInsn(Opcodes.DUP)
+        ),
+
+
+        /**
          * Return an integer from a method.
          */
         IRETURN(Opcodes.IRETURN, (visitor, arguments) ->
@@ -138,6 +181,31 @@ final class BytecodeInstruction {
                 String.valueOf(arguments.get(1)),
                 String.valueOf(arguments.get(2)),
                 false
+            )
+        ),
+
+        /**
+         * Invoke instance method on object objectref and puts the result on the stack
+         * (might be void); the method is identified by method reference index in constant pool
+         */
+        INCOKESPECIAL(Opcodes.INVOKESPECIAL, (visitor, arguments) ->
+            visitor.visitMethodInsn(
+                Opcodes.INVOKESPECIAL,
+                String.valueOf(arguments.get(0)),
+                String.valueOf(arguments.get(1)),
+                String.valueOf(arguments.get(2)),
+                false
+            )
+        ),
+
+
+        /**
+         * Create new object of type identified by class reference in constant pool index
+         */
+        NEW(Opcodes.NEW, (visitor, arguments) ->
+            visitor.visitTypeInsn(
+                Opcodes.NEW,
+                String.valueOf(arguments.get(0))
             )
         );
 

--- a/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
@@ -36,9 +36,9 @@ import org.objectweb.asm.Opcodes;
 import org.xembly.Xembler;
 
 /**
- * Test case for {@link MethodDirectives}.
- * We create {@link MethodDirectives} only in the context
- * of using {@link DirectivesClass} in other words, {@link MethodDirectives} can't be createad
+ * Test case for {@link DirectivesMethod}.
+ * We create {@link DirectivesMethod} only in the context
+ * of using {@link DirectivesClass} in other words, {@link DirectivesMethod} can't be createad
  * without {@link DirectivesClass} and it is the main reason why in all the test we create
  * {@link DirectivesClass}.
  *
@@ -52,9 +52,9 @@ import org.xembly.Xembler;
  *  Right now, we parse methods without parameters. We need to implement
  *  parsing of methods with parameters. Once completed, remove this puzzle.
  *  Don't forget to add unit tests for this feature.
- *  See {@link org.eolang.jeo.representation.asm.MethodDirectivesTest#parsesMethodParameters()}.
+ *  See {@link DirectivesMethodTest#parsesMethodParameters()}.
  */
-class MethodDirectivesTest {
+class DirectivesMethodTest {
 
     @Test
     void parsesMethodInstructions() {

--- a/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
@@ -48,11 +48,6 @@ import org.xembly.Xembler;
  *  the resulting XML, which are hard to read and understand. I believe
  *  we need to simplify these checks. Perhaps, we should introduce a new
  *  Hamcrest matcher. Once completed, remove this puzzle.
- * @todo #97:60min Implement passing parameters to methods.
- *  Right now, we parse methods without parameters. We need to implement
- *  parsing of methods with parameters. Once completed, remove this puzzle.
- *  Don't forget to add unit tests for this feature.
- *  See {@link DirectivesMethodTest#parsesMethodParameters()}.
  */
 class DirectivesMethodTest {
 

--- a/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
@@ -107,9 +107,31 @@ class DirectivesMethodTest {
      */
     @Test
     void parsesMethodParameters() {
-        final XML xml = new BytecodeClass("ParametersExample").xml();
-
-        System.out.println(xml);
+        final XML xml = new BytecodeClass("ParametersExample")
+            .withMethod("main", Opcodes.ACC_PUBLIC, Opcodes.ACC_STATIC)
+            .descriptor("([Ljava/lang/String;)V")
+            .instruction(Opcodes.NEW, "ParametersExample")
+            .instruction(Opcodes.DUP)
+            .instruction(Opcodes.INVOKESPECIAL, "ParametersExample", "<init>", "()V")
+            .instruction(Opcodes.ASTORE, 1)
+            .instruction(Opcodes.ALOAD, 1)
+            .instruction(Opcodes.BIPUSH, 10)
+            .instruction(Opcodes.BIPUSH, 20)
+            .instruction(Opcodes.INVOKEVIRTUAL, "ParametersExample", "printSum", "(II)V")
+            .instruction(Opcodes.RETURN)
+            .up()
+            .withMethod("printSum", Opcodes.ACC_PUBLIC)
+            .descriptor("(II)V")
+            .instruction(Opcodes.ILOAD, 1)
+            .instruction(Opcodes.ILOAD, 2)
+            .instruction(Opcodes.IADD)
+            .instruction(Opcodes.ISTORE, 3)
+            .instruction(Opcodes.GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;")
+            .instruction(Opcodes.ILOAD, 3)
+            .instruction(Opcodes.INVOKEVIRTUAL, "java/io/PrintStream", "println", "(I)V")
+            .instruction(Opcodes.RETURN)
+            .up()
+            .xml();
     }
 
     @Test

--- a/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
@@ -107,31 +107,47 @@ class DirectivesMethodTest {
      */
     @Test
     void parsesMethodParameters() {
-        final XML xml = new BytecodeClass("ParametersExample")
-            .withMethod("main", Opcodes.ACC_PUBLIC, Opcodes.ACC_STATIC)
-            .descriptor("([Ljava/lang/String;)V")
-            .instruction(Opcodes.NEW, "ParametersExample")
-            .instruction(Opcodes.DUP)
-            .instruction(Opcodes.INVOKESPECIAL, "ParametersExample", "<init>", "()V")
-            .instruction(Opcodes.ASTORE, 1)
-            .instruction(Opcodes.ALOAD, 1)
-            .instruction(Opcodes.BIPUSH, 10)
-            .instruction(Opcodes.BIPUSH, 20)
-            .instruction(Opcodes.INVOKEVIRTUAL, "ParametersExample", "printSum", "(II)V")
-            .instruction(Opcodes.RETURN)
-            .up()
-            .withMethod("printSum", Opcodes.ACC_PUBLIC)
-            .descriptor("(II)V")
-            .instruction(Opcodes.ILOAD, 1)
-            .instruction(Opcodes.ILOAD, 2)
-            .instruction(Opcodes.IADD)
-            .instruction(Opcodes.ISTORE, 3)
-            .instruction(Opcodes.GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;")
-            .instruction(Opcodes.ILOAD, 3)
-            .instruction(Opcodes.INVOKEVIRTUAL, "java/io/PrintStream", "println", "(I)V")
-            .instruction(Opcodes.RETURN)
-            .up()
-            .xml();
+        MatcherAssert.assertThat(
+            String.join(
+                "\n",
+                "Currently we don't save method parameters as separate objects in the XML.",
+                "Method parameters implemented through opcodes.",
+                "I don't know if we need to change this behavior."
+            ),
+            new BytecodeClass("ParametersExample")
+                .withMethod("main", Opcodes.ACC_PUBLIC, Opcodes.ACC_STATIC)
+                .descriptor("([Ljava/lang/String;)V")
+                .instruction(Opcodes.NEW, "ParametersExample")
+                .instruction(Opcodes.DUP)
+                .instruction(Opcodes.INVOKESPECIAL, "ParametersExample", "<init>", "()V")
+                .instruction(Opcodes.ASTORE, 1)
+                .instruction(Opcodes.ALOAD, 1)
+                .instruction(Opcodes.BIPUSH, 10)
+                .instruction(Opcodes.BIPUSH, 20)
+                .instruction(Opcodes.INVOKEVIRTUAL, "ParametersExample", "printSum", "(II)V")
+                .instruction(Opcodes.RETURN)
+                .up()
+                .withMethod("printSum", Opcodes.ACC_PUBLIC)
+                .descriptor("(II)V")
+                .instruction(Opcodes.ILOAD, 1)
+                .instruction(Opcodes.ILOAD, 2)
+                .instruction(Opcodes.IADD)
+                .instruction(Opcodes.ISTORE, 3)
+                .instruction(Opcodes.GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;")
+                .instruction(Opcodes.ILOAD, 3)
+                .instruction(Opcodes.INVOKEVIRTUAL, "java/io/PrintStream", "println", "(I)V")
+                .instruction(Opcodes.RETURN)
+                .up()
+                .xml(),
+            Matchers.allOf(
+                XhtmlMatchers.hasXPath(
+                    "/program/objects/o/o[contains(@name,'1__printSum__(II)V')]/o[@name='x_int_1']"
+                ),
+                XhtmlMatchers.hasXPath(
+                    "/program/objects/o/o[contains(@name,'1__printSum__(II)V')]/o[@name='x_int_2']"
+                )
+            )
+        );
     }
 
     @Test

--- a/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
@@ -24,7 +24,6 @@
 package org.eolang.jeo.representation.asm;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.asm.generation.BytecodeClass;
 import org.hamcrest.MatcherAssert;
@@ -86,7 +85,7 @@ class DirectivesMethodTest {
     }
 
     /**
-     * In this test we parse the next java code (but represented as bytecode.)
+     * In this test we parse the next java code (but represented as bytecode).
      *
      * <p>
      *     {@code

--- a/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation.asm;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.asm.generation.BytecodeClass;
 import org.hamcrest.MatcherAssert;
@@ -84,10 +85,31 @@ class DirectivesMethodTest {
         );
     }
 
+    /**
+     * In this test we parse the next java code (but represented as bytecode.)
+     *
+     * <p>
+     *     {@code
+     *
+     *     public class ParamsExample {
+     *       public static void main(String[] args) {
+     *         ParamsExample pe = new ParamsExample();
+     *         pe.printSum(10, 20);
+     *       }
+     *       public void printSum(int a, int b) {
+     *         int sum = a + b;
+     *         System.out.println(sum);
+     *       }
+     *     }
+     *
+     *     }
+     * </p>
+     */
     @Test
-    @Disabled("We have to implement method parameters parsing first")
     void parsesMethodParameters() {
-        Assertions.fail("We have to implement method parameters parsing first");
+        final XML xml = new BytecodeClass("ParametersExample").xml();
+
+        System.out.println(xml);
     }
 
     @Test

--- a/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
@@ -112,7 +112,7 @@ class DirectivesMethodTest {
                 "\n",
                 "Currently we don't save method parameters as separate objects in the XML.",
                 "Method parameters implemented through opcodes.",
-                "I don't know if we need to change this behavior."
+                "I don't know if we need to change this behavior.\n\n"
             ),
             new BytecodeClass("ParametersExample")
                 .withMethod("main", Opcodes.ACC_PUBLIC, Opcodes.ACC_STATIC)
@@ -141,10 +141,10 @@ class DirectivesMethodTest {
                 .xml(),
             Matchers.allOf(
                 XhtmlMatchers.hasXPath(
-                    "/program/objects/o/o[contains(@name,'1__printSum__(II)V')]/o[@name='x_int_1']"
+                    "/program/objects/o/o[contains(@name,'1__printSum__(II)V')]/o[@name='arg__I__0']"
                 ),
                 XhtmlMatchers.hasXPath(
-                    "/program/objects/o/o[contains(@name,'1__printSum__(II)V')]/o[@name='x_int_2']"
+                    "/program/objects/o/o[contains(@name,'1__printSum__(II)V')]/o[@name='arg__I__1']"
                 )
             )
         );


### PR DESCRIPTION
Parse method parameters from bytecode and save them into XMIR.

Closes: #107.
____
History:
- feat(#107): rename MethodDirectives -> DirectivesMethod
- feat(#107): add the test idea
- feat(#107): write bytecode with method invokations together with parameters
- feat(#107): explain in the test what we want to get
- feat(#107): add arguments to the eo method object
- feat(#107): add one more puzzle
- feat(#107): fix all qulice suggestions
- feat(#107): remove the puzzle for the #107 issue


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Renamed `MethodDirectives` class to `DirectivesMethod`.
- Added a todo comment in `DirectivesClass` regarding method argument naming strategy.
- Added new bytecode instructions in `BytecodeInstruction` enum.
- Renamed `MethodDirectivesTest` class to `DirectivesMethodTest`.
- Added a test case for parsing method parameters in `DirectivesMethodTest`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->