### PR TITLE
feat(#91): refactor method names and modifiers

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
@@ -29,7 +29,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Type;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -141,24 +140,10 @@ public final class DirectivesClass extends ClassVisitor implements Iterable<Dire
         if (name.equals("<init>")) {
             result = super.visitMethod(access, name, descriptor, signature, exceptions);
         } else {
-//            DirectivesClass.methodName(access, name, descriptor);
             this.directives.add("o")
                 .attr("abstract", "")
-                .attr("name", name);
-//            if (Type.getMethodType(descriptor).getArgumentTypes().length > 0) {
-//                this.directives.add("o")
-//                    .attr("name", "args")
-//                    .up();
-//            }
-//            final Type[] arguments = Type.getArgumentTypes(descriptor);
-//            for (int index = 0; index < arguments.length; ++index) {
-//                this.directives.add("o")
-//                    .attr("abstract", "")
-//                    .attr("name", String.format("arg__%s__%d", arguments[index], index))
-//                    .up();
-//            }
-            this.directives.append(new DirectivesMethodProperties(access, descriptor, signature, exceptions));
-            this.directives
+                .attr("name", name)
+                .append(new DirectivesMethodProperties(access, descriptor, signature, exceptions))
                 .add("o")
                 .attr("base", "seq")
                 .attr("name", "@");

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
@@ -185,11 +185,6 @@ public final class DirectivesClass extends ClassVisitor implements Iterable<Dire
      * @param name Name.
      * @param descriptor Descriptor.
      * @return Method name.
-     * @todo #108:90min Implement different way to generate method name.
-     *  Right now we use method name, access and descriptor to generate method name
-     *  and insert it as a name attribute of the method. This is not a good way to do it.
-     *  At least it looks ugly. We should find a better way to generate method name and place
-     *  it somewhere in the XML representation of the class.
      */
     private static String methodName(final int access, final String name, final String descriptor) {
         return String.format(

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
@@ -165,20 +165,4 @@ public final class DirectivesClass extends ClassVisitor implements Iterable<Dire
     public Iterator<Directive> iterator() {
         return this.directives.iterator();
     }
-
-    /**
-     * Method name.
-     * @param access Access.
-     * @param name Name.
-     * @param descriptor Descriptor.
-     * @return Method name.
-     */
-    private static String methodName(final int access, final String name, final String descriptor) {
-        return String.format(
-            "%d__%s__%s",
-            access,
-            name,
-            descriptor
-        );
-    }
 }

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
@@ -141,22 +141,8 @@ public final class DirectivesClass extends ClassVisitor implements Iterable<Dire
         if (name.equals("<init>")) {
             result = super.visitMethod(access, name, descriptor, signature, exceptions);
         } else {
-            this.directives.add("o")
-                .attr("abstract", "")
-                .attr("name", DirectivesClass.methodName(access, name, descriptor));
-            if (Type.getMethodType(descriptor).getArgumentTypes().length > 0) {
-                this.directives.add("o")
-                    .attr("name", "args")
-                    .up();
-            }
-            final Type[] arguments = Type.getArgumentTypes(descriptor);
-            for (int index = 0; index < arguments.length; ++index) {
-                this.directives.add("o")
-                    .attr("abstract", "")
-                    .attr("name", String.format("arg__%s__%d", arguments[index], index))
-                    .up();
-            }
             this.directives
+                .append(new DirectivesMethodProperties(access, descriptor, signature, exceptions))
                 .add("o")
                 .attr("base", "seq")
                 .attr("name", "@");

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesClass.java
@@ -141,8 +141,24 @@ public final class DirectivesClass extends ClassVisitor implements Iterable<Dire
         if (name.equals("<init>")) {
             result = super.visitMethod(access, name, descriptor, signature, exceptions);
         } else {
+//            DirectivesClass.methodName(access, name, descriptor);
+            this.directives.add("o")
+                .attr("abstract", "")
+                .attr("name", name);
+//            if (Type.getMethodType(descriptor).getArgumentTypes().length > 0) {
+//                this.directives.add("o")
+//                    .attr("name", "args")
+//                    .up();
+//            }
+//            final Type[] arguments = Type.getArgumentTypes(descriptor);
+//            for (int index = 0; index < arguments.length; ++index) {
+//                this.directives.add("o")
+//                    .attr("abstract", "")
+//                    .attr("name", String.format("arg__%s__%d", arguments[index], index))
+//                    .up();
+//            }
+            this.directives.append(new DirectivesMethodProperties(access, descriptor, signature, exceptions));
             this.directives
-                .append(new DirectivesMethodProperties(access, descriptor, signature, exceptions))
                 .add("o")
                 .attr("base", "seq")
                 .attr("name", "@");

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethod.java
@@ -34,10 +34,6 @@ import org.xembly.Directives;
  * Method printer.
  * ASM method visitor which scans the method and builds Xembly directives.
  * @since 0.1
- * @todo #84:30min Handle method parameters.
- *  Right now we just skip method parameters. We should handle them in order to
- *  build correct XML representation of the class. When the method is ready
- *  remove that puzzle.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class DirectivesMethod extends MethodVisitor implements Iterable<Directive> {

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethodProperties.java
@@ -32,6 +32,10 @@ import org.xembly.Directives;
 /**
  * Method properties as Xembly directives.
  * @since 0.1.0
+ * @todo #91:60min Move all Directives* classes to a separate package.
+ *  Right now they are in the same package as Xml* classes.
+ *  We need to move them to a separate package. It will make it possible to hide
+ *  some classes and probably remove prefixes like Directives*.
  */
 final class DirectivesMethodProperties implements Iterable<Directive> {
 

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethodProperties.java
@@ -1,0 +1,53 @@
+package org.eolang.jeo.representation.asm;
+
+import java.util.Iterator;
+import java.util.Optional;
+import org.xembly.Directive;
+import org.xembly.Directives;
+import org.objectweb.asm.Type;
+
+public class DirectivesMethodProperties implements Iterable<Directive> {
+
+    private final int access;
+    private final String desciptor;
+
+    private final String signature;
+
+    private final String[] interfaces;
+
+    public DirectivesMethodProperties(
+        final int access,
+        final String desciptor,
+        final String signature,
+        final String... interfaces
+    ) {
+        this.access = access;
+        this.desciptor = Optional.ofNullable(desciptor).orElse("");
+        this.signature = Optional.ofNullable(signature).orElse("");
+        this.interfaces = Optional.ofNullable(interfaces).orElse(new String[0]).clone();
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        return new Directives()
+            .append(new DirectivesData(this.access, "access").directives())
+            .append(new DirectivesData(this.desciptor, "descriptor").directives())
+            .append(new DirectivesData(this.signature, "signature").directives())
+//            .append(new DirectivesData(this.interfaces, "interfaces").directives())
+            .append(this.arguments())
+            .iterator();
+    }
+
+    private Directives arguments() {
+        Directives directives = new Directives();
+        final Type[] arguments = Type.getArgumentTypes(this.desciptor);
+        for (int index = 0; index < arguments.length; ++index) {
+            directives.add("o")
+                .attr("abstract", "")
+                .attr("name", String.format("arg__%s__%d", arguments[index], index))
+                .up();
+        }
+        return directives;
+    }
+
+}

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethodProperties.java
@@ -25,15 +25,15 @@ package org.eolang.jeo.representation.asm;
 
 import java.util.Iterator;
 import java.util.Optional;
+import org.objectweb.asm.Type;
 import org.xembly.Directive;
 import org.xembly.Directives;
-import org.objectweb.asm.Type;
 
 /**
  * Method properties as Xembly directives.
  * @since 0.1.0
  */
-public class DirectivesMethodProperties implements Iterable<Directive> {
+final class DirectivesMethodProperties implements Iterable<Directive> {
 
     /**
      * Method access modifiers.
@@ -61,6 +61,7 @@ public class DirectivesMethodProperties implements Iterable<Directive> {
      * @param descriptor Method descriptor.
      * @param signature Method signature.
      * @param exceptions Method exceptions.
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     DirectivesMethodProperties(
         final int access,
@@ -80,7 +81,7 @@ public class DirectivesMethodProperties implements Iterable<Directive> {
             .append(new DirectivesData(this.access, "access").directives())
             .append(new DirectivesData(this.descriptor, "descriptor").directives())
             .append(new DirectivesData(this.signature, "signature").directives())
-            .append(this.exceptions())
+            .append(this.exceptionsDirectives())
             .append(this.arguments())
             .iterator();
     }
@@ -88,8 +89,14 @@ public class DirectivesMethodProperties implements Iterable<Directive> {
     /**
      * Method exceptions.
      * @return Exceptions.
+     * @todo #91:60min Create DirectivesTuple class.
+     *  Replace DirectivesMethodProperties.exceptions() with DirectivesTuple.
+     *  Right now we have the code duplication between two methods:
+     *  - DirectivesMethodProperties.exceptions()
+     *  - DirectivesClassProperties.interfaces()
+     *  We need to create DirectivesTuple class and use it in both methods instead.
      */
-    private Directives exceptions() {
+    private Directives exceptionsDirectives() {
         final Directives tuple = new Directives()
             .add("o")
             .attr("base", "tuple")
@@ -107,7 +114,7 @@ public class DirectivesMethodProperties implements Iterable<Directive> {
      * @return Arguments.
      */
     private Directives arguments() {
-        Directives directives = new Directives();
+        final Directives directives = new Directives();
         final Type[] arguments = Type.getArgumentTypes(this.descriptor);
         for (int index = 0; index < arguments.length; ++index) {
             directives.add("o")

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethodProperties.java
@@ -13,18 +13,18 @@ public class DirectivesMethodProperties implements Iterable<Directive> {
 
     private final String signature;
 
-    private final String[] interfaces;
+    private final String[] exceptions;
 
-    public DirectivesMethodProperties(
+    DirectivesMethodProperties(
         final int access,
         final String desciptor,
         final String signature,
-        final String... interfaces
+        final String... exceptions
     ) {
         this.access = access;
         this.desciptor = Optional.ofNullable(desciptor).orElse("");
         this.signature = Optional.ofNullable(signature).orElse("");
-        this.interfaces = Optional.ofNullable(interfaces).orElse(new String[0]).clone();
+        this.exceptions = Optional.ofNullable(exceptions).orElse(new String[0]).clone();
     }
 
     @Override
@@ -33,9 +33,22 @@ public class DirectivesMethodProperties implements Iterable<Directive> {
             .append(new DirectivesData(this.access, "access").directives())
             .append(new DirectivesData(this.desciptor, "descriptor").directives())
             .append(new DirectivesData(this.signature, "signature").directives())
-//            .append(new DirectivesData(this.interfaces, "interfaces").directives())
+            .append(this.exceptions())
             .append(this.arguments())
             .iterator();
+    }
+
+    private Directives exceptions() {
+        final Directives tuple = new Directives()
+            .add("o")
+            .attr("base", "tuple")
+            .attr("data", "tuple")
+            .attr("name", "exceptions");
+        for (final String exception : this.exceptions) {
+            tuple.append(new DirectivesData(exception).directives());
+        }
+        tuple.up();
+        return tuple;
     }
 
     private Directives arguments() {

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethodProperties.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.asm;
 
 import java.util.Iterator;
@@ -6,23 +29,47 @@ import org.xembly.Directive;
 import org.xembly.Directives;
 import org.objectweb.asm.Type;
 
+/**
+ * Method properties as Xembly directives.
+ * @since 0.1.0
+ */
 public class DirectivesMethodProperties implements Iterable<Directive> {
 
+    /**
+     * Method access modifiers.
+     */
     private final int access;
-    private final String desciptor;
 
+    /**
+     * Method descriptor.
+     */
+    private final String descriptor;
+
+    /**
+     * Method signature.
+     */
     private final String signature;
 
+    /**
+     * Method exceptions.
+     */
     private final String[] exceptions;
 
+    /**
+     * Constructor.
+     * @param access Access modifiers.
+     * @param descriptor Method descriptor.
+     * @param signature Method signature.
+     * @param exceptions Method exceptions.
+     */
     DirectivesMethodProperties(
         final int access,
-        final String desciptor,
+        final String descriptor,
         final String signature,
         final String... exceptions
     ) {
         this.access = access;
-        this.desciptor = Optional.ofNullable(desciptor).orElse("");
+        this.descriptor = Optional.ofNullable(descriptor).orElse("");
         this.signature = Optional.ofNullable(signature).orElse("");
         this.exceptions = Optional.ofNullable(exceptions).orElse(new String[0]).clone();
     }
@@ -31,13 +78,17 @@ public class DirectivesMethodProperties implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new Directives()
             .append(new DirectivesData(this.access, "access").directives())
-            .append(new DirectivesData(this.desciptor, "descriptor").directives())
+            .append(new DirectivesData(this.descriptor, "descriptor").directives())
             .append(new DirectivesData(this.signature, "signature").directives())
             .append(this.exceptions())
             .append(this.arguments())
             .iterator();
     }
 
+    /**
+     * Method exceptions.
+     * @return Exceptions.
+     */
     private Directives exceptions() {
         final Directives tuple = new Directives()
             .add("o")
@@ -51,9 +102,13 @@ public class DirectivesMethodProperties implements Iterable<Directive> {
         return tuple;
     }
 
+    /**
+     * Method arguments.
+     * @return Arguments.
+     */
     private Directives arguments() {
         Directives directives = new Directives();
-        final Type[] arguments = Type.getArgumentTypes(this.desciptor);
+        final Type[] arguments = Type.getArgumentTypes(this.descriptor);
         for (int index = 0; index < arguments.length; ++index) {
             directives.add("o")
                 .attr("abstract", "")
@@ -62,5 +117,4 @@ public class DirectivesMethodProperties implements Iterable<Directive> {
         }
         return directives;
     }
-
 }

--- a/src/main/java/org/eolang/jeo/representation/asm/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/XmlMethod.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.asm;
 
+import com.jcabi.xml.XMLDocument;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -40,22 +41,14 @@ final class XmlMethod {
     /**
      * Method node.
      */
-    private final Node node;
+    private final XMLDocument node;
 
     /**
      * Constructor.
      * @param node Method node.
      */
     XmlMethod(final Node node) {
-        this.node = node;
-    }
-
-    /**
-     * Method access modifiers.
-     * @return Access modifiers.
-     */
-    int access() {
-        return Integer.parseInt(this.nameAttribute()[0]);
+        this.node = new XMLDocument(node);
     }
 
     /**
@@ -63,7 +56,15 @@ final class XmlMethod {
      * @return Name.
      */
     String name() {
-        return String.valueOf(this.nameAttribute()[1]);
+        return String.valueOf(this.node.xpath("./@name").get(0));
+    }
+
+    /**
+     * Method access modifiers.
+     * @return Access modifiers.
+     */
+    int access() {
+        return new HexString(this.node.xpath("./o[@name='access']/text()").get(0)).decodeAsInt();
     }
 
     /**
@@ -71,7 +72,7 @@ final class XmlMethod {
      * @return Descriptor.
      */
     String descriptor() {
-        return String.valueOf(this.nameAttribute()[2]);
+        return new HexString(this.node.xpath("./o[@name='descriptor']/text()").get(0)).decode();
     }
 
     /**
@@ -97,15 +98,6 @@ final class XmlMethod {
         return result;
     }
 
-    /**
-     * Method 'name' attribute.
-     * @return Attribute value.
-     */
-    private String[] nameAttribute() {
-        final Node name = this.node.getAttributes().getNamedItem("name");
-        final String content = name.getTextContent();
-        return content.split("__");
-    }
 
     /**
      * Find sequence node.
@@ -113,7 +105,7 @@ final class XmlMethod {
      */
     private Optional<Node> sequence() {
         Optional<Node> result = Optional.empty();
-        final NodeList children = this.node.getChildNodes();
+        final NodeList children = this.node.node().getChildNodes();
         for (int index = 0; index < children.getLength(); ++index) {
             final Node item = children.item(index);
             final NamedNodeMap attributes = item.getAttributes();

--- a/src/main/java/org/eolang/jeo/representation/asm/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/XmlMethod.java
@@ -98,7 +98,6 @@ final class XmlMethod {
         return result;
     }
 
-
     /**
      * Find sequence node.
      * @return Sequence node.

--- a/src/test/java/org/eolang/jeo/representation/EoRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/EoRepresentationTest.java
@@ -24,7 +24,6 @@
 package org.eolang.jeo.representation;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import com.jcabi.xml.XML;
 import org.eolang.jeo.representation.asm.Bytecode;
 import org.eolang.jeo.representation.asm.generation.BytecodeClass;
 import org.hamcrest.MatcherAssert;

--- a/src/test/java/org/eolang/jeo/representation/EoRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/EoRepresentationTest.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XML;
 import org.eolang.jeo.representation.asm.Bytecode;
 import org.eolang.jeo.representation.asm.generation.BytecodeClass;
 import org.hamcrest.MatcherAssert;

--- a/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
@@ -134,10 +134,14 @@ class DirectivesMethodTest {
                 .up()
                 .xml(),
             Matchers.allOf(
-                XhtmlMatchers.hasXPath(
-                    "/program/objects/o/o[contains(@name,'printSum')]/o[@name='arg__I__0']"
+                XhtmlMatchers.hasXPaths(
+                    "/program/objects/o/o[contains(@name,'printSum')]/o[@name='access']",
+                    "/program/objects/o/o[contains(@name,'printSum')]/o[@name='descriptor']",
+                    "/program/objects/o/o[contains(@name,'printSum')]/o[@name='signature']",
+                    "/program/objects/o/o[contains(@name,'printSum')]/o[@name='exceptions']"
                 ),
-                XhtmlMatchers.hasXPath(
+                XhtmlMatchers.hasXPaths(
+                    "/program/objects/o/o[contains(@name,'printSum')]/o[@name='arg__I__0']",
                     "/program/objects/o/o[contains(@name,'printSum')]/o[@name='arg__I__1']"
                 )
             )

--- a/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/DirectivesMethodTest.java
@@ -135,10 +135,10 @@ class DirectivesMethodTest {
                 .xml(),
             Matchers.allOf(
                 XhtmlMatchers.hasXPath(
-                    "/program/objects/o/o[contains(@name,'1__printSum__(II)V')]/o[@name='arg__I__0']"
+                    "/program/objects/o/o[contains(@name,'printSum')]/o[@name='arg__I__0']"
                 ),
                 XhtmlMatchers.hasXPath(
-                    "/program/objects/o/o[contains(@name,'1__printSum__(II)V')]/o[@name='arg__I__1']"
+                    "/program/objects/o/o[contains(@name,'printSum')]/o[@name='arg__I__1']"
                 )
             )
         );


### PR DESCRIPTION
Create separate data objects for method modifiers in XMIR representation.

Closes: #91
____
History:

- feat(#91): remove outdated puzzle for the #91 issue
- feat(#91): remove the puzzle for method name strategy
- feat(#91): the first implementation of DirectivesMethodProperties
- feat(#91): stabilize all unit tests
- feat(#91): add exceptions to the DirectivesMethodProperties
- feat(#91): add javadocs for DirectivesMethodProperties
- feat(#91): check method metadata in tests
- feat(#91): refactor classes
- feat(#91): add refactoring todo


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on handling method parameters in the DirectivesMethod class. It includes changes to handle method parameters and generate correct XML representation of the class.

### Detailed summary
- Added handling of method parameters in DirectivesMethod class
- Updated XML representation of methods to include method parameters
- Removed unused imports

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->