### PR TITLE
feat(#139): Add DirectivesTuple Class

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesClassProperties.java
@@ -77,12 +77,12 @@ final class DirectivesClassProperties implements Iterable<Directive> {
     @Override
     public Iterator<Directive> iterator() {
         final Directives directives = new Directives()
-            .append(new DirectivesData(this.access, "access").directives());
+            .append(new DirectivesData("access", this.access).directives());
         if (this.signature != null) {
-            directives.append(new DirectivesData(this.signature, "signature").directives());
+            directives.append(new DirectivesData("signature", this.signature).directives());
         }
         if (this.supername != null) {
-            directives.append(new DirectivesData(this.supername, "supername").directives());
+            directives.append(new DirectivesData("supername", this.supername).directives());
         }
         if (this.interfaces != null) {
             directives.append(new DirectivesTuple("interfaces", this.interfaces));

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesClassProperties.java
@@ -85,15 +85,7 @@ final class DirectivesClassProperties implements Iterable<Directive> {
             directives.append(new DirectivesData(this.supername, "supername").directives());
         }
         if (this.interfaces != null) {
-            final Directives tuple = new Directives().add("o")
-                .attr("base", "tuple")
-                .attr("data", "tuple")
-                .attr("name", "interfaces");
-            for (final String interf : this.interfaces) {
-                tuple.append(new DirectivesData(interf).directives());
-            }
-            tuple.up();
-            directives.append(tuple);
+            directives.append(new DirectivesTuple("interfaces", this.interfaces));
         }
         return directives.iterator();
     }

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesData.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesData.java
@@ -50,15 +50,15 @@ final class DirectivesData {
      * @param data Data.
      */
     DirectivesData(final Object data) {
-        this(data, "");
+        this("", data);
     }
 
     /**
      * Constructor.
-     * @param data Data.
      * @param name Name.
+     * @param data Data.
      */
-    DirectivesData(final Object data, final String name) {
+    DirectivesData(final String name, final Object data) {
         this.data = data;
         this.name = name;
     }

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethodProperties.java
@@ -82,9 +82,9 @@ final class DirectivesMethodProperties implements Iterable<Directive> {
     @Override
     public Iterator<Directive> iterator() {
         return new Directives()
-            .append(new DirectivesData(this.access, "access").directives())
-            .append(new DirectivesData(this.descriptor, "descriptor").directives())
-            .append(new DirectivesData(this.signature, "signature").directives())
+            .append(new DirectivesData("access", this.access).directives())
+            .append(new DirectivesData("descriptor", this.descriptor).directives())
+            .append(new DirectivesData("signature", this.signature).directives())
             .append(new DirectivesTuple("exceptions", this.exceptions))
             .append(this.arguments())
             .iterator();

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesMethodProperties.java
@@ -85,32 +85,9 @@ final class DirectivesMethodProperties implements Iterable<Directive> {
             .append(new DirectivesData(this.access, "access").directives())
             .append(new DirectivesData(this.descriptor, "descriptor").directives())
             .append(new DirectivesData(this.signature, "signature").directives())
-            .append(this.exceptionsDirectives())
+            .append(new DirectivesTuple("exceptions", this.exceptions))
             .append(this.arguments())
             .iterator();
-    }
-
-    /**
-     * Method exceptions.
-     * @return Exceptions.
-     * @todo #91:60min Create DirectivesTuple class.
-     *  Replace DirectivesMethodProperties.exceptions() with DirectivesTuple.
-     *  Right now we have the code duplication between two methods:
-     *  - DirectivesMethodProperties.exceptions()
-     *  - DirectivesClassProperties.interfaces()
-     *  We need to create DirectivesTuple class and use it in both methods instead.
-     */
-    private Directives exceptionsDirectives() {
-        final Directives tuple = new Directives()
-            .add("o")
-            .attr("base", "tuple")
-            .attr("data", "tuple")
-            .attr("name", "exceptions");
-        for (final String exception : this.exceptions) {
-            tuple.append(new DirectivesData(exception).directives());
-        }
-        tuple.up();
-        return tuple;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesTuple.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesTuple.java
@@ -32,7 +32,7 @@ import org.xembly.Directives;
  *
  * @since 0.1.0
  */
-public class DirectivesTuple implements Iterable<Directive> {
+final class DirectivesTuple implements Iterable<Directive> {
 
     /**
      * Tuple name.
@@ -49,12 +49,12 @@ public class DirectivesTuple implements Iterable<Directive> {
      * @param name Tuple name.
      * @param values Tuple values.
      */
-    public DirectivesTuple(
+    DirectivesTuple(
         final String name,
-        final String[] values
+        final String... values
     ) {
         this.name = name;
-        this.values = values;
+        this.values = values.clone();
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/asm/DirectivesTuple.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DirectivesTuple.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.asm;
+
+import java.util.Iterator;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+/**
+ * Tuple representation as Xembly directives.
+ *
+ * @since 0.1.0
+ */
+public class DirectivesTuple implements Iterable<Directive> {
+
+    /**
+     * Tuple name.
+     */
+    private final String name;
+
+    /**
+     * Tuple values.
+     */
+    private final String[] values;
+
+    /**
+     * Constructor.
+     * @param name Tuple name.
+     * @param values Tuple values.
+     */
+    public DirectivesTuple(
+        final String name,
+        final String[] values
+    ) {
+        this.name = name;
+        this.values = values;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        final Directives tuple = new Directives()
+            .add("o")
+            .attr("base", "tuple")
+            .attr("data", "tuple")
+            .attr("name", this.name);
+        for (final String exception : this.values) {
+            tuple.append(new DirectivesData(exception).directives());
+        }
+        tuple.up();
+        return tuple.iterator();
+    }
+}


### PR DESCRIPTION
Add DirectivesTuple class that encapsulates the logic of tuple creations (XMIR generation.)

Closes: #139
____
History:
- feat(#139): Add DirectivesTuple class
- feat(#139): Apply DirectivesTuple for all places where it is required
- feat(#139): change DirectivesData constructor parameters order
- feat(#139): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the DirectivesData constructor and introducing the DirectivesTuple class. 

### Detailed summary
- Refactored the DirectivesData constructor to accept the name parameter before the data parameter.
- Introduced the DirectivesTuple class to represent a tuple as Xembly directives.
- Replaced code duplication in the exceptionsDirectives() method with the DirectivesTuple class in the DirectivesMethodProperties class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->