### PR TITLE
feat(#142): Fix Bytecode in Tests

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -148,7 +148,7 @@ public final class BytecodeClass {
         this.methods.forEach(BytecodeMethod::write);
         this.writer.visitEnd();
         final byte[] bytes = this.writer.toByteArray();
-        CheckClassAdapter.verify(new ClassReader(bytes), true, new PrintWriter(System.out));
+        CheckClassAdapter.verify(new ClassReader(bytes), false, new PrintWriter(System.err));
         return new Bytecode(bytes);
     }
 

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -55,8 +55,7 @@ class DirectivesClassTest {
         final DirectivesClass directives = new DirectivesClass();
         new ClassReader(
             new BytecodeClass("WithMethod")
-                .withMethod("main")
-                .up()
+                .helloWorldMethod()
                 .bytecode()
                 .asBytes()
         ).accept(directives, 0);

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -59,6 +59,7 @@ class DirectivesMethodTest {
         new ClassReader(
             new BytecodeClass()
                 .withMethod("main")
+                .descriptor("()I")
                 .instruction(Opcodes.BIPUSH, 28)
                 .instruction(Opcodes.IRETURN)
                 .up()


### PR DESCRIPTION
Fix byecode in tests in order to avoid some problems and redundant printing to stdout.
Closes: #142.
____
History:
- feat(#142): fix invalid bytecode in DirectivesMethodTest
- feat(#142): fix DirectivesClassTest
