### PR TITLE
feat(#106): Add HasClass and HasMethod matchers.

### DIFF
--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -23,11 +23,9 @@
  */
 package org.eolang.jeo.representation.directives;
 
-import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.ClassReader;
 import org.xembly.ImpossibleModificationException;
@@ -53,23 +51,20 @@ class DirectivesClassTest {
     @Test
     void parsesSimpleClassWithMethod() throws ImpossibleModificationException {
         final DirectivesClass directives = new DirectivesClass();
+        final String clazz = "WithMethod";
         new ClassReader(
-            new BytecodeClass("WithMethod")
+            new BytecodeClass(clazz)
                 .helloWorldMethod()
                 .bytecode()
                 .asBytes()
         ).accept(directives, 0);
+        final String xml = new Xembler(directives).xml();
         MatcherAssert.assertThat(
-            "Can't parse simple class with method",
-            new XMLDocument(new Xembler(directives).xml()),
-            Matchers.allOf(
-                XhtmlMatchers.hasXPath(
-                    "/program/objects/o[@name='WithMethod']/o[contains(@name,'main')]"
-                ),
-                XhtmlMatchers.hasXPath(
-                    "/program/objects/o[@name='WithMethod']/o[contains(@name,'main')]/o[@base='seq']"
-                )
-            )
+            String.format("Can't parse simple class with method, result is: '%s'",
+                new XMLDocument(xml)
+            ),
+            xml,
+            new HasMethod("main").inside(clazz)
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -45,8 +45,8 @@ class DirectivesClassTest {
         new ClassReader(new BytecodeClass().bytecode().asBytes()).accept(directives, 0);
         MatcherAssert.assertThat(
             "Can't parse simple class without constructor",
-            new XMLDocument(new Xembler(directives).xml()),
-            XhtmlMatchers.hasXPath("/program/objects/o[@name='Simple']")
+            new Xembler(directives).xml(),
+            new HasClass("Simple")
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -60,7 +60,8 @@ class DirectivesClassTest {
         ).accept(directives, 0);
         final String xml = new Xembler(directives).xml();
         MatcherAssert.assertThat(
-            String.format("Can't parse simple class with method, result is: '%s'",
+            String.format(
+                "Can't parse simple class with method, result is: '%s'",
                 new XMLDocument(xml)
             ),
             xml,

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -45,11 +45,6 @@ import org.xembly.Xembler;
  * {@link org.eolang.jeo.representation.directives.DirectivesClass}.
  *
  * @since 0.1.0
- * @todo #97:60min Add more user-friendly Hamcrest matchers.
- *  Right now, we have tests with complex XPath strings that check
- *  the resulting XML, which are hard to read and understand. I believe
- *  we need to simplify these checks. Perhaps, we should introduce a new
- *  Hamcrest matcher. Once completed, remove this puzzle.
  */
 class DirectivesMethodTest {
 

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -104,50 +104,44 @@ class DirectivesMethodTest {
      */
     @Test
     void parsesMethodParameters() {
+        final String clazz = "ParametersExample";
+        final String method = "printSum";
+        final String xml = new BytecodeClass(clazz)
+            .withMethod("main", Opcodes.ACC_PUBLIC, Opcodes.ACC_STATIC)
+            .descriptor("([Ljava/lang/String;)V")
+            .instruction(Opcodes.NEW, clazz)
+            .instruction(Opcodes.DUP)
+            .instruction(Opcodes.INVOKESPECIAL, clazz, "<init>", "()V")
+            .instruction(Opcodes.ASTORE, 1)
+            .instruction(Opcodes.ALOAD, 1)
+            .instruction(Opcodes.BIPUSH, 10)
+            .instruction(Opcodes.BIPUSH, 20)
+            .instruction(Opcodes.INVOKEVIRTUAL, clazz, method, "(II)V")
+            .instruction(Opcodes.RETURN)
+            .up()
+            .withMethod(method, Opcodes.ACC_PUBLIC)
+            .descriptor("(II)V")
+            .instruction(Opcodes.ILOAD, 1)
+            .instruction(Opcodes.ILOAD, 2)
+            .instruction(Opcodes.IADD)
+            .instruction(Opcodes.ISTORE, 3)
+            .instruction(Opcodes.GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;")
+            .instruction(Opcodes.ILOAD, 3)
+            .instruction(Opcodes.INVOKEVIRTUAL, "java/io/PrintStream", "println", "(I)V")
+            .instruction(Opcodes.RETURN)
+            .up()
+            .xml()
+            .toString();
         MatcherAssert.assertThat(
-            String.join(
-                "\n",
-                "Currently we don't save method parameters as separate objects in the XML.",
-                "Method parameters implemented through opcodes.",
-                "I don't know if we need to change this behavior.\n\n"
+            String.format(
+                "DirectivesMethod doesn't parse method parameters correctly. Please, check the resulting XMIR: \n%s\n",
+                xml
             ),
-            new BytecodeClass("ParametersExample")
-                .withMethod("main", Opcodes.ACC_PUBLIC, Opcodes.ACC_STATIC)
-                .descriptor("([Ljava/lang/String;)V")
-                .instruction(Opcodes.NEW, "ParametersExample")
-                .instruction(Opcodes.DUP)
-                .instruction(Opcodes.INVOKESPECIAL, "ParametersExample", "<init>", "()V")
-                .instruction(Opcodes.ASTORE, 1)
-                .instruction(Opcodes.ALOAD, 1)
-                .instruction(Opcodes.BIPUSH, 10)
-                .instruction(Opcodes.BIPUSH, 20)
-                .instruction(Opcodes.INVOKEVIRTUAL, "ParametersExample", "printSum", "(II)V")
-                .instruction(Opcodes.RETURN)
-                .up()
-                .withMethod("printSum", Opcodes.ACC_PUBLIC)
-                .descriptor("(II)V")
-                .instruction(Opcodes.ILOAD, 1)
-                .instruction(Opcodes.ILOAD, 2)
-                .instruction(Opcodes.IADD)
-                .instruction(Opcodes.ISTORE, 3)
-                .instruction(Opcodes.GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;")
-                .instruction(Opcodes.ILOAD, 3)
-                .instruction(Opcodes.INVOKEVIRTUAL, "java/io/PrintStream", "println", "(I)V")
-                .instruction(Opcodes.RETURN)
-                .up()
-                .xml(),
-            Matchers.allOf(
-                XhtmlMatchers.hasXPaths(
-                    "/program/objects/o/o[contains(@name,'printSum')]/o[@name='access']",
-                    "/program/objects/o/o[contains(@name,'printSum')]/o[@name='descriptor']",
-                    "/program/objects/o/o[contains(@name,'printSum')]/o[@name='signature']",
-                    "/program/objects/o/o[contains(@name,'printSum')]/o[@name='exceptions']"
-                ),
-                XhtmlMatchers.hasXPaths(
-                    "/program/objects/o/o[contains(@name,'printSum')]/o[@name='arg__I__0']",
-                    "/program/objects/o/o[contains(@name,'printSum')]/o[@name='arg__I__1']"
-                )
-            )
+            xml,
+            new HasMethod(method)
+                .inside(clazz)
+                .withParameter("arg__I__0")
+                .withParameter("arg__I__1")
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/directives/HasClass.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasClass.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Matcher to check if the received XMIR document has a class with a given name.
+ * @since 0.1.0
+ */
+final class HasClass extends TypeSafeMatcher<String> {
+
+    /**
+     * Class name.
+     */
+    private final String name;
+
+    /**
+     * Constructor.
+     * @param name Class name.
+     */
+    HasClass(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    protected boolean matchesSafely(final String item) {
+        return !new XMLDocument(item).xpath(
+            String.format("/program/objects/o[@name='%s']/text()", this.name)
+        ).isEmpty();
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        description.appendText("Received XMIR document doesn't have a class with name '")
+            .appendValue(this.name)
+            .appendText("' in it");
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/HasClass.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasClass.java
@@ -47,7 +47,7 @@ final class HasClass extends TypeSafeMatcher<String> {
     }
 
     @Override
-    protected boolean matchesSafely(final String item) {
+    public boolean matchesSafely(final String item) {
         return !new XMLDocument(item).xpath(
             String.format("/program/objects/o[@name='%s']/text()", this.name)
         ).isEmpty();

--- a/src/test/java/org/eolang/jeo/representation/directives/HasClass.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasClass.java
@@ -31,6 +31,7 @@ import org.hamcrest.TypeSafeMatcher;
  * Matcher to check if the received XMIR document has a class with a given name.
  * @since 0.1.0
  */
+@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleCorrectTestName"})
 final class HasClass extends TypeSafeMatcher<String> {
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
@@ -1,0 +1,109 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.xml.XMLDocument;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Matcher to check if the received XMIR document has a method inside a class with a given name.
+ * @since 0.1.0
+ */
+public class HasMethod extends TypeSafeMatcher<String> {
+
+    /**
+     * Class name.
+     */
+    private final String clazz;
+
+    /**
+     * Method name.
+     */
+    private final String method;
+
+    /**
+     * Constructor.
+     * @param method Method name.
+     */
+    HasMethod(final String method) {
+        this("", method);
+    }
+
+    /**
+     * Constructor.
+     * @param clazz Class name.
+     * @param method Method name.
+     */
+    private HasMethod(final String clazz, final String method) {
+        this.clazz = clazz;
+        this.method = method;
+    }
+
+    /**
+     * Inside a class.
+     * @param clazz Class name.
+     * @return New matcher that checks class.
+     */
+    HasMethod inside(final String clazz) {
+        return new HasMethod(clazz, this.method);
+    }
+
+    @Override
+    protected boolean matchesSafely(final String item) {
+        final XMLDocument document = new XMLDocument(item);
+        return this.checks().stream().map(document::xpath).noneMatch(List::isEmpty);
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+        final Description descr = description.appendText(
+            "Received XMIR document doesn't comply with the following XPaths: ");
+        this.checks().forEach(xpath -> descr.appendText("\n").appendText(xpath));
+        descr.appendText("\nPlease, check the received XMIR document.");
+    }
+
+    /**
+     * Checks.
+     * @return List of XPaths to check.
+     */
+    private List<String> checks() {
+        final String main = String.format(
+            "/program/objects/o[@name='%s']/o[@name='%s']",
+            this.clazz,
+            this.method
+        );
+        return Stream.of(
+            main.concat("/text()"),
+            main.concat("/o[@base='seq']/text()"),
+            main.concat("/o[@name='access']/@base"),
+            main.concat("/o[@name='descriptor']/@base"),
+            main.concat("/o[@name='signature']/@base"),
+            main.concat("/o[@name='exceptions']/@base")
+        ).collect(Collectors.toList());
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
@@ -34,7 +34,13 @@ import org.hamcrest.TypeSafeMatcher;
 /**
  * Matcher to check if the received XMIR document has a method inside a class with a given name.
  * @since 0.1.0
+ * @todo #106:30min Implement instructions check.
+ *  The matcher should check if the received XMIR document has a method with a given bytecode
+ *  instructions. When it is done, apply the matcher to the test case in
+ *  {@link org.eolang.jeo.representation.directives.DirectivesMethodTest#parsesMethodInstructions()}
+ *  and don't forget to remove that puzzle.
  */
+@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleCorrectTestName"})
 final class HasMethod extends TypeSafeMatcher<String> {
 
     /**


### PR DESCRIPTION
Add HasClass and HasMethod matchers to check received XMIR documents.

Closes: #106.
____
History:
- feat(#106): Add HasClass Matcher
- feat(#106): add HasMethod matcher
- feat(#106): check method parameters after parsing bytecode into XMIR
- feat(#106): remove the puzzle for 106 issue
- feat(#106): introduce one more puzzle


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the test readability and maintainability by introducing user-friendly Hamcrest matchers. 

### Detailed summary
- Introduced `HasClass` matcher to check if the XMIR document has a class with a given name.
- Introduced `HasMethod` matcher to check if the XMIR document has a method inside a class with a given name.
- Updated test cases in `DirectivesClassTest` and `DirectivesMethodTest` to use the new matchers.

> The following files were skipped due to too many changes: `src/test/java/org/eolang/jeo/representation/directives/HasMethod.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->