### PR TITLE
feat(#147): Check XMIR Instructions in Tests

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/HexData.java
+++ b/src/main/java/org/eolang/jeo/representation/HexData.java
@@ -1,0 +1,59 @@
+package org.eolang.jeo.representation;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.StringJoiner;
+
+public class HexData {
+
+    private final Object data;
+
+    public HexData(final Object data) {
+        this.data = data;
+    }
+
+    /**
+     * Value of the data.
+     * @return Value
+     */
+    public String value() {
+        final byte[] res;
+        if (this.data instanceof String) {
+            res = ((String) this.data).getBytes(StandardCharsets.UTF_8);
+        } else {
+            res = ByteBuffer
+                .allocate(Long.BYTES)
+                .putLong((int) this.data)
+                .array();
+        }
+        return HexData.bytesToHex(res);
+    }
+
+    /**
+     * Type of the data.
+     * @return Type
+     */
+    public String type() {
+        final String res;
+        if (this.data instanceof String) {
+            res = "string";
+        } else {
+            res = "int";
+        }
+        return res;
+    }
+
+    /**
+     * Bytes to HEX.
+     *
+     * @param bytes Bytes.
+     * @return Hexadecimal value as string.
+     */
+    private static String bytesToHex(final byte... bytes) {
+        final StringJoiner out = new StringJoiner(" ");
+        for (final byte bty : bytes) {
+            out.add(String.format("%02X", bty));
+        }
+        return out.toString();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/HexData.java
+++ b/src/main/java/org/eolang/jeo/representation/HexData.java
@@ -1,13 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.StringJoiner;
 
-public class HexData {
+/**
+ * Hexadecimal data.
+ * @since 0.1
+ */
+public final class HexData {
 
+    /**
+     * Data to convert.
+     */
     private final Object data;
 
+    /**
+     * Constructor.
+     * @param data Data.
+     */
     public HexData(final Object data) {
         this.data = data;
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesData.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesData.java
@@ -26,6 +26,7 @@ package org.eolang.jeo.representation.directives;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.StringJoiner;
+import org.eolang.jeo.representation.HexData;
 import org.xembly.Directives;
 
 /**
@@ -68,57 +69,13 @@ final class DirectivesData {
      * @return Directives
      */
     Directives directives() {
+        final HexData hex = new HexData(data);
         final Directives directives = new Directives().add("o")
-            .attr("base", this.type())
+            .attr("base", hex.type())
             .attr("data", "bytes");
         if (!this.name.isEmpty()) {
             directives.attr("name", this.name);
         }
-        return directives.set(this.value()).up();
-    }
-
-    /**
-     * Value of the data.
-     * @return Value
-     */
-    private String value() {
-        final byte[] res;
-        if (this.data instanceof String) {
-            res = ((String) this.data).getBytes(StandardCharsets.UTF_8);
-        } else {
-            res = ByteBuffer
-                .allocate(Long.BYTES)
-                .putLong((int) this.data)
-                .array();
-        }
-        return DirectivesData.bytesToHex(res);
-    }
-
-    /**
-     * Type of the data.
-     * @return Type
-     */
-    private String type() {
-        final String res;
-        if (this.data instanceof String) {
-            res = "string";
-        } else {
-            res = "int";
-        }
-        return res;
-    }
-
-    /**
-     * Bytes to HEX.
-     *
-     * @param bytes Bytes.
-     * @return Hexadecimal value as string.
-     */
-    private static String bytesToHex(final byte... bytes) {
-        final StringJoiner out = new StringJoiner(" ");
-        for (final byte bty : bytes) {
-            out.add(String.format("%02X", bty));
-        }
-        return out.toString();
+        return directives.set(hex.value()).up();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesData.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesData.java
@@ -23,9 +23,6 @@
  */
 package org.eolang.jeo.representation.directives;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.StringJoiner;
 import org.eolang.jeo.representation.HexData;
 import org.xembly.Directives;
 
@@ -69,7 +66,7 @@ final class DirectivesData {
      * @return Directives
      */
     Directives directives() {
-        final HexData hex = new HexData(data);
+        final HexData hex = new HexData(this.data);
         final Directives directives = new Directives().add("o")
             .attr("base", hex.type())
             .attr("data", "bytes");

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -23,16 +23,14 @@
  */
 package org.eolang.jeo.representation.directives;
 
-import com.jcabi.matchers.XhtmlMatchers;
-import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Opcodes;
+import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
 /**
@@ -49,7 +47,7 @@ import org.xembly.Xembler;
 class DirectivesMethodTest {
 
     @Test
-    void parsesMethodInstructions() {
+    void parsesMethodInstructions() throws ImpossibleModificationException {
         final DirectivesClass visitor = new DirectivesClass();
         new ClassReader(
             new BytecodeClass()
@@ -61,19 +59,17 @@ class DirectivesMethodTest {
                 .bytecode()
                 .asBytes()
         ).accept(visitor, 0);
-        final XMLDocument document = new XMLDocument(new Xembler(visitor).xmlQuietly());
+        final String xml = new Xembler(visitor).xml();
         MatcherAssert.assertThat(
-            "Can't find a method in the final XML by using XPath",
-            document,
-            Matchers.allOf(
-                XhtmlMatchers.hasXPath("/program/objects/o/o[contains(@name,'main')]"),
-                XhtmlMatchers.hasXPath(
-                    "/program/objects/o/o[contains(@name,'main')]/o[@base='seq']/o[@base='opcode' and contains(@name,'BIPUSH')]/o[@base='int' and @data='bytes' and text()='00 00 00 00 00 00 00 1C']"
-                ),
-                XhtmlMatchers.hasXPath(
-                    "/program/objects/o/o[contains(@name,'main')]/o[@base='seq']/o[@base='opcode' and contains(@name,'IRETURN')]"
-                )
-            )
+            String.format(
+                "Can't find a method in the final XML by using XPath. Please, check the resulting XMIR: \n%s\n",
+                xml
+            ),
+            xml,
+            new HasMethod("main")
+                .inside("Simple")
+                .withInstruction(Opcodes.BIPUSH, 28)
+                .withInstruction(Opcodes.IRETURN)
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
@@ -35,11 +35,6 @@ import org.hamcrest.TypeSafeMatcher;
 /**
  * Matcher to check if the received XMIR document has a method inside a class with a given name.
  * @since 0.1.0
- * @todo #106:30min Implement instructions check.
- *  The matcher should check if the received XMIR document has a method with a given bytecode
- *  instructions. When it is done, apply the matcher to the test case in
- *  {@link org.eolang.jeo.representation.directives.DirectivesMethodTest#parsesMethodInstructions()}
- *  and don't forget to remove that puzzle.
  */
 @SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleCorrectTestName"})
 final class HasMethod extends TypeSafeMatcher<String> {
@@ -62,7 +57,7 @@ final class HasMethod extends TypeSafeMatcher<String> {
     /**
      * Method instructions.
      */
-    private final List<HasInstruction> instructions;
+    private final List<HasInstruction> instr;
 
     /**
      * Constructor.
@@ -81,7 +76,7 @@ final class HasMethod extends TypeSafeMatcher<String> {
         this.clazz = clazz;
         this.name = method;
         this.params = new ArrayList<>(0);
-        this.instructions = new ArrayList<>(0);
+        this.instr = new ArrayList<>(0);
     }
 
     @Override
@@ -125,7 +120,7 @@ final class HasMethod extends TypeSafeMatcher<String> {
      * @return The same matcher that checks instruction.
      */
     HasMethod withInstruction(final int opcode, final Object... args) {
-        this.instructions.add(new HasInstruction(opcode, args));
+        this.instr.add(new HasInstruction(opcode, args));
         return this;
     }
 
@@ -175,7 +170,7 @@ final class HasMethod extends TypeSafeMatcher<String> {
      */
     private Stream<String> instructions() {
         final String root = this.root();
-        return this.instructions.stream()
+        return this.instr.stream()
             .flatMap(instruction -> instruction.checks(root));
     }
 

--- a/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
@@ -191,20 +191,47 @@ final class HasMethod extends TypeSafeMatcher<String> {
         );
     }
 
+    /**
+     * Instruction checks.
+     *
+     * @since 0.1.0
+     */
     private static final class HasInstruction {
 
+        /**
+         * Opcode.
+         */
         private final int opcode;
+
+        /**
+         * Arguments.
+         */
         private final List<Object> args;
 
+        /**
+         * Constructor.
+         * @param opcode Opcode.
+         * @param args Arguments.
+         */
         HasInstruction(final int opcode, final Object... args) {
             this(opcode, List.of(args));
         }
 
+        /**
+         * Constructor.
+         * @param opcode Opcode.
+         * @param args Arguments.
+         */
         HasInstruction(final int opcode, final List<Object> args) {
             this.opcode = opcode;
             this.args = args;
         }
 
+        /**
+         * Checks of instruction.
+         * @param root Root Method XPath.
+         * @return List of XPaths to check.
+         */
         Stream<String> checks(final String root) {
             final String instruction = String.format(
                 "%s/o[@base='seq']/o[@base='opcode' and contains(@name,'%s')]",
@@ -217,6 +244,11 @@ final class HasMethod extends TypeSafeMatcher<String> {
             );
         }
 
+        /**
+         * Checks of arguments.
+         * @param instruction Root Instruction XPath.
+         * @return List of XPaths to check.
+         */
         private Stream<String> arguments(final String instruction) {
             return this.args.stream()
                 .map(


### PR DESCRIPTION
Check bytecode instructions that were converted into XMIR.
We check the resulting XMIR.

Closes: #147.
____
History:
- feat(#147): Add HexData class
- feat(#147): use HasMethod instead of xpaths
- feat(#147): add javadocs for new classes
- feat(#147): remove the puzzle for 147 issue


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `DirectivesData` class and adding a new `HexData` class. 

### Detailed summary
- Refactored `DirectivesData` class to use `HexData` for data representation.
- Added `HexData` class for converting data to hexadecimal format.
- Updated unit test to reflect changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->