### PR TITLE
feat(#90): Implementation of Constructor Transformation

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -80,7 +80,7 @@ public final class BytecodeClass {
      * @param access Access modifiers.
      */
     public BytecodeClass(final String name, final int access) {
-        this(name.replace(".", "/"), access, new ClassWriter(ClassWriter.COMPUTE_MAXS));
+        this(name.replace(".", "/"), access, new ClassWriter(ClassWriter.COMPUTE_FRAMES));
     }
 
     /**
@@ -91,7 +91,7 @@ public final class BytecodeClass {
     public BytecodeClass(final String name, final BytecodeClassProperties properties) {
         this(
             name.replace(".", "/"),
-            new ClassWriter(ClassWriter.COMPUTE_MAXS),
+            new ClassWriter(ClassWriter.COMPUTE_FRAMES),
             new ArrayList<>(0),
             properties
         );

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -176,7 +176,12 @@ public final class BytecodeClass {
         final String descriptor,
         final int... modifiers
     ) {
-        final BytecodeMethod method = new BytecodeMethod(mname, this.writer, this, modifiers);
+        final BytecodeMethod method = new BytecodeMethod(
+            BytecodeClass.methodName(mname),
+            this.writer,
+            this,
+            modifiers
+        );
         this.methods.add(method.descriptor(descriptor));
         return method;
     }
@@ -198,5 +203,21 @@ public final class BytecodeClass {
             )
             .instruction(Opcodes.RETURN)
             .up();
+    }
+
+    /**
+     * Get method name.
+     * Returns <init> for constructor.
+     * @param raw Raw method name.
+     * @return Method name.
+     */
+    private static String methodName(final String raw) {
+        final String result;
+        if ("new".equals(raw)) {
+            result = "<init>";
+        } else {
+            result = raw;
+        }
+        return result;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -207,7 +207,7 @@ public final class BytecodeClass {
 
     /**
      * Get method name.
-     * Returns <init> for constructor.
+     * Returns "init" for a constructor.
      * @param raw Raw method name.
      * @return Method name.
      */

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -108,8 +108,19 @@ final class BytecodeInstruction {
         /**
          * Load a reference onto the stack from a local variable #index.
          */
-        ALOAD(Opcodes.ALOAD, (visitor, arguments) ->
-            visitor.visitVarInsn(Opcodes.ALOAD, (int) arguments.get(0))
+        ALOAD(Opcodes.ALOAD, (visitor, arguments) -> {
+            final Object argument = arguments.get(0);
+            if (!(argument instanceof Integer)) {
+                throw new IllegalStateException(
+                    String.format(
+                        "Unexpected argument type for ALOAD instruction: %s, value: %s",
+                        argument.getClass().getName(),
+                        argument
+                    )
+                );
+            }
+            visitor.visitVarInsn(Opcodes.ALOAD, (int) argument);
+        }
         ),
 
         /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -134,6 +134,13 @@ final class BytecodeInstruction {
         ),
 
         /**
+         * Discard the top value on the stack.
+         */
+        POP(Opcodes.POP, (visitor, arguments) ->
+            visitor.visitInsn(Opcodes.POP)
+        ),
+
+        /**
          * Duplicate the value on top of the stack.
          */
         DUP(Opcodes.DUP, (visitor, arguments) ->

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -41,10 +41,6 @@ import org.xembly.Directives;
  * - https://www.xembly.org
  * Firther all this directives will be used to build XML representation of the class.
  * @since 0.1
- * @todo #84:30min Handle constructors in classes.
- *  Right now we just skip constructors. We should handle them in order to
- *  build correct XML representation of the class. When the method is ready
- *  remove that puzzle.
  * @todo #107:30min Change method argument naming strategy.
  *  Right now we use method argument type and index to generate method argument name.
  *  For example for method with signature `void foo(int a, String b)` we generate

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -139,7 +139,17 @@ public final class DirectivesClass extends ClassVisitor implements Iterable<Dire
     ) {
         final MethodVisitor result;
         if (name.equals("<init>")) {
-            result = super.visitMethod(access, name, descriptor, signature, exceptions);
+            this.directives.add("o")
+                .attr("abstract", "")
+                .attr("name", "new")
+                .append(new DirectivesMethodProperties(access, descriptor, signature, exceptions))
+                .add("o")
+                .attr("base", "seq")
+                .attr("name", "@");
+            result = new DirectivesMethod(
+                this.directives,
+                super.visitMethod(access, name, descriptor, signature, exceptions)
+            );
         } else {
             this.directives.add("o")
                 .attr("abstract", "")

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.xmir;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -78,7 +79,12 @@ final class XmlInstruction {
         for (int index = 0; index < children.getLength(); ++index) {
             final Node child = children.item(index);
             if (child.getNodeName().equals("o")) {
-                res.add(new HexString(child.getTextContent()).decode());
+                final NamedNodeMap attributes = child.getAttributes();
+                if (attributes.getNamedItem("base").getNodeValue().equals("int")) {
+                    res.add(new HexString(child.getTextContent()).decodeAsInt());
+                } else {
+                    res.add(new HexString(child.getTextContent()).decode());
+                }
             }
         }
         return res.toArray();

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -27,7 +27,6 @@ import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Opcodes;
@@ -156,9 +155,12 @@ class DirectivesMethodTest {
         final String xml = new BytecodeClass("ConstructorExample")
             .withMethod("<init>", Opcodes.ACC_PUBLIC)
             .descriptor("()V")
-            .instruction(Opcodes.LDC, "Hello, constructor!")
+            .instruction(Opcodes.ALOAD, 0)
+            .instruction(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V")
             .instruction(Opcodes.GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;")
-            .instruction(Opcodes.INVOKEVIRTUAL,
+            .instruction(Opcodes.LDC, "Hello, constructor!")
+            .instruction(
+                Opcodes.INVOKEVIRTUAL,
                 "java/io/PrintStream",
                 "println",
                 "(Ljava/lang/String;)V"
@@ -170,6 +172,7 @@ class DirectivesMethodTest {
             .instruction(Opcodes.NEW, "ConstructorExample")
             .instruction(Opcodes.DUP)
             .instruction(Opcodes.INVOKESPECIAL, "ConstructorExample", "<init>", "()V")
+            .instruction(Opcodes.POP)
             .instruction(Opcodes.RETURN)
             .up()
             .xml()

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.directives;
 
+import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
@@ -78,7 +79,6 @@ class DirectivesMethodTest {
      *
      * <p>
      *     {@code
-     *
      *     public class ParamsExample {
      *       public static void main(String[] args) {
      *         ParamsExample pe = new ParamsExample();
@@ -89,7 +89,6 @@ class DirectivesMethodTest {
      *         System.out.println(sum);
      *       }
      *     }
-     *
      *     }
      * </p>
      */
@@ -136,14 +135,86 @@ class DirectivesMethodTest {
         );
     }
 
+    /**
+     * In this test we parse the next java code.
+     *
+     * <p>
+     *     {@code
+     *     public class ConstructorExample {
+     *       public ConstructorExample() {
+     *           System.out.println("Hello, constructor!");
+     *       }
+     *       public static void main(String[] args) {
+     *         new ConstructorExample();
+     *       }
+     *     }
+     *     }
+     * </p>
+     */
     @Test
-    @Disabled("We have to implement constructor parsing first")
     void parsesConstructor() {
-        Assertions.fail("We have to implement constructor parsing first");
+        final String xml = new BytecodeClass("ConstructorExample")
+            .withMethod("<init>", Opcodes.ACC_PUBLIC)
+            .descriptor("()V")
+            .instruction(Opcodes.LDC, "Hello, constructor!")
+            .instruction(Opcodes.GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;")
+            .instruction(Opcodes.INVOKEVIRTUAL,
+                "java/io/PrintStream",
+                "println",
+                "(Ljava/lang/String;)V"
+            )
+            .instruction(Opcodes.RETURN)
+            .up()
+            .withMethod("main", Opcodes.ACC_PUBLIC, Opcodes.ACC_STATIC)
+            .descriptor("([Ljava/lang/String;)V")
+            .instruction(Opcodes.NEW, "ConstructorExample")
+            .instruction(Opcodes.DUP)
+            .instruction(Opcodes.INVOKESPECIAL, "ConstructorExample", "<init>", "()V")
+            .instruction(Opcodes.RETURN)
+            .up()
+            .xml()
+            .toString();
+        MatcherAssert.assertThat(String.format(
+                "Constructor wasn't parsed correctly, please, check the resulting XMIR: \n%s\n",
+                new XMLDocument(xml)
+            ),
+            xml,
+            new HasMethod("new")
+                .inside("ConstructorExample")
+                .withInstruction(Opcodes.LDC, "Hello, constructor!")
+                .withInstruction(
+                    Opcodes.GETSTATIC,
+                    "java/lang/System",
+                    "out",
+                    "Ljava/io/PrintStream;"
+                )
+                .withInstruction(Opcodes.INVOKEVIRTUAL,
+                    "java/io/PrintStream",
+                    "println",
+                    "(Ljava/lang/String;)V"
+                )
+                .withInstruction(Opcodes.RETURN)
+        );
+
     }
 
+    /**
+     * In this test we parse the next java code.
+     *
+     * <p>
+     *     {@code
+     *     public class ConstructorExample {
+     *       public ConstructorExample(int a, int b)
+     *           System.out.println(a + b);
+     *       }
+     *       public static void main(String[] args) {
+     *         new ConstructorExample(11, 22);
+     *       }
+     *     }
+     *     }
+     * </p>
+     */
     @Test
-    @Disabled("We have to implement constructor with parameters parsing first")
     void parsesConstructorWithParameters() {
         Assertions.fail("We have to implement constructor with parameters parsing first");
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -43,6 +43,7 @@ import org.xembly.Xembler;
  *
  * @since 0.1.0
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class DirectivesMethodTest {
 
     @Test
@@ -176,7 +177,8 @@ class DirectivesMethodTest {
             .up()
             .xml()
             .toString();
-        MatcherAssert.assertThat(String.format(
+        MatcherAssert.assertThat(
+            String.format(
                 "Constructor wasn't parsed correctly, please, check the resulting XMIR: \n%s\n",
                 new XMLDocument(xml)
             ),
@@ -185,7 +187,6 @@ class DirectivesMethodTest {
                 .inside("ConstructorExample")
                 .withInstruction(Opcodes.LDC, "Hello, constructor!")
         );
-
     }
 
     /**
@@ -231,7 +232,8 @@ class DirectivesMethodTest {
             .up()
             .xml()
             .toString();
-        MatcherAssert.assertThat(String.format(
+        MatcherAssert.assertThat(
+            String.format(
                 "Constructor wasn't parsed correctly, please, check the resulting XMIR: \n%s\n",
                 new XMLDocument(xml)
             ),


### PR DESCRIPTION
Transform constructors from bytecode to XMIR and back.

Closes: #90.
____
History:
- feat(#90): add first draft of unit tests for constructor parsing
- feat(#90): finish with the first constructor parsing
- feat(#90): add tests for constructor with parameters
- feat(#90): remove puzzle for 90 issue
- feat(#90): add check for ALOAD instruction
- feat(#90): Convert XMIR data into Bytecode correctly
- feat(#90): fix back transformation of a constructor
- feat(#90): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on improving the code diff in several Java files of the project.

### Detailed summary:
- Added import for `org.w3c.dom.NamedNodeMap`
- Modified the `arguments` method in `XmlInstruction` to handle different attributes of the `o` node
- Modified the `ALOAD` instruction in `BytecodeInstruction` to throw an exception if the argument is not an Integer
- Added a new `POP` instruction in `BytecodeInstruction` to discard the top value on the stack
- Modified the `visitMethod` method in `DirectivesClass` to handle constructors and change method argument naming strategy
- Modified the `BytecodeClass` constructor to use `COMPUTE_FRAMES` instead of `COMPUTE_MAXS`
- Added a `methodName` method in `BytecodeClass` to handle constructor method names
- Added tests for parsing constructors and constructors with parameters in `DirectivesMethodTest`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->