### PR TITLE
feat(#153): Refactor XmlField

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.xmir;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -65,7 +66,7 @@ public class XmlField {
      * @return Access modifiers.
      */
     public int access() {
-        return new HexString(this.find("access")).decodeAsInt();
+        return this.find("access").map(HexString::decodeAsInt).orElse(0);
     }
 
     /**
@@ -73,14 +74,7 @@ public class XmlField {
      * @return Descriptor.
      */
     public String descriptor() {
-        final String result;
-        final String descriptor = this.find("descriptor");
-        if (descriptor.isEmpty()) {
-            result = null;
-        } else {
-            result = new HexString(descriptor).decode();
-        }
-        return result;
+        return this.find("descriptor").map(HexString::decode).orElse(null);
     }
 
     /**
@@ -88,14 +82,7 @@ public class XmlField {
      * @return Signature.
      */
     public String signature() {
-        final String result;
-        final String signature = this.find("signature");
-        if (signature.isEmpty()) {
-            result = null;
-        } else {
-            result = new HexString(signature).decode();
-        }
-        return result;
+        return this.find("signature").map(HexString::decode).orElse(null);
     }
 
     /**
@@ -103,14 +90,7 @@ public class XmlField {
      * @return Value.
      */
     public Object value() {
-        final Object result;
-        final String value = this.find("value");
-        if (value.isEmpty()) {
-            result = null;
-        } else {
-            result = new HexString(value).decode();
-        }
-        return result;
+        return this.find("value").map(HexString::decode).orElse(null);
     }
 
     /**
@@ -118,7 +98,7 @@ public class XmlField {
      * @param key Key.
      * @return Text.
      */
-    private String find(final String key) {
+    private Optional<HexString> find(final String key) {
         return this.children()
             .filter(
                 object -> object.getAttributes()
@@ -127,8 +107,9 @@ public class XmlField {
                     .equals(key)
             )
             .findFirst()
-            .orElseThrow(() -> new IllegalStateException(String.format("No such key: %s", key)))
-            .getTextContent();
+            .map(Node::getTextContent)
+            .filter(text -> !text.isEmpty())
+            .map(HexString::new);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -33,10 +33,6 @@ import org.w3c.dom.NodeList;
 /**
  * XML field.
  * @since 0.1
- * @todo #150:30min Refactor XmlField code.
- *  Right now it has many redundant and repeatable code, especially
- *  when we handle default values for signature, descriptor and value.
- *  After refactoring, we should remove that puzzle.
  */
 public class XmlField {
 


### PR DESCRIPTION
Refactor XmlField class.

Closes: #153.
____
History:
- feat(#153): refactor XmlField in order to remove boilerplate code
- feat(#153): remove the puzzle for 153 issue


<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the `XmlField` code to remove redundant and repeatable code for handling default values for signature, descriptor, and value.

### Detailed summary
- Added `import java.util.Optional` and `import java.util.stream.Stream`
- Refactored `access()`, `descriptor()`, `signature()`, and `value()` methods to use `Optional` for handling default values

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->