### PR TITLE
feat(#161): Replace Old Constructor Invocations

### DIFF
--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -213,13 +213,12 @@ public final class ImprovementDistilledObjects implements Improvement {
             final Node dup = new XMLDocument("<o base=\"opcode\" name=\"DUP-89-53\"/>")
                 .node()
                 .getFirstChild();
-            final List<XmlInstruction> list = Arrays.asList(
+            return Arrays.asList(
                 new XmlInstruction(first),
                 new XmlInstruction(dup),
                 new XmlInstruction(second),
                 new XmlInstruction(dup)
             );
-            return list;
         }
 
 
@@ -237,11 +236,10 @@ public final class ImprovementDistilledObjects implements Improvement {
             final Node dup = new XMLDocument("<o base=\"opcode\" name=\"DUP-89-53\"/>")
                 .node()
                 .getFirstChild();
-            final List<XmlInstruction> list = Arrays.asList(
+            return Arrays.asList(
                 new XmlInstruction(second),
                 new XmlInstruction(dup)
             );
-            return list;
         }
 
         /**

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -112,25 +112,60 @@ public final class ImprovementDistilledObjects implements Improvement {
                 final List<XmlInstruction> instructions = method.instructions();
                 final List<XmlInstruction> updated = new ArrayList<>(0);
                 final int size = target.size();
-                for (int i = 0; i < instructions.size(); i += size) {
-                    boolean replace = true;
-                    List<XmlInstruction> window = new ArrayList<>(0);
-                    for (int j = 0; j < size && i + j < instructions.size(); j++) {
-                        final XmlInstruction instruction = instructions.get(i + j);
-                        window.add(instruction);
-                        final XmlInstruction repl = target.get(j);
-                        replace = instruction.equals(repl);
-                    }
-                    if (replace && window.size() == size) {
-                        Logger.info(
-                            ImprovementDistilledObjects.class,
-                            "Constructor inlining happened"
-                        );
-                        updated.addAll(replacement);
-                    } else {
-                        updated.addAll(window);
+                for (int index = 0; index < instructions.size(); index++) {
+                    final List<XmlInstruction> stack = new ArrayList<>(0);
+                    for (
+                        int inner = 0;
+                        inner < size && index < instructions.size();
+                        ++inner
+                    ) {
+                        final XmlInstruction targeted = target.get(inner);
+                        final XmlInstruction current = instructions.get(index);
+                        if (current.equals(targeted)) {
+                            if (inner == size - 1) {
+                                Logger.info(
+                                    ImprovementDistilledObjects.class,
+                                    "Constructor inlining happened"
+                                );
+                                updated.addAll(replacement);
+                                stack.clear();
+                            } else {
+                                stack.add(current);
+                                index++;
+                            }
+                        } else {
+                            updated.addAll(stack);
+                            updated.add(current);
+                            break;
+                        }
                     }
                 }
+
+//
+//                for (int index = 0; index < instructions.size(); index += size) {
+//                    boolean replace = true;
+//                    List<XmlInstruction> window = new ArrayList<>(0);
+//                    for (
+//                        int inner = 0;
+//                        inner < size && index + inner < instructions.size();
+//                        inner++
+//                    ) {
+//                        final XmlInstruction instruction = instructions.get(index + inner);
+//                        window.add(instruction);
+//                        final XmlInstruction repl = target.get(inner);
+//                        replace = instruction.equals(repl);
+//                    }
+//                    if (replace && window.size() == size) {
+//                        Logger.info(
+//                            ImprovementDistilledObjects.class,
+//                            "Constructor inlining happened"
+//                        );
+//                        updated.addAll(replacement);
+//                    } else {
+//                        updated.addAll(window);
+//                    }
+//                }
+
                 method.setInstructions(updated);
             }
         }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -133,6 +133,7 @@ public final class ImprovementDistilledObjects implements Improvement {
                 method.setInstructions(updated);
             }
         }
+
         return new EoRepresentation(xmir);
     }
 

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -93,7 +93,8 @@ public final class ImprovementDistilledObjects implements Improvement {
         );
         return Stream.concat(
             representations.stream()
-                .map(repr -> ImprovementDistilledObjects.replaceConstructors(decorators, repr)),
+                .map(repr -> ImprovementDistilledObjects.replaceConstructors(decorators, repr))
+            ,
             additional.stream()
         ).collect(Collectors.toList());
     }
@@ -206,14 +207,6 @@ public final class ImprovementDistilledObjects implements Improvement {
         }
 
         private List<XmlInstruction> target() {
-//              <o base="opcode" name="NEW-187-50">
-//                  <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 42</o>
-//               </o>
-//               <o base="opcode" name="DUP-89-51"/>
-//               <o base="opcode" name="NEW-187-52">
-//                  <o base="string" data="bytes">6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41</o>
-//               </o>
-//               <o base="opcode" name="DUP-89-53"/>
             final String firstName = this.decorated.name();
             final Node first = new XMLDocument(
                 new StringBuilder()

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -133,7 +133,6 @@ public final class ImprovementDistilledObjects implements Improvement {
                 method.setInstructions(updated);
             }
         }
-
         return new EoRepresentation(xmir);
     }
 

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -56,9 +56,6 @@ import org.w3c.dom.NodeList;
  * You can find the description of the optimization right
  * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/102">here</a>
  * @since 0.1.0
- * @todo #157:90min Replace new B(new A()) with new AB().
- *  Right now we just compose a new object with name AB. But it's not enough.
- *  We have to replace all the old objects created with new B(new A()) with new AB().
  * @todo #157:90min ImprovementDistilledObjects is needed to be refactored.
  *  Right now it's a big class with a lot of methods, repetition and high complexity.
  *  We need to refactor it into a set of smaller classes and remove all

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -133,7 +133,27 @@ public final class ImprovementDistilledObjects implements Improvement {
                 method.setInstructions(updated);
             }
         }
-        return new EoRepresentation(xmir);
+        final Node replacement = clazz.node();
+        final Node program = xmir.node();
+        final NodeList top = program.getChildNodes();
+        for (int index = 0; index < top.getLength(); ++index) {
+            final Node current = top.item(index);
+            if (current.getNodeName().equals("program")) {
+                final NodeList subchildren = current.getChildNodes();
+                for (int indexnext = 0; indexnext < subchildren.getLength(); ++indexnext) {
+                    final Node next = subchildren.item(indexnext);
+                    if (next.getNodeName().equals("objects")) {
+                        while (next.hasChildNodes()) {
+                            next.removeChild(next.getFirstChild());
+                        }
+                        next.appendChild(
+                            next.getOwnerDocument().adoptNode(replacement.cloneNode(true))
+                        );
+                    }
+                }
+            }
+        }
+        return new EoRepresentation(new XMLDocument(program));
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -93,8 +93,7 @@ public final class ImprovementDistilledObjects implements Improvement {
         );
         return Stream.concat(
             representations.stream()
-                .map(repr -> ImprovementDistilledObjects.replaceConstructors(decorators, repr))
-            ,
+                .map(repr -> ImprovementDistilledObjects.replaceConstructors(decorators, repr)),
             additional.stream()
         ).collect(Collectors.toList());
     }
@@ -140,7 +139,9 @@ public final class ImprovementDistilledObjects implements Improvement {
         return new EoRepresentation(new XMLDocument(program));
     }
 
-    private static void replace(final XmlClass clazz, final List<XmlInstruction> target,
+    private static void replace(
+        final XmlClass clazz,
+        final List<XmlInstruction> target,
         final List<XmlInstruction> replacement
     ) {
         for (final XmlMethod method : clazz.methods()) {
@@ -174,6 +175,13 @@ public final class ImprovementDistilledObjects implements Improvement {
                         break;
                     }
                 }
+            }
+            for (final XmlInstruction instruction : method.instructions()) {
+                DecoratorPair.replaceArguments(
+                    instruction.node(),
+                    "org/eolang/jeo/B",
+                    "org/eolang/jeo/AB"
+                );
             }
             method.setInstructions(updated);
         }
@@ -538,7 +546,7 @@ public final class ImprovementDistilledObjects implements Improvement {
          * Replace arguments.
          * @param node Instruction.
          * @param oldname Old class name.
-         * @param bytename New class name.
+         * @param newname New class name.
          * @todo #157:90min Handle arguments correctly during inlining optimization.
          *  Right now we just replace all arguments with the new class name.
          *  It's not correct, because we need to handle arguments correctly.
@@ -546,7 +554,7 @@ public final class ImprovementDistilledObjects implements Improvement {
         private static void replaceArguments(
             final Node node,
             final String oldname,
-            final String bytename
+            final String newname
         ) {
             final NodeList children = node.getChildNodes();
             for (int index = 0; index < children.getLength(); ++index) {
@@ -555,7 +563,7 @@ public final class ImprovementDistilledObjects implements Improvement {
                     final String old = new HexData(oldname).value();
                     final String content = child.getTextContent();
                     if (old.equals(content)) {
-                        child.setTextContent(new HexData(bytename).value());
+                        child.setTextContent(new HexData(newname).value());
                     }
                 }
             }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -121,6 +121,10 @@ public final class ImprovementDistilledObjects implements Improvement {
                         replace = instruction.equals(repl);
                     }
                     if (replace && window.size() == size) {
+                        Logger.info(
+                            ImprovementDistilledObjects.class,
+                            "Constructor inlining happened"
+                        );
                         updated.addAll(replacement);
                     } else {
                         updated.addAll(window);
@@ -195,7 +199,7 @@ public final class ImprovementDistilledObjects implements Improvement {
                 new StringBuilder()
                     .append("<o base=\"opcode\" name=\"NEW-187-50\">")
                     .append("<o base=\"string\" data=\"bytes\">")
-                    .append(firstName)
+                    .append(new HexData(firstName.replace('.', '/')).value())
                     .append("</o>")
                     .append("</o>")
                     .toString()
@@ -205,7 +209,7 @@ public final class ImprovementDistilledObjects implements Improvement {
                 new StringBuilder()
                     .append("<o base=\"opcode\" name=\"NEW-187-50\">")
                     .append("<o base=\"string\" data=\"bytes\">")
-                    .append(secondName)
+                    .append(new HexData(secondName.replace('.', '/')).value())
                     .append("</o>")
                     .append("</o>")
                     .toString()
@@ -214,9 +218,9 @@ public final class ImprovementDistilledObjects implements Improvement {
                 .node()
                 .getFirstChild();
             return Arrays.asList(
-                new XmlInstruction(first),
-                new XmlInstruction(dup),
                 new XmlInstruction(second),
+                new XmlInstruction(dup),
+                new XmlInstruction(first),
                 new XmlInstruction(dup)
             );
         }
@@ -228,7 +232,7 @@ public final class ImprovementDistilledObjects implements Improvement {
                 new StringBuilder()
                     .append("<o base=\"opcode\" name=\"NEW-187-50\">")
                     .append("<o base=\"string\" data=\"bytes\">")
-                    .append(newname)
+                    .append(new HexData(newname.replace('.', '/')).value())
                     .append("</o>")
                     .append("</o>")
                     .toString()

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -98,6 +98,16 @@ public final class ImprovementDistilledObjects implements Improvement {
         ).collect(Collectors.toList());
     }
 
+    /**
+     * Replace constructor invocations.
+     * @param decorators Decorators.
+     * @param representation Representation.
+     * @return Representation with replaced constructors.
+     * @todo #161:90min Refactor replaceConstructors method.
+     *  Right now it's a big method with a lot of repetition and high complexity.
+     *  We have to simplify it and remove all linter warnings.
+     * @checkstyle NestedIfDepthCheck (200 lines)
+     */
     private static Representation replaceConstructors(
         final List<DecoratorPair> decorators,
         final Representation representation
@@ -139,6 +149,17 @@ public final class ImprovementDistilledObjects implements Improvement {
         return new EoRepresentation(new XMLDocument(program));
     }
 
+    /**
+     * Replace instructions.
+     * @param clazz Class where to replace.
+     * @param target What should be replaced.
+     * @param replacement Replacement.
+     * @todo #161:90min Refactor replace method.
+     *  Right now it's a big method with a lot of repetition and high complexity.
+     *  Moreover, some constants are hardcoded and it's not good.
+     *  We need to refactor it into a set of smaller methods and remove all linter warnings.
+     * @checkstyle ModifiedControlVariableCheck (200 lines)
+     */
     private static void replace(
         final XmlClass clazz,
         final List<XmlInstruction> target,
@@ -148,7 +169,7 @@ public final class ImprovementDistilledObjects implements Improvement {
             final List<XmlInstruction> instructions = method.instructions();
             final List<XmlInstruction> updated = new ArrayList<>(0);
             final int size = target.size();
-            for (int index = 0; index < instructions.size(); index++) {
+            for (int index = 0; index < instructions.size(); ++index) {
                 final List<XmlInstruction> stack = new ArrayList<>(0);
                 for (
                     int inner = 0;
@@ -167,7 +188,7 @@ public final class ImprovementDistilledObjects implements Improvement {
                             stack.clear();
                         } else {
                             stack.add(current);
-                            index++;
+                            ++index;
                         }
                     } else {
                         updated.addAll(stack);
@@ -236,23 +257,27 @@ public final class ImprovementDistilledObjects implements Improvement {
             this.decorator = decorator;
         }
 
+        /**
+         * List of NEW instructions that should be replaced.
+         * @return List of NEW instructions.
+         */
         private List<XmlInstruction> targetNew() {
-            final String firstName = this.decorated.name();
+            final String firstname = this.decorated.name();
             final Node first = new XMLDocument(
                 new StringBuilder()
                     .append("<o base=\"opcode\" name=\"NEW-187-50\">")
                     .append("<o base=\"string\" data=\"bytes\">")
-                    .append(new HexData(firstName.replace('.', '/')).value())
+                    .append(new HexData(firstname.replace('.', '/')).value())
                     .append("</o>")
                     .append("</o>")
                     .toString()
             ).node().getFirstChild();
-            final String secondName = this.decorator.name();
+            final String secondname = this.decorator.name();
             final Node second = new XMLDocument(
                 new StringBuilder()
                     .append("<o base=\"opcode\" name=\"NEW-187-50\">")
                     .append("<o base=\"string\" data=\"bytes\">")
-                    .append(new HexData(secondName.replace('.', '/')).value())
+                    .append(new HexData(secondname.replace('.', '/')).value())
                     .append("</o>")
                     .append("</o>")
                     .toString()
@@ -268,7 +293,10 @@ public final class ImprovementDistilledObjects implements Improvement {
             );
         }
 
-
+        /**
+         * Replacement for NEW instruction.
+         * @return Replacement.
+         */
         private List<XmlInstruction> replacementNew() {
             final String newname = this.newname();
             final Node second = new XMLDocument(
@@ -289,7 +317,11 @@ public final class ImprovementDistilledObjects implements Improvement {
             );
         }
 
-        List<XmlInstruction> targetSpecial() {
+        /**
+         * List of INVOKESPECIAL instructions that should be replaced.
+         * @return List of INVOKESPECIAL instructions.
+         */
+        private List<XmlInstruction> targetSpecial() {
             return Arrays.asList(
                 new XmlInstruction(
                     new XMLDocument(
@@ -328,7 +360,11 @@ public final class ImprovementDistilledObjects implements Improvement {
             );
         }
 
-        List<XmlInstruction> replacementSpecial() {
+        /**
+         * Replacement for INVOKESPECIAL instruction.
+         * @return Replacement.
+         */
+        private List<XmlInstruction> replacementSpecial() {
             return Collections.singletonList(
                 new XmlInstruction(
                     new XMLDocument(
@@ -349,7 +385,6 @@ public final class ImprovementDistilledObjects implements Improvement {
                 )
             );
         }
-
 
         /**
          * Combine two representations into one.
@@ -573,6 +608,11 @@ public final class ImprovementDistilledObjects implements Improvement {
          * Set instructions.
          * @param method Method.
          * @param res Instructions.
+         * @todo #161:90min Move setInstructions method.
+         *  Right now we implemented this method inside ImprovementDistilledObjects class.
+         *  But it's better to move it into a XmlMethod class. Moreover, this method is
+         *  overcomplicated, so it makes sense to refactor it and remove all linter warnings.
+         * @checkstyle NestedIfDepthCheck (100 lines)
          */
         private static void setInstructions(final Node method, final List<XmlInstruction> res) {
             final NodeList children = method.getChildNodes();

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -26,8 +26,6 @@ package org.eolang.jeo.improvement;
 import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
-import java.io.IOException;
-import java.io.StringReader;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -37,12 +35,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import java.util.WeakHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import org.eolang.jeo.Improvement;
 import org.eolang.jeo.Representation;
 import org.eolang.jeo.representation.EoRepresentation;
@@ -56,8 +50,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 
 /**
  * Distilled objects improvement.
@@ -218,61 +210,38 @@ public final class ImprovementDistilledObjects implements Improvement {
                     .append("</o>")
                     .toString()
             ).node().getFirstChild();
-            final Node dup = new XMLDocument("<o base=\"opcode\" name=\"DUP-89-53\"/>").node();
-            return Arrays.asList(
+            final Node dup = new XMLDocument("<o base=\"opcode\" name=\"DUP-89-53\"/>")
+                .node()
+                .getFirstChild();
+            final List<XmlInstruction> list = Arrays.asList(
                 new XmlInstruction(first),
                 new XmlInstruction(dup),
                 new XmlInstruction(second),
                 new XmlInstruction(dup)
             );
-        }
-
-        DocumentBuilder builder;
-
-        {
-            try {
-                builder = DocumentBuilderFactory.newDefaultInstance().newDocumentBuilder();
-            } catch (ParserConfigurationException ex) {
-                throw new RuntimeException(ex);
-            }
+            return list;
         }
 
 
         private List<XmlInstruction> replacement() {
             final String newname = this.newname();
-            final Node second;
-            try {
-                second = this.builder.parse(
-                    new InputSource(
-                        new StringReader(
-                            new StringBuilder()
-                                .append("<o base=\"opcode\" name=\"NEW-187-50\">")
-                                .append("<o base=\"string\" data=\"bytes\">")
-                                .append(newname)
-                                .append("</o>")
-                                .append("</o>")
-                                .toString()
-                        )
-                    )
-                );
-            } catch (SAXException ex) {
-                throw new RuntimeException(ex);
-            } catch (IOException ex) {
-                throw new RuntimeException(ex);
-            }
-            final Node dup;
-            try {
-                dup = this.builder.parse(
-                    new InputSource(new StringReader("<o base=\"opcode\" name=\"DUP-89-53\"/>")));
-            } catch (SAXException ex) {
-                throw new RuntimeException(ex);
-            } catch (IOException ex) {
-                throw new RuntimeException(ex);
-            }
-            return Arrays.asList(
+            final Node second = new XMLDocument(
+                new StringBuilder()
+                    .append("<o base=\"opcode\" name=\"NEW-187-50\">")
+                    .append("<o base=\"string\" data=\"bytes\">")
+                    .append(newname)
+                    .append("</o>")
+                    .append("</o>")
+                    .toString()
+            ).node().getFirstChild();
+            final Node dup = new XMLDocument("<o base=\"opcode\" name=\"DUP-89-53\"/>")
+                .node()
+                .getFirstChild();
+            final List<XmlInstruction> list = Arrays.asList(
                 new XmlInstruction(second),
                 new XmlInstruction(dup)
             );
+            return list;
         }
 
         /**

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -282,61 +282,62 @@ public final class ImprovementDistilledObjects implements Improvement {
         }
 
         List<XmlInstruction> targetSpecial() {
-            final String firstName = this.decorated.name();
-            final Node first = new XMLDocument(
-                new StringBuilder()
-                    .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">")
-                    .append("<o base=\"string\" data=\"bytes\">")
-                    .append(new HexData(firstName.replace('.', '/')).value())
-                    .append("</o>")
-                    .append("<o base=\"string\" data=\"bytes\">")
-                    .append(new HexData("<init>").value())
-                    .append("</o>")
-                    .append("<o base=\"string\" data=\"bytes\">")
-                    .append(new HexData("(I)V").value())
-                    .append("</o>")
-                    .append("</o>")
-                    .toString()
-            ).node().getFirstChild();
-            final String secondName = this.decorator.name();
-            final Node second = new XMLDocument(
-                new StringBuilder()
-                    .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">")
-                    .append("<o base=\"string\" data=\"bytes\">")
-                    .append(new HexData(secondName.replace('.', '/')).value())
-                    .append("</o>")
-                    .append("<o base=\"string\" data=\"bytes\">")
-                    .append(new HexData("<init>").value())
-                    .append("</o>")
-                    .append("<o base=\"string\" data=\"bytes\">")
-                    .append(new HexData("(Lorg/eolang/jeo/A;)V").value())
-                    .append("</o>")
-                    .append("</o>")
-                    .toString()
-            ).node().getFirstChild();
             return Arrays.asList(
-                new XmlInstruction(first),
-                new XmlInstruction(second)
+                new XmlInstruction(
+                    new XMLDocument(
+                        new StringBuilder()
+                            .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">")
+                            .append("<o base=\"string\" data=\"bytes\">")
+                            .append(new HexData(this.decorated.name().replace('.', '/')).value())
+                            .append("</o>")
+                            .append("<o base=\"string\" data=\"bytes\">")
+                            .append(new HexData("<init>").value())
+                            .append("</o>")
+                            .append("<o base=\"string\" data=\"bytes\">")
+                            .append(new HexData("(I)V").value())
+                            .append("</o>")
+                            .append("</o>")
+                            .toString()
+                    ).node().getFirstChild()
+                ),
+                new XmlInstruction(
+                    new XMLDocument(
+                        new StringBuilder()
+                            .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">")
+                            .append("<o base=\"string\" data=\"bytes\">")
+                            .append(new HexData(this.decorator.name().replace('.', '/')).value())
+                            .append("</o>")
+                            .append("<o base=\"string\" data=\"bytes\">")
+                            .append(new HexData("<init>").value())
+                            .append("</o>")
+                            .append("<o base=\"string\" data=\"bytes\">")
+                            .append(new HexData("(Lorg/eolang/jeo/A;)V").value())
+                            .append("</o>")
+                            .append("</o>")
+                            .toString()
+                    ).node().getFirstChild()
+                )
             );
         }
 
         List<XmlInstruction> replacementSpecial() {
             return Collections.singletonList(
-                new XmlInstruction(new XMLDocument(
-                    new StringBuilder()
-                        .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">")
-                        .append("<o base=\"string\" data=\"bytes\">")
-                        .append(new HexData(this.newname().replace('.', '/')).value())
-                        .append("</o>")
-                        .append("<o base=\"string\" data=\"bytes\">")
-                        .append(new HexData("<init>").value())
-                        .append("</o>")
-                        .append("<o base=\"string\" data=\"bytes\">")
-                        .append(new HexData("(I)V").value())
-                        .append("</o>")
-                        .append("</o>")
-                        .toString()
-                ).node().getFirstChild()
+                new XmlInstruction(
+                    new XMLDocument(
+                        new StringBuilder()
+                            .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">")
+                            .append("<o base=\"string\" data=\"bytes\">")
+                            .append(new HexData(this.newname().replace('.', '/')).value())
+                            .append("</o>")
+                            .append("<o base=\"string\" data=\"bytes\">")
+                            .append(new HexData("<init>").value())
+                            .append("</o>")
+                            .append("<o base=\"string\" data=\"bytes\">")
+                            .append(new HexData("(I)V").value())
+                            .append("</o>")
+                            .append("</o>")
+                            .toString()
+                    ).node().getFirstChild()
                 )
             );
         }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -83,6 +83,14 @@ public final class XmlClass {
     }
 
     /**
+     * Internal XML node.
+     * @return Internal XML node.
+     */
+    public Node node() {
+        return this.node;
+    }
+
+    /**
      * Class name.
      * @return Name.
      */

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -41,6 +41,7 @@ public final class XmlClass {
     /**
      * Class node from entire XML.
      */
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     private final Node node;
 
     /**
@@ -85,7 +86,12 @@ public final class XmlClass {
     /**
      * Internal XML node.
      * @return Internal XML node.
+     * @todo #161:30min Hide internal node representation in XmlClass.
+     *  This class should not expose internal node representation.
+     *  We have to consider to add methods or classes in order to avoid
+     *  exposing internal node representation.
      */
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     public Node node() {
         return this.node;
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import com.jcabi.log.Logger;
 import com.jcabi.xml.XMLDocument;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -107,39 +108,52 @@ public final class XmlInstruction {
     }
 
     private boolean nodesAreEqual(Node first, Node second) {
+        boolean result = true;
         if (first.getNodeType() != second.getNodeType()) {
-            return false;
-        }
-        if (!first.getNodeName().equals(second.getNodeName())) {
-            return false;
-        }
-        if (!first.getTextContent().trim().equals(second.getTextContent().trim())) {
-            return false;
-        }
-        if (first.getAttributes().getLength() != second.getAttributes().getLength()) {
-            return false;
-        }
-        for (int i = 0; i < first.getAttributes().getLength(); i++) {
-            Node attr1 = first.getAttributes().item(i);
-            Node attr2 = second.getAttributes().getNamedItem(attr1.getNodeName());
-            if (attr1.getNodeName().equals("name")) {
-                continue;
+            result = false;
+        } else if (!first.getNodeName().equals(second.getNodeName())) {
+            result = false;
+        } else if (!first.getTextContent().trim().equals(second.getTextContent().trim())) {
+            result = false;
+        } else if (first.getAttributes().getLength() != second.getAttributes().getLength()) {
+            result = false;
+        } else {
+            for (int i = 0; i < first.getAttributes().getLength(); i++) {
+                Node attr1 = first.getAttributes().item(i);
+                Node attr2 = second.getAttributes().getNamedItem(attr1.getNodeName());
+                if (attr1.getNodeName().equals("name")) {
+                    continue;
+                }
+                if (attr2 == null || !attr1.getNodeValue().equals(attr2.getNodeValue())) {
+                    result = false;
+                    break;
+                }
             }
-            if (attr2 == null || !attr1.getNodeValue().equals(attr2.getNodeValue())) {
-                return false;
+            if (result) {
+                NodeList firstChildren = first.getChildNodes();
+                NodeList secondChildren = second.getChildNodes();
+                if (firstChildren.getLength() != secondChildren.getLength()) {
+                    result = false;
+                } else {
+                    for (int i = 0; i < firstChildren.getLength(); i++) {
+                        if (!this.nodesAreEqual(firstChildren.item(i), secondChildren.item(i))) {
+                            result = false;
+                            break;
+                        }
+                    }
+                }
             }
         }
-        NodeList firstChildren = first.getChildNodes();
-        NodeList secondChildren = second.getChildNodes();
-        if (firstChildren.getLength() != secondChildren.getLength()) {
-            return false;
-        }
-        for (int i = 0; i < firstChildren.getLength(); i++) {
-            if (!this.nodesAreEqual(firstChildren.item(i), secondChildren.item(i))) {
-                return false;
-            }
-        }
-        return true;
+        Logger.info(
+            this,
+            String.format(
+                "COMPARE %n%s%n VS %n%s%n RESULT: %s",
+                new XMLDocument(first),
+                new XMLDocument(second),
+                result
+            )
+        );
+        return result;
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import com.jcabi.log.Logger;
 import com.jcabi.xml.XMLDocument;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -86,6 +85,30 @@ public final class XmlInstruction {
         return this.node;
     }
 
+    @Override
+    public boolean equals(final Object other) {
+        final boolean result;
+        if (this == other) {
+            result = true;
+        } else if (other == null || this.getClass() != other.getClass()) {
+            result = false;
+        } else {
+            final XmlInstruction that = (XmlInstruction) other;
+            result = this.nodesAreEqual(this.node, that.node);
+        }
+        return result;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.node);
+    }
+
+    @Override
+    public String toString() {
+        return new XMLDocument(this.node).toString();
+    }
+
     /**
      * Get opcode arguments.
      * @param node Node.
@@ -108,21 +131,53 @@ public final class XmlInstruction {
         return res.toArray();
     }
 
-    private boolean nodesAreEqual(Node first, Node second) {
+    /**
+     * Get children nodes.
+     * @param root Root node.
+     * @return Children nodes.
+     */
+    private static List<Node> children(final Node root) {
+        final NodeList all = root.getChildNodes();
+        final List<Node> res = new ArrayList<>(0);
+        for (int index = 0; index < all.getLength(); ++index) {
+            final Node item = all.item(index);
+            if (item.getNodeType() == Node.ELEMENT_NODE) {
+                res.add(item);
+            }
+        }
+        return res;
+    }
+
+    /**
+     * Check if two nodes are equal.
+     * @param first First node.
+     * @param second Second node.
+     * @return True if nodes are equal.
+     * @todo #161:60min Refactor XmlInstruction#nodesAreEqual() method.
+     *  This method is too complex and it is hard to understand.
+     *  We have to refactor this method in order to make it more readable.
+     *  Don't forget to write test and remove suppressed checks.
+     * @checkstyle LocalFinalVariableNameCheck (100 lines)
+     * @checkstyle NestedIfDepthCheck (100 lines)
+     * @checkstyle CyclomaticComplexityCheck (100 lines)
+     * @checkstyle LocalVariableNameCheck (100 lines)
+     */
+    @SuppressWarnings({"PMD.ConfusingTernary", "PMD.CollapsibleIfStatements"})
+    private boolean nodesAreEqual(final Node first, final Node second) {
         boolean result = true;
         if (first.getNodeType() != second.getNodeType()) {
             result = false;
         } else if (!first.getNodeName().equals(second.getNodeName())) {
             result = false;
-        } else if (first.getNodeType() == Node.TEXT_NODE && !first.getTextContent().trim().equals(
-            second.getTextContent().trim())) {
+        } else if (first.getNodeType() == Node.TEXT_NODE && !first.getTextContent()
+            .trim().equals(second.getTextContent().trim())) {
             result = false;
         } else if (first.getAttributes().getLength() != second.getAttributes().getLength()) {
             result = false;
         } else {
-            for (int i = 0; i < first.getAttributes().getLength(); i++) {
-                Node attr1 = first.getAttributes().item(i);
-                Node attr2 = second.getAttributes().getNamedItem(attr1.getNodeName());
+            for (int index = 0; index < first.getAttributes().getLength(); ++index) {
+                final Node attr1 = first.getAttributes().item(index);
+                final Node attr2 = second.getAttributes().getNamedItem(attr1.getNodeName());
                 if (attr1.getNodeName().equals("name")) {
                     if (attr1.getNodeValue().split("-")[0]
                         .equals(attr2.getNodeValue().split("-")[0])) {
@@ -135,13 +190,13 @@ public final class XmlInstruction {
                 }
             }
             if (result) {
-                final List<Node> firstChildren = XmlInstruction.children(first);
-                final List<Node> secondChildren = XmlInstruction.children(second);
-                if (firstChildren.size() != secondChildren.size()) {
+                final List<Node> firstchildren = XmlInstruction.children(first);
+                final List<Node> secondchildren = XmlInstruction.children(second);
+                if (firstchildren.size() != secondchildren.size()) {
                     result = false;
                 } else {
-                    for (int i = 0; i < firstChildren.size(); i++) {
-                        if (!this.nodesAreEqual(firstChildren.get(i), secondChildren.get(i))) {
+                    for (int i = 0; i < firstchildren.size(); ++i) {
+                        if (!this.nodesAreEqual(firstchildren.get(i), secondchildren.get(i))) {
                             result = false;
                             break;
                         }
@@ -149,49 +204,6 @@ public final class XmlInstruction {
                 }
             }
         }
-        Logger.info(
-            this,
-            String.format(
-                "COMPARE %n%s%n VS %n%s%n RESULT: %s",
-                new XMLDocument(first),
-                new XMLDocument(second),
-                result
-            )
-        );
         return result;
-    }
-
-    private static List<Node> children(final Node root) {
-        final NodeList all = root.getChildNodes();
-        final List<Node> res = new ArrayList<>();
-        for (int index = 0; index < all.getLength(); ++index) {
-            final Node item = all.item(index);
-            if (item.getNodeType() == Node.ELEMENT_NODE) {
-                res.add(item);
-            }
-        }
-        return res;
-    }
-
-    @Override
-    public boolean equals(final Object other) {
-        if (this == other) {
-            return true;
-        }
-        if (other == null || this.getClass() != other.getClass()) {
-            return false;
-        }
-        final XmlInstruction that = (XmlInstruction) other;
-        return this.nodesAreEqual(this.node, that.node);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.node);
-    }
-
-    @Override
-    public String toString() {
-        return new XMLDocument(this.node).toString();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -114,7 +114,8 @@ public final class XmlInstruction {
             result = false;
         } else if (!first.getNodeName().equals(second.getNodeName())) {
             result = false;
-        } else if (!first.getTextContent().trim().equals(second.getTextContent().trim())) {
+        } else if (first.getNodeType() == Node.TEXT_NODE && !first.getTextContent().trim().equals(
+            second.getTextContent().trim())) {
             result = false;
         } else if (first.getAttributes().getLength() != second.getAttributes().getLength()) {
             result = false;

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -122,7 +122,10 @@ public final class XmlInstruction {
                 Node attr1 = first.getAttributes().item(i);
                 Node attr2 = second.getAttributes().getNamedItem(attr1.getNodeName());
                 if (attr1.getNodeName().equals("name")) {
-                    continue;
+                    if (attr1.getNodeValue().split("-")[0]
+                        .equals(attr2.getNodeValue().split("-")[0])) {
+                        continue;
+                    }
                 }
                 if (attr2 == null || !attr1.getNodeValue().equals(attr2.getNodeValue())) {
                     result = false;

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -27,6 +27,7 @@ import com.jcabi.log.Logger;
 import com.jcabi.xml.XMLDocument;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -133,13 +134,13 @@ public final class XmlInstruction {
                 }
             }
             if (result) {
-                NodeList firstChildren = first.getChildNodes();
-                NodeList secondChildren = second.getChildNodes();
-                if (firstChildren.getLength() != secondChildren.getLength()) {
+                final List<Node> firstChildren = XmlInstruction.children(first);
+                final List<Node> secondChildren = XmlInstruction.children(second);
+                if (firstChildren.size() != secondChildren.size()) {
                     result = false;
                 } else {
-                    for (int i = 0; i < firstChildren.getLength(); i++) {
-                        if (!this.nodesAreEqual(firstChildren.item(i), secondChildren.item(i))) {
+                    for (int i = 0; i < firstChildren.size(); i++) {
+                        if (!this.nodesAreEqual(firstChildren.get(i), secondChildren.get(i))) {
                             result = false;
                             break;
                         }
@@ -157,6 +158,18 @@ public final class XmlInstruction {
             )
         );
         return result;
+    }
+
+    private static List<Node> children(final Node root) {
+        final NodeList all = root.getChildNodes();
+        final List<Node> res = new ArrayList<>();
+        for (int index = 0; index < all.getLength(); ++index) {
+            final Node item = all.item(index);
+            if (item.getNodeType() == Node.ELEMENT_NODE) {
+                res.add(item);
+            }
+        }
+        return res;
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -23,8 +23,10 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import com.jcabi.xml.XMLDocument;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -102,5 +104,63 @@ public final class XmlInstruction {
             }
         }
         return res.toArray();
+    }
+
+    private boolean nodesAreEqual(Node first, Node second) {
+        if (first.getNodeType() != second.getNodeType()) {
+            return false;
+        }
+        if (!first.getNodeName().equals(second.getNodeName())) {
+            return false;
+        }
+        if (!first.getTextContent().trim().equals(second.getTextContent().trim())) {
+            return false;
+        }
+        if (first.getAttributes().getLength() != second.getAttributes().getLength()) {
+            return false;
+        }
+        for (int i = 0; i < first.getAttributes().getLength(); i++) {
+            Node attr1 = first.getAttributes().item(i);
+            Node attr2 = second.getAttributes().getNamedItem(attr1.getNodeName());
+            if (attr1.getNodeName().equals("name")) {
+                continue;
+            }
+            if (attr2 == null || !attr1.getNodeValue().equals(attr2.getNodeValue())) {
+                return false;
+            }
+        }
+        NodeList firstChildren = first.getChildNodes();
+        NodeList secondChildren = second.getChildNodes();
+        if (firstChildren.getLength() != secondChildren.getLength()) {
+            return false;
+        }
+        for (int i = 0; i < firstChildren.getLength(); i++) {
+            if (!this.nodesAreEqual(firstChildren.item(i), secondChildren.item(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || this.getClass() != other.getClass()) {
+            return false;
+        }
+        final XmlInstruction that = (XmlInstruction) other;
+        return this.nodesAreEqual(this.node, that.node);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.node);
+    }
+
+    @Override
+    public String toString() {
+        return new XMLDocument(this.node).toString();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -45,14 +45,14 @@ public final class XmlMethod {
      * Method node.
      */
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
-    private final XMLDocument node;
+    private final Node node;
 
     /**
      * Constructor.
      * @param node Method node.
      */
     public XmlMethod(final Node node) {
-        this.node = new XMLDocument(node);
+        this.node = node;
     }
 
     /**
@@ -60,7 +60,7 @@ public final class XmlMethod {
      * @return Name.
      */
     public String name() {
-        return String.valueOf(this.node.xpath("./@name").get(0));
+        return String.valueOf(new XMLDocument(this.node).xpath("./@name").get(0));
     }
 
     /**
@@ -68,7 +68,8 @@ public final class XmlMethod {
      * @return Access modifiers.
      */
     public int access() {
-        return new HexString(this.node.xpath("./o[@name='access']/text()").get(0)).decodeAsInt();
+        return new HexString(
+            new XMLDocument(this.node).xpath("./o[@name='access']/text()").get(0)).decodeAsInt();
     }
 
     /**
@@ -76,7 +77,8 @@ public final class XmlMethod {
      * @return Descriptor.
      */
     public String descriptor() {
-        return new HexString(this.node.xpath("./o[@name='descriptor']/text()").get(0)).decode();
+        return new HexString(
+            new XMLDocument(this.node).xpath("./o[@name='descriptor']/text()").get(0)).decode();
     }
 
     /**
@@ -89,7 +91,7 @@ public final class XmlMethod {
      */
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     public Node node() {
-        return this.node.node();
+        return this.node;
     }
 
     /**
@@ -97,7 +99,7 @@ public final class XmlMethod {
      * @return True if method is a constructor.
      */
     public boolean isConstructor() {
-        return this.node.node().getAttributes().getNamedItem("name").getNodeValue().equals("new");
+        return this.node.getAttributes().getNamedItem("name").getNodeValue().equals("new");
     }
 
     /**
@@ -128,7 +130,7 @@ public final class XmlMethod {
      * @param updated New instructions.
      */
     public void setInstructions(final List<XmlInstruction> updated) {
-        final Node root = this.node.node();
+        final Node root = this.node;
         final Document owner = root.getOwnerDocument();
         Logger.info(
             this,
@@ -151,7 +153,7 @@ public final class XmlMethod {
      */
     private Optional<Node> sequence() {
         Optional<Node> result = Optional.empty();
-        final NodeList children = this.node.node().getChildNodes();
+        final NodeList children = this.node.getChildNodes();
         for (int index = 0; index < children.getLength(); ++index) {
             final Node item = children.item(index);
             final NamedNodeMap attributes = item.getAttributes();

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -23,11 +23,13 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import com.jcabi.log.Logger;
 import com.jcabi.xml.XMLDocument;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -128,12 +130,18 @@ public final class XmlMethod {
     public void setInstructions(final List<XmlInstruction> updated) {
         final Node root = this.node.node();
         final Document owner = root.getOwnerDocument();
+        Logger.info(
+            this,
+            String.format("Set new method instructions %n%s%n",
+                updated.stream().map(XmlInstruction::toString)
+                    .collect(Collectors.joining("\n"))
+            )
+        );
         while (root.hasChildNodes()) {
             root.removeChild(root.getFirstChild());
         }
         for (final XmlInstruction instruction : updated) {
-            final Node node1 = instruction.node();
-            root.appendChild(owner.adoptNode(node1));
+            root.appendChild(owner.adoptNode(instruction.node()));
         }
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -118,6 +119,21 @@ public final class XmlMethod {
             result = Collections.emptyList();
         }
         return result;
+    }
+
+    /**
+     * Set instructions for method
+     * @param updated New instructions.
+     */
+    public void setInstructions(final List<XmlInstruction> updated) {
+        final Node root = this.node.node();
+        final Document owner = root.getOwnerDocument();
+        while (root.hasChildNodes()) {
+            root.removeChild(root.getFirstChild());
+        }
+        for (final XmlInstruction instruction : updated) {
+            root.appendChild(owner.adoptNode(instruction.node()));
+        }
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -130,7 +130,9 @@ public final class XmlMethod {
      * @param updated New instructions.
      */
     public void setInstructions(final List<XmlInstruction> updated) {
-        final Node root = this.node;
+        final Node root = this.sequence().orElseThrow(
+            () -> new IllegalStateException("Can't find bytecode of the method")
+        );
         final Document owner = root.getOwnerDocument();
         Logger.info(
             this,

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -132,7 +132,8 @@ public final class XmlMethod {
             root.removeChild(root.getFirstChild());
         }
         for (final XmlInstruction instruction : updated) {
-            root.appendChild(owner.adoptNode(instruction.node()));
+            final Node node1 = instruction.node();
+            root.appendChild(owner.adoptNode(node1));
         }
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -69,7 +69,8 @@ public final class XmlMethod {
      */
     public int access() {
         return new HexString(
-            new XMLDocument(this.node).xpath("./o[@name='access']/text()").get(0)).decodeAsInt();
+            new XMLDocument(this.node).xpath("./o[@name='access']/text()").get(0)
+        ).decodeAsInt();
     }
 
     /**
@@ -78,7 +79,8 @@ public final class XmlMethod {
      */
     public String descriptor() {
         return new HexString(
-            new XMLDocument(this.node).xpath("./o[@name='descriptor']/text()").get(0)).decode();
+            new XMLDocument(this.node).xpath("./o[@name='descriptor']/text()").get(0)
+        ).decode();
     }
 
     /**
@@ -126,7 +128,7 @@ public final class XmlMethod {
     }
 
     /**
-     * Set instructions for method
+     * Set instructions for method.
      * @param updated New instructions.
      */
     public void setInstructions(final List<XmlInstruction> updated) {
@@ -136,9 +138,9 @@ public final class XmlMethod {
         final Document owner = root.getOwnerDocument();
         Logger.info(
             this,
-            String.format("Set new method instructions %n%s%n",
-                updated.stream().map(XmlInstruction::toString)
-                    .collect(Collectors.joining("\n"))
+            String.format(
+                "Set new method instructions %n%s%n",
+                updated.stream().map(XmlInstruction::toString).collect(Collectors.joining("\n"))
             )
         );
         while (root.hasChildNodes()) {

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.xmir;
+
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+class XmlInstructionTest {
+
+    @Test
+    void comparesSuccessfully() {
+        MatcherAssert.assertThat(
+            "Xml Instruction nodes with different empty spaces, but with the same content should be the same, but they weren't",
+            new XmlInstruction(
+                new XMLDocument(
+                    new StringBuilder()
+                        .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">\n")
+                        .append("   <o base=\"string\" data=\"bytes\">1</o>\n")
+                        .append("   <o base=\"string\" data=\"bytes\">2</o>\n")
+                        .append("   <o base=\"string\" data=\"bytes\">3</o>\n")
+                        .append("</o>").toString()
+                ).node().getFirstChild()
+            ),
+            Matchers.equalTo(
+                new XmlInstruction(
+                    new XMLDocument(
+                        new StringBuilder()
+                            .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">\n")
+                            .append("<o base=\"string\" data=\"bytes\">1</o>\n")
+                            .append("<o base=\"string\" data=\"bytes\">2</o>\n")
+                            .append("<o base=\"string\" data=\"bytes\">3</o>\n")
+                            .append("</o>").toString()
+                    ).node().getFirstChild()
+                )
+            )
+        );
+    }
+
+}

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
@@ -28,7 +28,11 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
-class XmlInstructionTest {
+/**
+ * Test case for {@link XmlInstruction}.
+ * @since 0.1
+ */
+final class XmlInstructionTest {
 
     @Test
     void comparesSuccessfully() {
@@ -58,5 +62,4 @@ class XmlInstructionTest {
             )
         );
     }
-
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/package-info.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/**
+ * Tests for {@link org.eolang.jeo.representation.xmir} classes.
+ */
+package org.eolang.jeo.representation.xmir;


### PR DESCRIPTION
Replace old constructors invokations with new one.

Closes: #161.
____
History:
- feat(#161): ugly implementation of instruction replacement for constructors
- feat(#161): try to compare XML nodes correctly
- feat(#161): build correct XML nodes for instructions
- feat(#161): compare instructions opcodes
- feat(#161): precise XML node comparision
- feat(#161): print information about inserted instructions into methods
- feat(#161): Make XmlMethod stateful
- feat(#161): update XML after inlining constructors
- feat(#161): fix setInstructions method
- feat(#161): correct replacement algorithm
- feat(#161): replace INVOKESPECIAL for constructors
- feat(#161): prepare unit test for XmlInstruction comparision
- feat(#161): fix XmlInstruction comparision
- feat(#161): Finish with correct integration test
- feat(#161): fix all qulice suggestions
- feat(#161): add more puzzles

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the XML representation in the `XmlClass`, `XmlMethod`, and `XmlInstruction` classes. 

### Detailed summary
- Added a `node()` method in `XmlClass` and `XmlMethod` to expose the internal XML node.
- Added a `setInstructions()` method in `XmlMethod` to update the method instructions.
- Added `equals()`, `hashCode()`, and `toString()` methods in `XmlInstruction`.
- Refactored the `nodesAreEqual()` method in `XmlInstruction` for better readability.

> The following files were skipped due to too many changes: `src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->