### PR TITLE
feat(#178): Refactor XmlInstruction

### DIFF
--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -122,6 +122,9 @@ public final class ImprovementDistilledObjects implements Improvement {
                 decorator.targetSpecial(),
                 decorator.replacementSpecial()
             );
+            ImprovementDistilledObjects.replaceArguments(
+                clazz
+            );
         }
         final Node replacement = clazz.node();
         final Node program = xmir.node();
@@ -194,6 +197,12 @@ public final class ImprovementDistilledObjects implements Improvement {
                     }
                 }
             }
+            method.setInstructions(updated);
+        }
+    }
+
+    private static void replaceArguments(final XmlClass clazz) {
+        for (final XmlMethod method : clazz.methods()) {
             for (final XmlInstruction instruction : method.instructions()) {
                 DecoratorPair.replaceArguments(
                     instruction.node(),
@@ -201,7 +210,6 @@ public final class ImprovementDistilledObjects implements Improvement {
                     "org/eolang/jeo/AB"
                 );
             }
-            method.setInstructions(updated);
         }
     }
 

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -201,6 +201,10 @@ public final class ImprovementDistilledObjects implements Improvement {
         }
     }
 
+    /**
+     * Replace arguments.
+     * @param clazz Class where to replace.
+     */
     private static void replaceArguments(final XmlClass clazz) {
         for (final XmlMethod method : clazz.methods()) {
             for (final XmlInstruction instruction : method.instructions()) {
@@ -543,6 +547,8 @@ public final class ImprovementDistilledObjects implements Improvement {
          * @param root Original method.
          * @param method Inlined method.
          * @param bytename Class name.
+         * @checkstyle NestedIfDepthCheck (100 lines)
+         * @checkstyle NestedForDepthCheck (100 lines)
          */
         private void replaceMethodContent(
             final Node root,

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -187,20 +187,25 @@ public final class XmlInstruction {
         return result;
     }
 
+    /**
+     * Check if two attributes are equal.
+     * @param first First attribute.
+     * @param second Second attribute.
+     * @return True if attributes are equal.
+     */
     private static boolean areAttributesEqual(final Node first, final Node second) {
-        if (first == null || second == null) {
-            return false;
+        boolean result = false;
+        if (first != null && second != null) {
+            if (first.getNodeName().equals(second.getNodeName())) {
+                if (first.getNodeName().equals("name")) {
+                    result = first.getNodeValue().split("-")[0]
+                        .equals(second.getNodeValue().split("-")[0]);
+                } else {
+                    result = first.getNodeValue().equals(second.getNodeValue());
+                }
+            }
         }
-        if (!first.getNodeName().equals(second.getNodeName())) {
-            return false;
-        }
-        if (first.getNodeName().equals("name")) {
-            return first.getNodeValue().split("-")[0]
-                .equals(second.getNodeValue().split("-")[0]);
-        } else {
-            return first.getNodeValue().equals(second.getNodeValue());
-        }
-
+        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.IntStream;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -144,18 +145,24 @@ public final class XmlInstruction {
         } else if (first.getNodeType() == Node.TEXT_NODE) {
             result = first.getTextContent().trim().equals(second.getTextContent().trim());
         } else {
-            result = this.elementEquals(first, second);
+            result = this.isElementEquals(first, second);
         }
         return result;
     }
 
-    private boolean elementEquals(final Node first, final Node second) {
+    /**
+     * Check if two elements are equal.
+     * @param first First element.
+     * @param second Second element.
+     * @return True if elements are equal.
+     */
+    private boolean isElementEquals(final Node first, final Node second) {
         return first.getNodeName().equals(second.getNodeName())
-            && XmlInstruction.sameAttributes(first, second)
-            && this.sameChildren(first, second);
+            && XmlInstruction.isSameAttributes(first, second)
+            && this.isSameChildren(first, second);
     }
 
-    private static boolean sameAttributes(final Node first, final Node second) {
+    private static boolean isSameAttributes(final Node first, final Node second) {
         boolean result = true;
         if (first.getAttributes().getLength() != second.getAttributes().getLength()) {
             result = false;
@@ -178,21 +185,18 @@ public final class XmlInstruction {
         return result;
     }
 
-    private boolean sameChildren(final Node first, final Node second) {
-        boolean result = true;
-        final List<Node> firstchildren = XmlInstruction.children(first);
-        final List<Node> secondchildren = XmlInstruction.children(second);
-        if (firstchildren.size() != secondchildren.size()) {
-            result = false;
-        } else {
-            for (int i = 0; i < firstchildren.size(); ++i) {
-                if (!this.equals(firstchildren.get(i), secondchildren.get(i))) {
-                    result = false;
-                    break;
-                }
-            }
-        }
-        return result;
+    /**
+     * Check if two nodes have the same children.
+     * @param left Left node.
+     * @param right Right node.
+     * @return True if nodes have the same children.
+     */
+    private boolean isSameChildren(final Node left, final Node right) {
+        final List<Node> first = XmlInstruction.children(left);
+        final List<Node> second = XmlInstruction.children(right);
+        return first.size() == second.size()
+            && IntStream.range(0, first.size())
+            .allMatch(index -> this.equals(first.get(index), second.get(index)));
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -37,6 +37,7 @@ import org.w3c.dom.NodeList;
  * Bytecode instruction from XML.
  * @since 0.1
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class XmlInstruction {
 
     /**
@@ -140,12 +141,14 @@ public final class XmlInstruction {
      */
     private boolean equals(final Node first, final Node second) {
         final boolean result;
-        if (first.getNodeType() != second.getNodeType()) {
-            result = false;
-        } else if (first.getNodeType() == Node.TEXT_NODE) {
-            result = first.getTextContent().trim().equals(second.getTextContent().trim());
+        if (first.getNodeType() == second.getNodeType()) {
+            if (first.getNodeType() == Node.TEXT_NODE) {
+                result = first.getTextContent().trim().equals(second.getTextContent().trim());
+            } else {
+                result = this.areElementsEqual(first, second);
+            }
         } else {
-            result = this.areElementsEquals(first, second);
+            result = false;
         }
         return result;
     }
@@ -156,7 +159,7 @@ public final class XmlInstruction {
      * @param second Second element.
      * @return True if elements are equal.
      */
-    private boolean areElementsEquals(final Node first, final Node second) {
+    private boolean areElementsEqual(final Node first, final Node second) {
         return first.getNodeName().equals(second.getNodeName())
             && XmlInstruction.hasSameAttributes(first, second)
             && this.hasSameChildren(first, second);
@@ -194,16 +197,16 @@ public final class XmlInstruction {
      * @return True if attributes are equal.
      */
     private static boolean areAttributesEqual(final Node first, final Node second) {
-        boolean result = false;
-        if (first != null && second != null) {
-            if (first.getNodeName().equals(second.getNodeName())) {
-                if (first.getNodeName().equals("name")) {
-                    result = first.getNodeValue().split("-")[0]
-                        .equals(second.getNodeValue().split("-")[0]);
-                } else {
-                    result = first.getNodeValue().equals(second.getNodeValue());
-                }
+        final boolean result;
+        if (first != null && second != null && first.getNodeName().equals(second.getNodeName())) {
+            if (first.getNodeName().equals("name")) {
+                result = first.getNodeValue().split("-")[0]
+                    .equals(second.getNodeValue().split("-")[0]);
+            } else {
+                result = first.getNodeValue().equals(second.getNodeValue());
             }
+        } else {
+            result = false;
         }
         return result;
     }
@@ -232,11 +235,11 @@ public final class XmlInstruction {
         final List<Node> res = new ArrayList<>(0);
         for (int index = 0; index < all.getLength(); ++index) {
             final Node item = all.item(index);
-            final short type = item.getNodeType();
+            final int type = item.getNodeType();
             if (type == Node.ELEMENT_NODE) {
                 res.add(item);
             }
-            if (type == Node.TEXT_NODE && !item.getTextContent().trim().isEmpty()) {
+            if (type == Node.TEXT_NODE && !item.getTextContent().isBlank()) {
                 res.add(item);
             }
         }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -141,10 +141,9 @@ public final class XmlInstruction {
         final boolean result;
         if (first.getNodeType() != second.getNodeType()) {
             result = false;
+        } else if (first.getNodeType() == Node.TEXT_NODE) {
+            result = first.getTextContent().trim().equals(second.getTextContent().trim());
         } else if (!first.getNodeName().equals(second.getNodeName())) {
-            result = false;
-        } else if (first.getNodeType() == Node.TEXT_NODE && !first.getTextContent()
-            .trim().equals(second.getTextContent().trim())) {
             result = false;
         } else if (first.getAttributes().getLength() != second.getAttributes().getLength()) {
             result = false;
@@ -154,6 +153,14 @@ public final class XmlInstruction {
             result = this.sameChildren(first, second);
         }
         return result;
+    }
+
+    private static boolean sameType(final Node first, final Node second) {
+        if (first.getNodeType() == Node.TEXT_NODE && second.getNodeType() == Node.TEXT_NODE) {
+            return first.getTextContent().trim().equals(second.getTextContent().trim());
+        } else {
+            return first.getNodeType() == second.getNodeType();
+        }
     }
 
     private static boolean sameAttributes(final Node first, final Node second) {
@@ -202,7 +209,11 @@ public final class XmlInstruction {
         final List<Node> res = new ArrayList<>(0);
         for (int index = 0; index < all.getLength(); ++index) {
             final Node item = all.item(index);
-            if (item.getNodeType() == Node.ELEMENT_NODE) {
+            final short type = item.getNodeType();
+            if (type == Node.ELEMENT_NODE) {
+                res.add(item);
+            }
+            if (type == Node.TEXT_NODE && !item.getTextContent().trim().isEmpty()) {
                 res.add(item);
             }
         }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -143,28 +143,24 @@ public final class XmlInstruction {
             result = false;
         } else if (first.getNodeType() == Node.TEXT_NODE) {
             result = first.getTextContent().trim().equals(second.getTextContent().trim());
-        } else if (!first.getNodeName().equals(second.getNodeName())) {
-            result = false;
-        } else if (first.getAttributes().getLength() != second.getAttributes().getLength()) {
-            result = false;
-        } else if (!XmlInstruction.sameAttributes(first, second)) {
-            result = false;
         } else {
-            result = this.sameChildren(first, second);
+            result = this.elementEquals(first, second);
         }
         return result;
     }
 
-    private static boolean sameType(final Node first, final Node second) {
-        if (first.getNodeType() == Node.TEXT_NODE && second.getNodeType() == Node.TEXT_NODE) {
-            return first.getTextContent().trim().equals(second.getTextContent().trim());
-        } else {
-            return first.getNodeType() == second.getNodeType();
-        }
+    private boolean elementEquals(final Node first, final Node second) {
+        return first.getNodeName().equals(second.getNodeName())
+            && XmlInstruction.sameAttributes(first, second)
+            && this.sameChildren(first, second);
     }
 
     private static boolean sameAttributes(final Node first, final Node second) {
         boolean result = true;
+        if (first.getAttributes().getLength() != second.getAttributes().getLength()) {
+            result = false;
+            return result;
+        }
         for (int index = 0; index < first.getAttributes().getLength(); ++index) {
             final Node attr1 = first.getAttributes().item(index);
             final Node attr2 = second.getAttributes().getNamedItem(attr1.getNodeName());

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -94,7 +94,7 @@ public final class XmlInstruction {
             result = false;
         } else {
             final XmlInstruction that = (XmlInstruction) other;
-            result = this.nodesAreEqual(this.node, that.node);
+            result = this.equals(this.node, that.node);
         }
         return result;
     }
@@ -132,6 +132,67 @@ public final class XmlInstruction {
     }
 
     /**
+     * Check if two nodes are equal.
+     * @param first First node.
+     * @param second Second node.
+     * @return True if nodes are equal.
+     */
+    private boolean equals(final Node first, final Node second) {
+        final boolean result;
+        if (first.getNodeType() != second.getNodeType()) {
+            result = false;
+        } else if (!first.getNodeName().equals(second.getNodeName())) {
+            result = false;
+        } else if (first.getNodeType() == Node.TEXT_NODE && !first.getTextContent()
+            .trim().equals(second.getTextContent().trim())) {
+            result = false;
+        } else if (first.getAttributes().getLength() != second.getAttributes().getLength()) {
+            result = false;
+        } else if (!XmlInstruction.sameAttributes(first, second)) {
+            result = false;
+        } else {
+            result = this.sameChildren(first, second);
+        }
+        return result;
+    }
+
+    private static boolean sameAttributes(final Node first, final Node second) {
+        boolean result = true;
+        for (int index = 0; index < first.getAttributes().getLength(); ++index) {
+            final Node attr1 = first.getAttributes().item(index);
+            final Node attr2 = second.getAttributes().getNamedItem(attr1.getNodeName());
+            if (attr1.getNodeName().equals("name")) {
+                if (attr1.getNodeValue().split("-")[0]
+                    .equals(attr2.getNodeValue().split("-")[0])) {
+                    continue;
+                }
+            }
+            if (attr2 == null || !attr1.getNodeValue().equals(attr2.getNodeValue())) {
+                result = false;
+                break;
+            }
+        }
+        return result;
+    }
+
+    private boolean sameChildren(final Node first, final Node second) {
+        boolean result = true;
+        final List<Node> firstchildren = XmlInstruction.children(first);
+        final List<Node> secondchildren = XmlInstruction.children(second);
+        if (firstchildren.size() != secondchildren.size()) {
+            result = false;
+        } else {
+            for (int i = 0; i < firstchildren.size(); ++i) {
+                if (!this.equals(firstchildren.get(i), secondchildren.get(i))) {
+                    result = false;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
      * Get children nodes.
      * @param root Root node.
      * @return Children nodes.
@@ -146,64 +207,5 @@ public final class XmlInstruction {
             }
         }
         return res;
-    }
-
-    /**
-     * Check if two nodes are equal.
-     * @param first First node.
-     * @param second Second node.
-     * @return True if nodes are equal.
-     * @todo #161:60min Refactor XmlInstruction#nodesAreEqual() method.
-     *  This method is too complex and it is hard to understand.
-     *  We have to refactor this method in order to make it more readable.
-     *  Don't forget to write test and remove suppressed checks.
-     * @checkstyle LocalFinalVariableNameCheck (100 lines)
-     * @checkstyle NestedIfDepthCheck (100 lines)
-     * @checkstyle CyclomaticComplexityCheck (100 lines)
-     * @checkstyle LocalVariableNameCheck (100 lines)
-     */
-    @SuppressWarnings({"PMD.ConfusingTernary", "PMD.CollapsibleIfStatements"})
-    private boolean nodesAreEqual(final Node first, final Node second) {
-        boolean result = true;
-        if (first.getNodeType() != second.getNodeType()) {
-            result = false;
-        } else if (!first.getNodeName().equals(second.getNodeName())) {
-            result = false;
-        } else if (first.getNodeType() == Node.TEXT_NODE && !first.getTextContent()
-            .trim().equals(second.getTextContent().trim())) {
-            result = false;
-        } else if (first.getAttributes().getLength() != second.getAttributes().getLength()) {
-            result = false;
-        } else {
-            for (int index = 0; index < first.getAttributes().getLength(); ++index) {
-                final Node attr1 = first.getAttributes().item(index);
-                final Node attr2 = second.getAttributes().getNamedItem(attr1.getNodeName());
-                if (attr1.getNodeName().equals("name")) {
-                    if (attr1.getNodeValue().split("-")[0]
-                        .equals(attr2.getNodeValue().split("-")[0])) {
-                        continue;
-                    }
-                }
-                if (attr2 == null || !attr1.getNodeValue().equals(attr2.getNodeValue())) {
-                    result = false;
-                    break;
-                }
-            }
-            if (result) {
-                final List<Node> firstchildren = XmlInstruction.children(first);
-                final List<Node> secondchildren = XmlInstruction.children(second);
-                if (firstchildren.size() != secondchildren.size()) {
-                    result = false;
-                } else {
-                    for (int i = 0; i < firstchildren.size(); ++i) {
-                        if (!this.nodesAreEqual(firstchildren.get(i), secondchildren.get(i))) {
-                            result = false;
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-        return result;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -145,7 +145,7 @@ public final class XmlInstruction {
         } else if (first.getNodeType() == Node.TEXT_NODE) {
             result = first.getTextContent().trim().equals(second.getTextContent().trim());
         } else {
-            result = this.isElementEquals(first, second);
+            result = this.areElementsEquals(first, second);
         }
         return result;
     }
@@ -156,33 +156,51 @@ public final class XmlInstruction {
      * @param second Second element.
      * @return True if elements are equal.
      */
-    private boolean isElementEquals(final Node first, final Node second) {
+    private boolean areElementsEquals(final Node first, final Node second) {
         return first.getNodeName().equals(second.getNodeName())
-            && XmlInstruction.isSameAttributes(first, second)
-            && this.isSameChildren(first, second);
+            && XmlInstruction.hasSameAttributes(first, second)
+            && this.hasSameChildren(first, second);
     }
 
-    private static boolean isSameAttributes(final Node first, final Node second) {
+    /**
+     * Check if two nodes have the same attributes.
+     * @param first First node.
+     * @param second Second node.
+     * @return True if nodes have the same attributes.
+     */
+    private static boolean hasSameAttributes(final Node first, final Node second) {
         boolean result = true;
-        if (first.getAttributes().getLength() != second.getAttributes().getLength()) {
-            result = false;
-            return result;
-        }
-        for (int index = 0; index < first.getAttributes().getLength(); ++index) {
-            final Node attr1 = first.getAttributes().item(index);
-            final Node attr2 = second.getAttributes().getNamedItem(attr1.getNodeName());
-            if (attr1.getNodeName().equals("name")) {
-                if (attr1.getNodeValue().split("-")[0]
-                    .equals(attr2.getNodeValue().split("-")[0])) {
-                    continue;
+        final NamedNodeMap attributes = first.getAttributes();
+        final int length = attributes.getLength();
+        if (length == second.getAttributes().getLength()) {
+            for (int index = 0; index < length; ++index) {
+                final Node left = attributes.item(index);
+                final Node right = second.getAttributes().getNamedItem(left.getNodeName());
+                if (!XmlInstruction.areAttributesEqual(left, right)) {
+                    result = false;
+                    break;
                 }
             }
-            if (attr2 == null || !attr1.getNodeValue().equals(attr2.getNodeValue())) {
-                result = false;
-                break;
-            }
+        } else {
+            result = false;
         }
         return result;
+    }
+
+    private static boolean areAttributesEqual(final Node first, final Node second) {
+        if (first == null || second == null) {
+            return false;
+        }
+        if (!first.getNodeName().equals(second.getNodeName())) {
+            return false;
+        }
+        if (first.getNodeName().equals("name")) {
+            return first.getNodeValue().split("-")[0]
+                .equals(second.getNodeValue().split("-")[0]);
+        } else {
+            return first.getNodeValue().equals(second.getNodeValue());
+        }
+
     }
 
     /**
@@ -191,7 +209,7 @@ public final class XmlInstruction {
      * @param right Right node.
      * @return True if nodes have the same children.
      */
-    private boolean isSameChildren(final Node left, final Node right) {
+    private boolean hasSameChildren(final Node left, final Node right) {
         final List<Node> first = XmlInstruction.children(left);
         final List<Node> second = XmlInstruction.children(right);
         return first.size() == second.size()

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
@@ -34,14 +34,51 @@ import org.junit.jupiter.api.Test;
  */
 final class XmlInstructionTest {
 
+    /**
+     * Default instruction which we use for testing.
+     * This XML is compare with all other XMLs.
+     */
+    private static final String DEFAULT_INSTRUCTION = new StringBuilder()
+        .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">")
+        .append("<o base=\"string\" data=\"bytes\">1</o>")
+        .append("<o base=\"string\" data=\"bytes\">2</o>")
+        .append("<o base=\"string\" data=\"bytes\">3</o>")
+        .append("</o>")
+        .toString();
+
     @Test
-    void comparesSuccessfully() {
+    void comparesSuccessfullyWithSpaces() {
         MatcherAssert.assertThat(
-            "Xml Instruction nodes with different empty spaces, but with the same content should be the same, but they weren't",
+            "Xml Instruction nodes with different empty spaces, but with the same content should be the same, but it wasn't",
             new XmlInstruction(
                 new XMLDocument(
                     new StringBuilder()
                         .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">\n")
+                        .append("   <o base=\"string\" data=\"bytes\">1</o>\n")
+                        .append("   <o base=\"string\" data=\"bytes\">2</o>\n")
+                        .append("   <o base=\"string\" data=\"bytes\">3</o>\n")
+                        .append("</o>")
+                        .toString()
+                ).node().getFirstChild()
+            ),
+            Matchers.equalTo(
+                new XmlInstruction(
+                    new XMLDocument(
+                        XmlInstructionTest.DEFAULT_INSTRUCTION
+                    ).node().getFirstChild()
+                )
+            )
+        );
+    }
+
+    @Test
+    void comparesSuccessfullyWithDifferentOpcodeNumber() {
+        MatcherAssert.assertThat(
+            "Xml Instruction nodes with different opcode number in name, but with the same content should be the same, but it wasn't",
+            new XmlInstruction(
+                new XMLDocument(
+                    new StringBuilder()
+                        .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-66\">\n")
                         .append("   <o base=\"string\" data=\"bytes\">1</o>\n")
                         .append("   <o base=\"string\" data=\"bytes\">2</o>\n")
                         .append("   <o base=\"string\" data=\"bytes\">3</o>\n")
@@ -51,13 +88,54 @@ final class XmlInstructionTest {
             Matchers.equalTo(
                 new XmlInstruction(
                     new XMLDocument(
-                        new StringBuilder()
-                            .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">\n")
-                            .append("<o base=\"string\" data=\"bytes\">1</o>\n")
-                            .append("<o base=\"string\" data=\"bytes\">2</o>\n")
-                            .append("<o base=\"string\" data=\"bytes\">3</o>\n")
-                            .append("</o>").toString()
+                        XmlInstructionTest.DEFAULT_INSTRUCTION
                     ).node().getFirstChild()
+                )
+            )
+        );
+    }
+
+    @Test
+    void comparesDeeply() {
+        MatcherAssert.assertThat(
+            "Xml Instruction with different child content should not be equal, but it was",
+            new XmlInstruction(
+                new XMLDocument(
+                    new StringBuilder()
+                        .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">\n")
+                        .append("</o>")
+                        .toString())
+                    .node()
+                    .getFirstChild()
+            ),
+            Matchers.not(
+                Matchers.equalTo(
+                    new XmlInstruction(
+                        new XMLDocument(
+                            XmlInstructionTest.DEFAULT_INSTRUCTION
+                        ).node().getFirstChild()
+                    )
+                )
+            )
+        );
+    }
+
+    @Test
+    void comparesDifferentInstructions() {
+        MatcherAssert.assertThat(
+            "Xml Instruction with different content should not be equal, but it was",
+            new XmlInstruction(
+                new XMLDocument("<o base=\"opcode\" name=\"DUP-89-55\"/>\n")
+                    .node()
+                    .getFirstChild()
+            ),
+            Matchers.not(
+                Matchers.equalTo(
+                    new XmlInstruction(
+                        new XMLDocument(
+                            XmlInstructionTest.DEFAULT_INSTRUCTION
+                        ).node().getFirstChild()
+                    )
                 )
             )
         );

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
@@ -38,7 +38,7 @@ final class XmlInstructionTest {
      * Default instruction which we use for testing.
      * This XML is compare with all other XMLs.
      */
-    private static final String DEFAULT_INSTRUCTION = new StringBuilder()
+    private static final String INSTRUCTION = new StringBuilder()
         .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">")
         .append("<o base=\"string\" data=\"bytes\">1</o>")
         .append("<o base=\"string\" data=\"bytes\">2</o>")
@@ -56,15 +56,14 @@ final class XmlInstructionTest {
                         .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">\n")
                         .append("   <o base=\"string\" data=\"bytes\">1</o>\n")
                         .append("   <o base=\"string\" data=\"bytes\">2</o>\n")
-                        .append("   <o base=\"string\" data=\"bytes\">3</o>\n")
-                        .append("</o>")
+                        .append("   <o base=\"string\" data=\"bytes\">3</o></o>")
                         .toString()
                 ).node().getFirstChild()
             ),
             Matchers.equalTo(
                 new XmlInstruction(
                     new XMLDocument(
-                        XmlInstructionTest.DEFAULT_INSTRUCTION
+                        XmlInstructionTest.INSTRUCTION
                     ).node().getFirstChild()
                 )
             )
@@ -81,14 +80,14 @@ final class XmlInstructionTest {
                         .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-66\">\n")
                         .append("   <o base=\"string\" data=\"bytes\">1</o>\n")
                         .append("   <o base=\"string\" data=\"bytes\">2</o>\n")
-                        .append("   <o base=\"string\" data=\"bytes\">3</o>\n")
-                        .append("</o>").toString()
+                        .append("   <o base=\"string\" data=\"bytes\">3</o></o>")
+                        .toString()
                 ).node().getFirstChild()
             ),
             Matchers.equalTo(
                 new XmlInstruction(
                     new XMLDocument(
-                        XmlInstructionTest.DEFAULT_INSTRUCTION
+                        XmlInstructionTest.INSTRUCTION
                     ).node().getFirstChild()
                 )
             )
@@ -102,18 +101,18 @@ final class XmlInstructionTest {
             new XmlInstruction(
                 new XMLDocument(
                     new StringBuilder()
-                        .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-66\">\n")
-                        .append("   <o base=\"string\" data=\"bytes\">32</o>\n")
-                        .append("   <o base=\"string\" data=\"bytes\">23</o>\n")
-                        .append("   <o base=\"string\" data=\"bytes\">14</o>\n")
-                        .append("</o>").toString()
+                        .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-66\">")
+                        .append("   <o base=\"string\" data=\"bytes\">32</o>")
+                        .append("   <o base=\"string\" data=\"bytes\">23</o>")
+                        .append("   <o base=\"string\" data=\"bytes\">14</o></o>")
+                        .toString()
                 ).node().getFirstChild()
             ),
             Matchers.not(
                 Matchers.equalTo(
                     new XmlInstruction(
                         new XMLDocument(
-                            XmlInstructionTest.DEFAULT_INSTRUCTION
+                            XmlInstructionTest.INSTRUCTION
                         ).node().getFirstChild()
                     )
                 )
@@ -127,18 +126,14 @@ final class XmlInstructionTest {
             "Xml Instruction with different child content should not be equal, but it was",
             new XmlInstruction(
                 new XMLDocument(
-                    new StringBuilder()
-                        .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">\n")
-                        .append("</o>")
-                        .toString())
-                    .node()
-                    .getFirstChild()
+                    "<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\"></o>"
+                ).node().getFirstChild()
             ),
             Matchers.not(
                 Matchers.equalTo(
                     new XmlInstruction(
                         new XMLDocument(
-                            XmlInstructionTest.DEFAULT_INSTRUCTION
+                            XmlInstructionTest.INSTRUCTION
                         ).node().getFirstChild()
                     )
                 )
@@ -159,7 +154,7 @@ final class XmlInstructionTest {
                 Matchers.equalTo(
                     new XmlInstruction(
                         new XMLDocument(
-                            XmlInstructionTest.DEFAULT_INSTRUCTION
+                            XmlInstructionTest.INSTRUCTION
                         ).node().getFirstChild()
                     )
                 )

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
@@ -96,6 +96,32 @@ final class XmlInstructionTest {
     }
 
     @Test
+    void comparesSuccessfullyWithDifferentTextNodes() {
+        MatcherAssert.assertThat(
+            "Xml Instruction with different arguments should not be equal, but it was",
+            new XmlInstruction(
+                new XMLDocument(
+                    new StringBuilder()
+                        .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-66\">\n")
+                        .append("   <o base=\"string\" data=\"bytes\">32</o>\n")
+                        .append("   <o base=\"string\" data=\"bytes\">23</o>\n")
+                        .append("   <o base=\"string\" data=\"bytes\">14</o>\n")
+                        .append("</o>").toString()
+                ).node().getFirstChild()
+            ),
+            Matchers.not(
+                Matchers.equalTo(
+                    new XmlInstruction(
+                        new XMLDocument(
+                            XmlInstructionTest.DEFAULT_INSTRUCTION
+                        ).node().getFirstChild()
+                    )
+                )
+            )
+        );
+    }
+
+    @Test
     void comparesDeeply() {
         MatcherAssert.assertThat(
             "Xml Instruction with different child content should not be equal, but it was",


### PR DESCRIPTION
Refactor XmlInstruction#equals() method.

Closes: #178.
____
History:
- feat(#178): add more tests before changing the logic of comparision method
- feat(#178): add more fine grained method for comparision
- feat(#178): working comparision code
- feat(#178): simplify elements comparision
- feat(#178): add javadocs for some methods
- feat(#178): hasSameAttributes method
- feat(#178): add javadocs
- feat(#178): refactor XmlInstructionTest
- feat(#178): finish with refactoring of XmlInstruction comparision

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the code in the `ImprovementDistilledObjects` and `XmlInstruction` classes. 

### Detailed summary
- Added a new method `replaceArguments` in the `ImprovementDistilledObjects` class to replace arguments in methods.
- Refactored the `XmlInstruction` class to improve code readability and maintainability.
- Added new test cases in the `XmlInstructionTest` class to cover different scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->