### PR TITLE
feat(#167): Remove Code Duplication between ImprovementDistilledObjects and XmlClass

### DIFF
--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -667,47 +667,5 @@ public final class ImprovementDistilledObjects implements Improvement {
             }
             return res.stream();
         }
-
-        /**
-         * Find sequence node.
-         * @param node Node.
-         * @return Sequence node.
-         */
-        private static Optional<Node> sequence(final Node node) {
-            Optional<Node> result = Optional.empty();
-            final NodeList children = node.getChildNodes();
-            for (int index = 0; index < children.getLength(); ++index) {
-                final Node item = children.item(index);
-                final NamedNodeMap attributes = item.getAttributes();
-                if (attributes == null) {
-                    continue;
-                }
-                final Node base = attributes.getNamedItem("base");
-                if (base == null) {
-                    continue;
-                }
-                if (base.getNodeValue().equals("seq")) {
-                    result = Optional.of(item);
-                    break;
-                }
-            }
-            return result;
-        }
-
-        /**
-         * Check if node is an instruction.
-         * @param node Node.
-         * @return True if node is an instruction.
-         */
-        private static boolean isInstruction(final Node node) {
-            final boolean result;
-            final NamedNodeMap attrs = node.getAttributes();
-            if (attrs == null || attrs.getNamedItem("name") == null) {
-                result = false;
-            } else {
-                result = true;
-            }
-            return result;
-        }
     }
 }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -532,13 +532,7 @@ public final class ImprovementDistilledObjects implements Improvement {
          *  those fields that are used in the decorator.
          */
         private static void removeOldFields(final Node root) {
-            DecoratorPair.objects(root).filter(
-                node -> {
-                    final NamedNodeMap attributes = node.getAttributes();
-                    final Node base = attributes.getNamedItem("base");
-                    return base != null && base.getNodeValue().equals("field");
-                }
-            ).forEach(root::removeChild);
+            new XmlClass(root).fields().stream().map(XmlField::node).forEach(root::removeChild);
         }
 
         /**

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -514,13 +514,10 @@ public final class ImprovementDistilledObjects implements Improvement {
          *  It's not correct, because we need to handle constructors correctly.
          */
         private static void removeOldConstructors(final Node root) {
-            DecoratorPair.objects(root).filter(
-                node -> {
-                    final NamedNodeMap attributes = node.getAttributes();
-                    final Node base = attributes.getNamedItem("name");
-                    return base != null && base.getNodeValue().equals("new");
-                }
-            ).forEach(root::removeChild);
+            new XmlClass(root).constructors()
+                .stream()
+                .map(XmlMethod::node)
+                .forEach(root::removeChild);
         }
 
         /**
@@ -532,7 +529,10 @@ public final class ImprovementDistilledObjects implements Improvement {
          *  those fields that are used in the decorator.
          */
         private static void removeOldFields(final Node root) {
-            new XmlClass(root).fields().stream().map(XmlField::node).forEach(root::removeChild);
+            new XmlClass(root).fields()
+                .stream()
+                .map(XmlField::node)
+                .forEach(root::removeChild);
         }
 
         /**

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -643,22 +643,5 @@ public final class ImprovementDistilledObjects implements Improvement {
                 }
             }
         }
-
-        /**
-         * Objects.
-         * @param root Root node.
-         * @return Stream of class objects.
-         */
-        private static Stream<Node> objects(final Node root) {
-            final NodeList children = root.getChildNodes();
-            final List<Node> res = new ArrayList<>(children.getLength());
-            for (int index = 0; index < children.getLength(); ++index) {
-                final Node child = children.item(index);
-                if (child.getNodeName().equals("o")) {
-                    res.add(child);
-                }
-            }
-            return res.stream();
-        }
     }
 }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -34,7 +34,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.jeo.Improvement;

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -56,7 +56,7 @@ public final class XmlClass {
      * Constructor.
      * @param xml Class node.
      */
-    private XmlClass(final Node xml) {
+    public XmlClass(final Node xml) {
         this.node = xml;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -64,12 +64,14 @@ public final class XmlClass {
     /**
      * Retrieve all constructors from XMIR.
      * @return List of constructors.
+     * @todo #167:60min Add unit tests for 'constructors' method.
+     *  Currently we don't have unit tests for that method. So, it makes sense to add
+     *  them to keep code safe and clear.
      */
     public List<XmlMethod> constructors() {
         return this.objects().filter(
             xmirnode -> {
-                final NamedNodeMap attributes = xmirnode.getAttributes();
-                final Node base = attributes.getNamedItem("name");
+                final Node base = xmirnode.getAttributes().getNamedItem("name");
                 return base != null && "new".equals(base.getNodeValue());
             }
         ).map(XmlMethod::new).collect(Collectors.toList());

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,10 +61,14 @@ public final class XmlClass {
         this.node = xml;
     }
 
+    /**
+     * Retrieve all constructors from XMIR.
+     * @return List of constructors.
+     */
     public List<XmlMethod> constructors() {
         return this.objects().filter(
-            node -> {
-                final NamedNodeMap attributes = node.getAttributes();
+            xmirnode -> {
+                final NamedNodeMap attributes = xmirnode.getAttributes();
                 final Node base = attributes.getNamedItem("name");
                 return base != null && "new".equals(base.getNodeValue());
             }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -23,12 +23,14 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -58,6 +60,16 @@ public final class XmlClass {
      */
     public XmlClass(final Node xml) {
         this.node = xml;
+    }
+
+    public List<XmlMethod> constructors() {
+        return this.objects().filter(
+            node -> {
+                final NamedNodeMap attributes = node.getAttributes();
+                final Node base = attributes.getNamedItem("name");
+                return base != null && "new".equals(base.getNodeValue());
+            }
+        ).map(XmlMethod::new).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 


### PR DESCRIPTION
Remove duplicated methods in ImprovementDistilledObjects. Use `XmlClass` methods instead.

Closes: #167.
____
History:
- feat(#167): remove duplicated methods
- feat(#167): remove redundant methos
- feat(#167): remove redundant methods
- feat(#167): use XmlClass to retrieve fields
- feat(#167): add 'constructors' method to XmlClass
- feat(#167): remove duplicated method
- feat(#167): fix all qulice suggestions

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding unit tests for the `constructors` method in the `XmlClass` class. 

### Detailed summary
- Added a public `XmlClass` constructor that takes a `Node` parameter.
- Added a `constructors` method in the `XmlClass` class that retrieves all constructors from XMIR.
- Added a comment to indicate the need for unit tests for the `constructors` method.
- Refactored the `removeOldConstructors` method in the `ImprovementDistilledObjects` class to use the `XmlClass` class and its `constructors` method.
- Refactored the `replaceMethodContent` method in the `ImprovementDistilledObjects` class to use the `XmlClass` class and its `methods` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->