### PR TITLE
feat(#183): Use DecoratorCompositionName Class

### DIFF
--- a/src/it/distilled/verify.groovy
+++ b/src/it/distilled/verify.groovy
@@ -29,8 +29,8 @@ assert log.contains("Result: 31")
 assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/Main.xmir').exists()
 assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/A.xmir').exists()
 assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/B.xmir').exists()
-assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/AB.xmir').exists()
-assert new File(basedir, 'target/classes/org/eolang/jeo/AB.class').exists()
+assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/A$B.xmir').exists()
+assert new File(basedir, 'target/classes/org/eolang/jeo/A$B.class').exists()
 //Check that class file was changed
 assert log.contains("Main.class was recompiled successfully.")
 true

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -306,12 +306,11 @@ public final class ImprovementDistilledObjects implements Improvement {
          * @return Replacement.
          */
         private List<XmlInstruction> replacementNew() {
-            final String newname = this.newname();
             final Node second = new XMLDocument(
                 new StringBuilder()
                     .append("<o base=\"opcode\" name=\"NEW-187-50\">")
                     .append("<o base=\"string\" data=\"bytes\">")
-                    .append(new HexData(newname.replace('.', '/')).value())
+                    .append(new DecoratorCompositionName(this.decorated, this.decorator).hex())
                     .append("</o>")
                     .append("</o>")
                     .toString()
@@ -379,7 +378,9 @@ public final class ImprovementDistilledObjects implements Improvement {
                         new StringBuilder()
                             .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">")
                             .append("<o base=\"string\" data=\"bytes\">")
-                            .append(new HexData(this.newname().replace('.', '/')).value())
+                            .append(
+                                new DecoratorCompositionName(this.decorated, this.decorator).hex()
+                            )
                             .append("</o>")
                             .append("<o base=\"string\" data=\"bytes\">")
                             .append(new HexData("<init>").value())
@@ -399,19 +400,11 @@ public final class ImprovementDistilledObjects implements Improvement {
          * @return Combined representation.
          */
         private Representation combine() {
-            return new EoRepresentation(this.skeleton(this.decorator.toEO(), this.newname()));
-        }
-
-        /**
-         * New name of the combined class.
-         * @return New name.
-         */
-        private String newname() {
-            final String second = this.decorator.name();
-            return String.format(
-                "%s%s",
-                this.decorated.name(),
-                second.substring(second.lastIndexOf('.') + 1)
+            return new EoRepresentation(
+                this.skeleton(
+                    this.decorator.toEO(),
+                    new DecoratorCompositionName(this.decorated, this.decorator).value()
+                )
             );
         }
 

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -210,7 +210,7 @@ public final class ImprovementDistilledObjects implements Improvement {
                 DecoratorPair.replaceArguments(
                     instruction.node(),
                     "org/eolang/jeo/B",
-                    "org/eolang/jeo/AB"
+                    "org/eolang/jeo/A$B"
                 );
             }
         }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -445,9 +445,8 @@ public final class ImprovementDistilledObjects implements Improvement {
             for (int index = 0; index < children.getLength(); ++index) {
                 final Node item = children.item(index);
                 if (item.getNodeName().equals("o")) {
-                    final String bytename = name.replaceAll("\\.", "/");
-                    item.getAttributes().getNamedItem("name").setNodeValue(bytename);
-                    this.handleRootObject(item, bytename);
+                    item.getAttributes().getNamedItem("name").setNodeValue(name);
+                    this.handleRootObject(item, name);
                 }
             }
         }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -418,7 +418,7 @@ public final class ImprovementDistilledObjects implements Improvement {
             final List<XML> roots = decor.nodes("/program");
             final Node root = roots.get(0).node();
             final NamedNodeMap attributes = root.getAttributes();
-            attributes.getNamedItem("name").setNodeValue(name);
+            attributes.getNamedItem("name").setNodeValue(name.replace('/', '.'));
             attributes.getNamedItem("time").setTextContent(
                 LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
             );

--- a/src/test/java/org/eolang/jeo/improvement/ImprovementDistilledObjectsTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/ImprovementDistilledObjectsTest.java
@@ -47,7 +47,7 @@ final class ImprovementDistilledObjectsTest {
     /**
      * Name of the combined class.
      */
-    private static final String COMBINED = "org/eolang/jeo/A$B";
+    private static final String COMBINED = "org.eolang.jeo.A$B";
 
     @Test
     void appliesSuccessfully() {

--- a/src/test/java/org/eolang/jeo/improvement/ImprovementDistilledObjectsTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/ImprovementDistilledObjectsTest.java
@@ -46,6 +46,11 @@ final class ImprovementDistilledObjectsTest {
 
     /**
      * Name of the combined class.
+     * @todo #183:90min Use / instead of . in class names.
+     *  Currently we use . and / in different places for class names. It's much easier
+     *  to use just / everywhere, then we will be able to avoid the usage of the next statements:
+     *  ".replace('.', '/')" and ".replace('/', '.')" - now we have lot's of places where we use
+     *  them (~16 times).
      */
     private static final String COMBINED = "org.eolang.jeo.A$B";
 

--- a/src/test/java/org/eolang/jeo/improvement/ImprovementDistilledObjectsTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/ImprovementDistilledObjectsTest.java
@@ -47,7 +47,7 @@ final class ImprovementDistilledObjectsTest {
     /**
      * Name of the combined class.
      */
-    private static final String COMBINED = "org.eolang.jeo.AB";
+    private static final String COMBINED = "org/eolang/jeo/A$B";
 
     @Test
     void appliesSuccessfully() {
@@ -98,7 +98,7 @@ final class ImprovementDistilledObjectsTest {
                 combined
             ),
             combined,
-            new HasMethod("new").inside("org/eolang/jeo/AB")
+            new HasMethod("new").inside("org/eolang/jeo/A$B")
         );
     }
 


### PR DESCRIPTION
Use `DecoratorCompositionName` in `ImprovementDistilledObjects`.

Closes: #183.
____
History:
- feat(#183): remove newname method
- feat(#183): use DecoratorCompositionName in ImprovementDistilledObjects
- feat(#183): fix integration tests according with new naming strategy
- feat(#183): remove redundant replacements
- feat(#183): add one more puzzle for class names


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on improving the class naming convention by replacing "." with "/" in class names.

### Detailed summary:
- Replaced class name "org.eolang.jeo.AB" with "org.eolang.jeo.A$B" in multiple files.
- Updated comments to reflect the class name change.
- Modified code to use "/" instead of "." in class names.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->