### PR TITLE
feat(#174): refactor 'replaceConstructors' method and add XmlProgram

### DIFF
--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -109,8 +109,13 @@ public final class ImprovementDistilledObjects implements Improvement {
         final List<DecoratorPair> decorators,
         final Representation representation
     ) {
+//        final XML xmir = representation.toEO();
+//        new XmlProgram(xmir).topClass();
+//
+//        final XmlClass clazz = new XmlClass(xmir);
+
         final XML xmir = representation.toEO();
-        final XmlClass clazz = new XmlClass(xmir);
+        final XmlClass clazz = new XmlProgram(xmir).topClass();
         for (final DecoratorPair decorator : decorators) {
             ImprovementDistilledObjects.replace(
                 clazz,
@@ -134,25 +139,6 @@ public final class ImprovementDistilledObjects implements Improvement {
                 .withTopClass(clazz)
                 .toXMIR()
         );
-//
-//        for (int index = 0; index < top.getLength(); ++index) {
-//            final Node current = top.item(index);
-//            if (current.getNodeName().equals("program")) {
-//                final NodeList subchildren = current.getChildNodes();
-//                for (int indexnext = 0; indexnext < subchildren.getLength(); ++indexnext) {
-//                    final Node next = subchildren.item(indexnext);
-//                    if (next.getNodeName().equals("objects")) {
-//                        while (next.hasChildNodes()) {
-//                            next.removeChild(next.getFirstChild());
-//                        }
-//                        next.appendChild(
-//                            next.getOwnerDocument().adoptNode(replacement.cloneNode(true))
-//                        );
-//                    }
-//                }
-//            }
-//        }
-//        return new EoRepresentation(new XMLDocument(program));
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -100,20 +100,11 @@ public final class ImprovementDistilledObjects implements Improvement {
      * @param decorators Decorators.
      * @param representation Representation.
      * @return Representation with replaced constructors.
-     * @todo #161:90min Refactor replaceConstructors method.
-     *  Right now it's a big method with a lot of repetition and high complexity.
-     *  We have to simplify it and remove all linter warnings.
-     * @checkstyle NestedIfDepthCheck (200 lines)
      */
     private static Representation replaceConstructors(
-        final List<DecoratorPair> decorators,
+        final List<? extends DecoratorPair> decorators,
         final Representation representation
     ) {
-//        final XML xmir = representation.toEO();
-//        new XmlProgram(xmir).topClass();
-//
-//        final XmlClass clazz = new XmlClass(xmir);
-
         final XML xmir = representation.toEO();
         final XmlClass clazz = new XmlProgram(xmir).topClass();
         for (final DecoratorPair decorator : decorators) {
@@ -127,18 +118,9 @@ public final class ImprovementDistilledObjects implements Improvement {
                 decorator.targetSpecial(),
                 decorator.replacementSpecial()
             );
-            ImprovementDistilledObjects.replaceArguments(
-                clazz
-            );
+            ImprovementDistilledObjects.replaceArguments(clazz);
         }
-//        final Node replacement = clazz.node();
-//        final Node program = xmir.node();
-//        final NodeList top = program.getChildNodes();
-        return new EoRepresentation(
-            new XmlProgram(xmir)
-                .withTopClass(clazz)
-                .toXMIR()
-        );
+        return new EoRepresentation(new XmlProgram(xmir).withTopClass(clazz).toXMIR());
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -44,6 +44,7 @@ import org.eolang.jeo.representation.xmir.XmlClass;
 import org.eolang.jeo.representation.xmir.XmlField;
 import org.eolang.jeo.representation.xmir.XmlInstruction;
 import org.eolang.jeo.representation.xmir.XmlMethod;
+import org.eolang.jeo.representation.xmir.XmlProgram;
 import org.objectweb.asm.Opcodes;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
@@ -125,27 +126,33 @@ public final class ImprovementDistilledObjects implements Improvement {
                 clazz
             );
         }
-        final Node replacement = clazz.node();
-        final Node program = xmir.node();
-        final NodeList top = program.getChildNodes();
-        for (int index = 0; index < top.getLength(); ++index) {
-            final Node current = top.item(index);
-            if (current.getNodeName().equals("program")) {
-                final NodeList subchildren = current.getChildNodes();
-                for (int indexnext = 0; indexnext < subchildren.getLength(); ++indexnext) {
-                    final Node next = subchildren.item(indexnext);
-                    if (next.getNodeName().equals("objects")) {
-                        while (next.hasChildNodes()) {
-                            next.removeChild(next.getFirstChild());
-                        }
-                        next.appendChild(
-                            next.getOwnerDocument().adoptNode(replacement.cloneNode(true))
-                        );
-                    }
-                }
-            }
-        }
-        return new EoRepresentation(new XMLDocument(program));
+//        final Node replacement = clazz.node();
+//        final Node program = xmir.node();
+//        final NodeList top = program.getChildNodes();
+        return new EoRepresentation(
+            new XmlProgram(xmir)
+                .withTopClass(clazz)
+                .toXMIR()
+        );
+//
+//        for (int index = 0; index < top.getLength(); ++index) {
+//            final Node current = top.item(index);
+//            if (current.getNodeName().equals("program")) {
+//                final NodeList subchildren = current.getChildNodes();
+//                for (int indexnext = 0; indexnext < subchildren.getLength(); ++indexnext) {
+//                    final Node next = subchildren.item(indexnext);
+//                    if (next.getNodeName().equals("objects")) {
+//                        while (next.hasChildNodes()) {
+//                            next.removeChild(next.getFirstChild());
+//                        }
+//                        next.appendChild(
+//                            next.getOwnerDocument().adoptNode(replacement.cloneNode(true))
+//                        );
+//                    }
+//                }
+//            }
+//        }
+//        return new EoRepresentation(new XMLDocument(program));
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -435,8 +435,7 @@ public final class ImprovementDistilledObjects implements Improvement {
             final Document owner = root.getOwnerDocument();
             DecoratorPair.removeOldFields(root);
             DecoratorPair.removeOldConstructors(root);
-            final XML original = this.decorated.toEO();
-            final XmlClass clazz = new XmlClass(original);
+            final XmlClass clazz = new XmlProgram(this.decorated.toEO()).topClass();
             for (final XmlField field : clazz.fields()) {
                 root.appendChild(owner.adoptNode(field.node().cloneNode(true)));
             }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -120,7 +120,7 @@ public final class ImprovementDistilledObjects implements Improvement {
             );
             ImprovementDistilledObjects.replaceArguments(clazz);
         }
-        return new EoRepresentation(new XmlProgram(xmir).withTopClass(clazz).toXMIR());
+        return new EoRepresentation(new XmlProgram(xmir).withTopClass(clazz).toXmir());
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
@@ -52,7 +52,7 @@ public final class XmlBytecode {
      * @return Bytecode.
      */
     public Bytecode bytecode() {
-        final XmlClass clazz = new XmlClass(this.xml);
+        final XmlClass clazz = new XmlProgram(this.xml).topClass();
         final BytecodeClass bytecode = new BytecodeClass(
             clazz.name(),
             clazz.properties().toBytecodeProperties()

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -23,10 +23,8 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import com.jcabi.xml.XML;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.w3c.dom.Node;
@@ -43,14 +41,6 @@ public final class XmlClass {
      */
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     private final Node node;
-
-    /**
-     * Constructor.
-     * @param xml Entire XML.
-     */
-    public XmlClass(final XML xml) {
-        this(XmlClass.findClass(xml));
-    }
 
     /**
      * Constructor.
@@ -142,60 +132,5 @@ public final class XmlClass {
             }
         }
         return res.stream();
-    }
-
-    /**
-     * Find class node in entire XML.
-     * @param xml Entire XML.
-     * @return Class node.
-     */
-    private static Node findClass(final XML xml) {
-        final Node result;
-        final Node root = xml.node();
-        if (XmlClass.isClass(root)) {
-            result = root;
-        } else {
-            result = XmlClass.findClass(root)
-                .orElseThrow(
-                    () -> new IllegalStateException(
-                        String.format(
-                            "No top-level class found in '%s'",
-                            xml
-                        )
-                    )
-                );
-        }
-        return result;
-    }
-
-    /**
-     * Find class node in the current node.
-     * @param node Current node.
-     * @return Class node.
-     */
-    private static Optional<Node> findClass(final Node node) {
-        Optional<Node> res = Optional.empty();
-        if (XmlClass.isClass(node)) {
-            res = Optional.of(node);
-        } else {
-            final NodeList children = node.getChildNodes();
-            for (int index = 0; index < children.getLength(); ++index) {
-                final Optional<Node> child = XmlClass.findClass(children.item(index));
-                if (child.isPresent()) {
-                    res = child;
-                }
-            }
-        }
-        return res;
-    }
-
-    /**
-     * Check if the node is a class.
-     * @param node Node.
-     * @return True if the node is a class.
-     */
-    private static boolean isClass(final Node node) {
-        return node.getNodeName().equals("o")
-            && node.getParentNode().getNodeName().equals("objects");
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -2,6 +2,7 @@ package org.eolang.jeo.representation.xmir;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
+import java.util.Optional;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -13,14 +14,26 @@ public class XmlProgram {
         this(xml.node());
     }
 
-    public XmlProgram(final Node root) {
+    private XmlProgram(final Node root) {
         this.root = root;
     }
 
-    XmlClass topClass() {
-
-
-        return null;
+    public XmlClass topClass() {
+        final Node result;
+        if (XmlProgram.isClass(this.root)) {
+            result = this.root;
+        } else {
+            result = XmlProgram.findClass(this.root)
+                .orElseThrow(
+                    () -> new IllegalStateException(
+                        String.format(
+                            "No top-level class found in '%s'",
+                            this.root
+                        )
+                    )
+                );
+        }
+        return new XmlClass(result);
     }
 
     public XmlProgram withTopClass(XmlClass clazz) {
@@ -47,6 +60,63 @@ public class XmlProgram {
 
     public XML toXMIR() {
         return new XMLDocument(this.root);
+    }
+
+
+    /**
+     * Find class node in entire XML.
+     * @param xml Entire XML.
+     * @return Class node.
+     */
+    private static Node findClass(final XML xml) {
+        final Node result;
+        final Node root = xml.node();
+        if (XmlProgram.isClass(root)) {
+            result = root;
+        } else {
+            result = XmlProgram.findClass(root)
+                .orElseThrow(
+                    () -> new IllegalStateException(
+                        String.format(
+                            "No top-level class found in '%s'",
+                            xml
+                        )
+                    )
+                );
+        }
+        return result;
+    }
+
+    /**
+     * Find class node in the current node.
+     * @param node Current node.
+     * @return Class node.
+     */
+    private static Optional<Node> findClass(final Node node) {
+        Optional<Node> res = Optional.empty();
+        if (XmlProgram.isClass(node)) {
+            res = Optional.of(node);
+        } else {
+            final NodeList children = node.getChildNodes();
+            for (int index = 0; index < children.getLength(); ++index) {
+                final Optional<Node> child = XmlProgram.findClass(children.item(index));
+                if (child.isPresent()) {
+                    res = child;
+                }
+            }
+        }
+        return res;
+    }
+
+
+    /**
+     * Check if the node is a class.
+     * @param node Node.
+     * @return True if the node is a class.
+     */
+    private static boolean isClass(final Node node) {
+        return node.getNodeName().equals("o")
+            && node.getParentNode().getNodeName().equals("objects");
     }
 
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.xmir;
 
 import com.jcabi.xml.XML;
@@ -6,18 +29,34 @@ import java.util.Optional;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+/**
+ * XMIR Program.
+ * @since 0.1
+ */
 public class XmlProgram {
 
     private final Node root;
 
+    /**
+     * Constructor.
+     * @param xml Raw XMIR.
+     */
     public XmlProgram(XML xml) {
         this(xml.node());
     }
 
+    /**
+     * Constructor.
+     * @param root Root node.
+     */
     private XmlProgram(final Node root) {
         this.root = root;
     }
 
+    /**
+     * Find top-level class.
+     * @return Class.
+     */
     public XmlClass topClass() {
         final Node result;
         if (XmlProgram.isClass(this.root)) {
@@ -36,8 +75,14 @@ public class XmlProgram {
         return new XmlClass(result);
     }
 
+    /**
+     * Set top-level class and return new XmlProgram.
+     * @param clazz Class.
+     * @return New XmlProgram.
+     */
     public XmlProgram withTopClass(XmlClass clazz) {
-        final NodeList top = this.root.getChildNodes();
+        final Node res = new XMLDocument(this.root).node();
+        final NodeList top = res.getChildNodes();
         for (int index = 0; index < top.getLength(); ++index) {
             final Node current = top.item(index);
             if (current.getNodeName().equals("program")) {
@@ -55,36 +100,15 @@ public class XmlProgram {
                 }
             }
         }
-        return this;
+        return new XmlProgram(res);
     }
-
-    public XML toXMIR() {
-        return new XMLDocument(this.root);
-    }
-
 
     /**
-     * Find class node in entire XML.
-     * @param xml Entire XML.
-     * @return Class node.
+     * Convert to XMIR .
+     * @return XMIR.
      */
-    private static Node findClass(final XML xml) {
-        final Node result;
-        final Node root = xml.node();
-        if (XmlProgram.isClass(root)) {
-            result = root;
-        } else {
-            result = XmlProgram.findClass(root)
-                .orElseThrow(
-                    () -> new IllegalStateException(
-                        String.format(
-                            "No top-level class found in '%s'",
-                            xml
-                        )
-                    )
-                );
-        }
-        return result;
+    public XML toXMIR() {
+        return new XMLDocument(this.root);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -1,0 +1,52 @@
+package org.eolang.jeo.representation.xmir;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class XmlProgram {
+
+    private final Node root;
+
+    public XmlProgram(XML xml) {
+        this(xml.node());
+    }
+
+    public XmlProgram(final Node root) {
+        this.root = root;
+    }
+
+    XmlClass topClass() {
+
+
+        return null;
+    }
+
+    public XmlProgram withTopClass(XmlClass clazz) {
+        final NodeList top = this.root.getChildNodes();
+        for (int index = 0; index < top.getLength(); ++index) {
+            final Node current = top.item(index);
+            if (current.getNodeName().equals("program")) {
+                final NodeList subchildren = current.getChildNodes();
+                for (int indexnext = 0; indexnext < subchildren.getLength(); ++indexnext) {
+                    final Node next = subchildren.item(indexnext);
+                    if (next.getNodeName().equals("objects")) {
+                        while (next.hasChildNodes()) {
+                            next.removeChild(next.getFirstChild());
+                        }
+                        next.appendChild(
+                            next.getOwnerDocument().adoptNode(clazz.node().cloneNode(true))
+                        );
+                    }
+                }
+            }
+        }
+        return this;
+    }
+
+    public XML toXMIR() {
+        return new XMLDocument(this.root);
+    }
+
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -32,16 +32,25 @@ import org.w3c.dom.NodeList;
 /**
  * XMIR Program.
  * @since 0.1
+ * @todo #174:90min Add unit tests for XmlProgram.
+ *  Currently we don't have unit tests for XmlProgram. So, it makes sense to add
+ *  them to keep code safe and clear.
+ * @todo #174:90min Refactor XmlProgram.
+ *  Currently some methods of XmlProgram have high code complexity. It makes sense to
+ *  simplify this code in order to make it more readable and maintainable.
  */
 public class XmlProgram {
 
+    /**
+     * Root node.
+     */
     private final Node root;
 
     /**
      * Constructor.
      * @param xml Raw XMIR.
      */
-    public XmlProgram(XML xml) {
+    public XmlProgram(final XML xml) {
         this(xml.node());
     }
 
@@ -80,7 +89,7 @@ public class XmlProgram {
      * @param clazz Class.
      * @return New XmlProgram.
      */
-    public XmlProgram withTopClass(XmlClass clazz) {
+    public XmlProgram withTopClass(final XmlClass clazz) {
         final Node res = new XMLDocument(this.root).node();
         final NodeList top = res.getChildNodes();
         for (int index = 0; index < top.getLength(); ++index) {
@@ -107,7 +116,7 @@ public class XmlProgram {
      * Convert to XMIR .
      * @return XMIR.
      */
-    public XML toXMIR() {
+    public XML toXmir() {
         return new XMLDocument(this.root);
     }
 
@@ -132,7 +141,6 @@ public class XmlProgram {
         return res;
     }
 
-
     /**
      * Check if the node is a class.
      * @param node Node.
@@ -142,5 +150,4 @@ public class XmlProgram {
         return node.getNodeName().equals("o")
             && node.getParentNode().getNodeName().equals("objects");
     }
-
 }


### PR DESCRIPTION
Add `XmlProgram` class and refactor `replaaceConstructors` method.

Closes: #174.
____
History:
- feat(#174): add XmlProgram class
- feat(#174): move findClass method into XmlProgram
- feat(#174): remove puzzle for 174 issue
- feat(#174): use XmlProgram in XmlBytecode
- feat(#174): remove redundant code from XmlClass
- feat(#174): return XmlProgram copy when set top level class
- feat(#174): add more puzzles


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the code related to XMIR representation in the project. 

### Detailed summary
- Introduced a new class `XmlProgram` to handle XMIR programs.
- Replaced the usage of `XmlClass` with `XmlProgram` in various places.
- Simplified and optimized the code related to finding and replacing constructors in XMIR programs.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->