### PR TITLE
feat(#190): Replace periods with slashes in class names

### DIFF
--- a/src/main/java/org/eolang/jeo/improvement/DecoratorCompositionName.java
+++ b/src/main/java/org/eolang/jeo/improvement/DecoratorCompositionName.java
@@ -32,17 +32,13 @@ import org.eolang.jeo.representation.HexData;
  * <ul>
  *     <li>decorated: A, decorator: B => name: A$B</li>
  *     <li>decorated: Foo, decorator: Bar => name: Foo$Bar</li>
- *     <li>decorated: org.eolang.Foo, decorator: org.eolang.Bar => name: org/eolang/Foo$Bar</li>
- *     <li>decorated: a.Foo, decorator: b.Bar => name: b/Foo$Bar</li>
+ *     <li>decorated: org/eolang/Foo, decorator: org/eolang/Bar => name: org/eolang/Foo$Bar</li>
+ *     <li>decorated: a/Foo, decorator: b/Bar => name: b/Foo$Bar</li>
  * </ul>
  * Pay attention that we replace periods with slashes. This class also can convert the final name
  * into hexadecimal representation.
  * @since 0.1
- * @todo #163:30min Replace newname method usage with DecoratorCompositionName.
- *  Right now we use {@link ImprovementDistilledObjects.DecoratorPair#newname()} method
- *  in {@link ImprovementDistilledObjects} class. We should use {@link DecoratorCompositionName}
- *  instead. Don't forget to remove the old method from {@link ImprovementDistilledObjects} class.
- */
+ * */
 final class DecoratorCompositionName {
 
     /**
@@ -76,17 +72,17 @@ final class DecoratorCompositionName {
         final String left = this.decorated.name();
         final String right = this.decorator.name();
         final String prefix;
-        if (right.contains(".")) {
-            prefix = right.substring(0, right.lastIndexOf('.') + 1);
+        if (right.contains("/")) {
+            prefix = right.substring(0, right.lastIndexOf('/') + 1);
         } else {
             prefix = "";
         }
         return String.format(
             "%s%s$%s",
             prefix,
-            left.substring(left.lastIndexOf('.') + 1),
-            right.substring(right.lastIndexOf('.') + 1)
-        ).replace('.', '/');
+            left.substring(left.lastIndexOf('/') + 1),
+            right.substring(right.lastIndexOf('/') + 1)
+        );
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/improvement/DecoratorCompositionName.java
+++ b/src/main/java/org/eolang/jeo/improvement/DecoratorCompositionName.java
@@ -38,7 +38,7 @@ import org.eolang.jeo.representation.HexData;
  * Pay attention that we replace periods with slashes. This class also can convert the final name
  * into hexadecimal representation.
  * @since 0.1
- * */
+ */
 final class DecoratorCompositionName {
 
     /**

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -393,7 +393,7 @@ public final class ImprovementDistilledObjects implements Improvement {
             final List<XML> roots = decor.nodes("/program");
             final Node root = roots.get(0).node();
             final NamedNodeMap attributes = root.getAttributes();
-            attributes.getNamedItem("name").setNodeValue(name.replace('/', '.'));
+            attributes.getNamedItem("name").setNodeValue(name);
             attributes.getNamedItem("time").setTextContent(
                 LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME)
             );

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -250,7 +250,7 @@ public final class ImprovementDistilledObjects implements Improvement {
                 new StringBuilder()
                     .append("<o base=\"opcode\" name=\"NEW-187-50\">")
                     .append("<o base=\"string\" data=\"bytes\">")
-                    .append(new HexData(firstname.replace('.', '/')).value())
+                    .append(new HexData(firstname).value())
                     .append("</o>")
                     .append("</o>")
                     .toString()
@@ -260,7 +260,7 @@ public final class ImprovementDistilledObjects implements Improvement {
                 new StringBuilder()
                     .append("<o base=\"opcode\" name=\"NEW-187-50\">")
                     .append("<o base=\"string\" data=\"bytes\">")
-                    .append(new HexData(secondname.replace('.', '/')).value())
+                    .append(new HexData(secondname).value())
                     .append("</o>")
                     .append("</o>")
                     .toString()
@@ -310,7 +310,7 @@ public final class ImprovementDistilledObjects implements Improvement {
                         new StringBuilder()
                             .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">")
                             .append("<o base=\"string\" data=\"bytes\">")
-                            .append(new HexData(this.decorated.name().replace('.', '/')).value())
+                            .append(new HexData(this.decorated.name()).value())
                             .append("</o>")
                             .append("<o base=\"string\" data=\"bytes\">")
                             .append(new HexData("<init>").value())
@@ -327,7 +327,7 @@ public final class ImprovementDistilledObjects implements Improvement {
                         new StringBuilder()
                             .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">")
                             .append("<o base=\"string\" data=\"bytes\">")
-                            .append(new HexData(this.decorator.name().replace('.', '/')).value())
+                            .append(new HexData(this.decorator.name()).value())
                             .append("</o>")
                             .append("<o base=\"string\" data=\"bytes\">")
                             .append(new HexData("<init>").value())
@@ -454,7 +454,7 @@ public final class ImprovementDistilledObjects implements Improvement {
                                     for (int inst = 0; inst < instructions.getLength(); ++inst) {
                                         DecoratorPair.replaceArguments(
                                             instructions.item(inst),
-                                            this.decorated.name().replace('.', '/'),
+                                            this.decorated.name(),
                                             bytename
                                         );
                                     }
@@ -512,7 +512,7 @@ public final class ImprovementDistilledObjects implements Improvement {
             final String bytename
         ) {
             final List<XmlMethod> methods = new XmlClass(clazz).methods();
-            final String old = this.decorated.name().replace('.', '/');
+            final String old = this.decorated.name();
             for (final XmlMethod candidate : methods) {
                 final List<XmlInstruction> instructions = candidate.instructions();
                 final List<XmlInstruction> res = new ArrayList<>(0);

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementEoFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementEoFootprint.java
@@ -74,7 +74,7 @@ public final class ImprovementEoFootprint implements Improvement {
     private void tryToSave(final Representation representation) {
         final String name = representation.name();
         final Path path = this.target.resolve(new EoDefaultDirectory().toPath())
-            .resolve(String.format("%s.xmir", name.replace('.', File.separatorChar)));
+            .resolve(String.format("%s.xmir", name.replace('/', File.separatorChar)));
         try {
             Files.createDirectories(path.getParent());
             Files.write(

--- a/src/main/java/org/eolang/jeo/representation/ClassName.java
+++ b/src/main/java/org/eolang/jeo/representation/ClassName.java
@@ -73,7 +73,7 @@ public final class ClassName extends ClassVisitor {
         final String supername,
         final String[] interfaces
     ) {
-        this.bag.set(name.replace('/', '.'));
+        this.bag.set(name);
         super.visit(version, access, name, signature, supername, interfaces);
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -80,7 +80,7 @@ public final class BytecodeClass {
      * @param access Access modifiers.
      */
     public BytecodeClass(final String name, final int access) {
-        this(name.replace(".", "/"), access, new ClassWriter(ClassWriter.COMPUTE_FRAMES));
+        this(name, access, new ClassWriter(ClassWriter.COMPUTE_FRAMES));
     }
 
     /**
@@ -90,7 +90,7 @@ public final class BytecodeClass {
      */
     public BytecodeClass(final String name, final BytecodeClassProperties properties) {
         this(
-            name.replace(".", "/"),
+            name,
             new ClassWriter(ClassWriter.COMPUTE_FRAMES),
             new ArrayList<>(0),
             properties

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -105,7 +105,7 @@ public final class DirectivesClass extends ClassVisitor implements Iterable<Dire
         final String now = ZonedDateTime.now(ZoneOffset.UTC)
             .format(DateTimeFormatter.ISO_INSTANT);
         this.directives.add("program")
-            .attr("name", name.replace('/', '.'))
+            .attr("name", name)
             .attr("version", "0.0.0")
             .attr("revision", "0.0.0")
             .attr("dob", now)

--- a/src/test/java/org/eolang/jeo/improvement/DecoratorCompositionNameTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/DecoratorCompositionNameTest.java
@@ -39,8 +39,8 @@ class DecoratorCompositionNameTest {
     @CsvSource({
         "A, B, A$B",
         "Foo, Bar, Foo$Bar",
-        "org.eolang.A, org.eolang.B, org/eolang/A$B",
-        "a.Foo, b.Bar, b/Foo$Bar"
+        "org/eolang/A, org/eolang/B, org/eolang/A$B",
+        "a/Foo, b/Bar, b/Foo$Bar"
     })
     void retrivesCombinedName(
         final String decorated,
@@ -68,8 +68,8 @@ class DecoratorCompositionNameTest {
     @CsvSource({
         "A, B, 41 24 42",
         "Foo, Bar, 46 6F 6F 24 42 61 72",
-        "org.eolang.A, org.eolang.B, 6F 72 67 2F 65 6F 6C 61 6E 67 2F 41 24 42",
-        "a.Foo, b.Bar, 62 2F 46 6F 6F 24 42 61 72"
+        "org/eolang/A, org/eolang/B, 6F 72 67 2F 65 6F 6C 61 6E 67 2F 41 24 42",
+        "a/Foo, b/Bar, 62 2F 46 6F 6F 24 42 61 72"
     })
     void retrievesHexDecimalRepresentation(
         final String decorated,

--- a/src/test/java/org/eolang/jeo/improvement/ImprovementBytecodeFootprintTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/ImprovementBytecodeFootprintTest.java
@@ -41,7 +41,7 @@ class ImprovementBytecodeFootprintTest {
 
     @Test
     void appliesSuccessfully(@TempDir final Path temp) {
-        final String expected = "jeo.xmir.Fake";
+        final String expected = "jeo/xmir/Fake";
         new ImprovementBytecodeFootprint(temp).apply(
             Collections.singleton(new EoRepresentation(new BytecodeClass(expected).xml()))
         );

--- a/src/test/java/org/eolang/jeo/improvement/ImprovementDistilledObjectsTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/ImprovementDistilledObjectsTest.java
@@ -52,7 +52,7 @@ final class ImprovementDistilledObjectsTest {
      *  ".replace('.', '/')" and ".replace('/', '.')" - now we have lot's of places where we use
      *  them (~16 times).
      */
-    private static final String COMBINED = "org.eolang.jeo.A$B";
+    private static final String COMBINED = "org/eolang/jeo/A$B";
 
     @Test
     void appliesSuccessfully() {
@@ -103,7 +103,7 @@ final class ImprovementDistilledObjectsTest {
                 combined
             ),
             combined,
-            new HasMethod("new").inside("org/eolang/jeo/A$B")
+            new HasMethod("new").inside(ImprovementDistilledObjectsTest.COMBINED)
         );
     }
 

--- a/src/test/java/org/eolang/jeo/improvement/ImprovementDistilledObjectsTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/ImprovementDistilledObjectsTest.java
@@ -46,11 +46,6 @@ final class ImprovementDistilledObjectsTest {
 
     /**
      * Name of the combined class.
-     * @todo #183:90min Use / instead of . in class names.
-     *  Currently we use . and / in different places for class names. It's much easier
-     *  to use just / everywhere, then we will be able to avoid the usage of the next statements:
-     *  ".replace('.', '/')" and ".replace('/', '.')" - now we have lot's of places where we use
-     *  them (~16 times).
      */
     private static final String COMBINED = "org/eolang/jeo/A$B";
 

--- a/src/test/java/org/eolang/jeo/improvement/ImprovementEoFootprintTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/ImprovementEoFootprintTest.java
@@ -45,7 +45,7 @@ final class ImprovementEoFootprintTest {
         footprint.apply(
             Collections.singleton(
                 new EoRepresentation(
-                    new BytecodeClass("org.eolang.jeo.Application").xml()
+                    new BytecodeClass("org/eolang/jeo/Application").xml()
                 )
             )
         );

--- a/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
@@ -49,7 +49,7 @@ final class BytecodeRepresentationTest {
             "The simplest class should contain the object with MethodByte name",
             new BytecodeRepresentation(new ResourceOf(BytecodeRepresentationTest.METHOD_BYTE))
                 .toEO().xpath("/program/@name").get(0),
-            Matchers.equalTo("org.eolang.jeo.MethodByte")
+            Matchers.equalTo("org/eolang/jeo/MethodByte")
         );
     }
 
@@ -69,7 +69,7 @@ final class BytecodeRepresentationTest {
     void retrievesName() {
         final ResourceOf input = new ResourceOf(BytecodeRepresentationTest.METHOD_BYTE);
         final String actual = new BytecodeRepresentation(input).name();
-        final String expected = "org.eolang.jeo.MethodByte";
+        final String expected = "org/eolang/jeo/MethodByte";
         MatcherAssert.assertThat(
             String.format(
                 "The name should be retrieved without exceptions and equal to the expected '%s'",

--- a/src/test/java/org/eolang/jeo/representation/ClassNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/ClassNameTest.java
@@ -38,12 +38,13 @@ class ClassNameTest {
     @Test
     void retrievesClassName() {
         final ClassName name = new ClassName();
-        new ClassReader(new BytecodeClass("representation/asm/ClassNameTest").bytecode().asBytes())
+        final String expected = "representation/asm/ClassNameTest";
+        new ClassReader(new BytecodeClass(expected).bytecode().asBytes())
             .accept(name, 0);
         MatcherAssert.assertThat(
             "Can't retrieve class name, or it's incorrect",
             name.asString(),
-            Matchers.equalTo("representation.asm.ClassNameTest")
+            Matchers.equalTo(expected)
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/EoRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/EoRepresentationTest.java
@@ -45,7 +45,7 @@ class EoRepresentationTest {
 
     @Test
     void retrievesName() {
-        final String expected = "org.eolang.foo.Math";
+        final String expected = "org/eolang/foo/Math";
         final String actual = new EoRepresentation(new BytecodeClass(expected).xml()).name();
         MatcherAssert.assertThat(
             String.format(
@@ -62,8 +62,8 @@ class EoRepresentationTest {
     void returnsXmlRepresentationOfEo() {
         MatcherAssert.assertThat(
             "The XML representation of the EO object is not correct",
-            new EoRepresentation(new BytecodeClass("org.eolang.foo.Math").xml()).toEO(),
-            XhtmlMatchers.hasXPath("/program[@name='org.eolang.foo.Math']")
+            new EoRepresentation(new BytecodeClass("org/eolang/foo/Math").xml()).toEO(),
+            XhtmlMatchers.hasXPath("/program[@name='org/eolang/foo/Math']")
         );
     }
 


### PR DESCRIPTION
Replace all periods from class names and replace them with slashes.

Closes: #190.
____
History:
- feat(#190): remove all replacements from slash to period
- feat(#190): fix all unit tests
- feat(#190): replace all the unnesessary replacements
- feat(#190): remove the puzzle for 190 issue


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on replacing periods with slashes in class names. 

### Detailed summary
- Replaces periods with slashes in class names in multiple files.
- Updates class names in method invocations and XML representations.
- Uses `DecoratorCompositionName` for generating combined class names.
- Removes unnecessary `replace` method in `ImprovementDistilledObjects` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->