### PR TITLE
feat(#193): Refactor XmlProgram Class

### DIFF
--- a/src/it/distilled/invoker.properties
+++ b/src/it/distilled/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = clean process-classes
+invoker.goals = clean process-classes -e

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -375,13 +375,13 @@ public final class ImprovementDistilledObjects implements Improvement {
          * @return Combined representation.
          */
         private Representation combine() {
-            final XML skeleton = this.skeleton(
-                this.decorator.toEO(),
-                new DecoratorCompositionName(this.decorated, this.decorator).value()
-            );
-            Logger.info(this, String.format("Skeleton is created %s", skeleton));
             return new EoRepresentation(
-              new XMLDocument(skeleton.toString())
+                new XMLDocument(
+                    this.skeleton(
+                        this.decorator.toEO(),
+                        new DecoratorCompositionName(this.decorated, this.decorator).value()
+                    ).toString()
+                )
             );
         }
 

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -106,7 +106,7 @@ public final class ImprovementDistilledObjects implements Improvement {
         final Representation representation
     ) {
         final XML xmir = representation.toEO();
-        final XmlClass clazz = new XmlProgram(xmir).topClass();
+        final XmlClass clazz = new XmlProgram(xmir).top();
         for (final DecoratorPair decorator : decorators) {
             ImprovementDistilledObjects.replace(
                 clazz,
@@ -120,7 +120,7 @@ public final class ImprovementDistilledObjects implements Improvement {
             );
             ImprovementDistilledObjects.replaceArguments(clazz);
         }
-        return new EoRepresentation(new XmlProgram(xmir).withTopClass(clazz).toXmir());
+        return new EoRepresentation(new XmlProgram(xmir).with(clazz).toXmir());
     }
 
     /**
@@ -435,7 +435,7 @@ public final class ImprovementDistilledObjects implements Improvement {
             final Document owner = root.getOwnerDocument();
             DecoratorPair.removeOldFields(root);
             DecoratorPair.removeOldConstructors(root);
-            final XmlClass clazz = new XmlProgram(this.decorated.toEO()).topClass();
+            final XmlClass clazz = new XmlProgram(this.decorated.toEO()).top();
             for (final XmlField field : clazz.fields()) {
                 root.appendChild(owner.adoptNode(field.node().cloneNode(true)));
             }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -375,11 +375,13 @@ public final class ImprovementDistilledObjects implements Improvement {
          * @return Combined representation.
          */
         private Representation combine() {
+            final XML skeleton = this.skeleton(
+                this.decorator.toEO(),
+                new DecoratorCompositionName(this.decorated, this.decorator).value()
+            );
+            Logger.info(this, String.format("Skeleton is created %s", skeleton));
             return new EoRepresentation(
-                this.skeleton(
-                    this.decorator.toEO(),
-                    new DecoratorCompositionName(this.decorated, this.decorator).value()
-                )
+              new XMLDocument(skeleton.toString())
             );
         }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
@@ -52,7 +52,7 @@ public final class XmlBytecode {
      * @return Bytecode.
      */
     public Bytecode bytecode() {
-        final XmlClass clazz = new XmlProgram(this.xml).topClass();
+        final XmlClass clazz = new XmlProgram(this.xml).top();
         final BytecodeClass bytecode = new BytecodeClass(
             clazz.name(),
             clazz.properties().toBytecodeProperties()

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -1,0 +1,57 @@
+package org.eolang.jeo.representation.xmir;
+
+import com.jcabi.xml.XMLDocument;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * XML smart element.
+ */
+final class XmlNode {
+
+    /**
+     * Parent node.
+     */
+    private final Node node;
+
+    public XmlNode(final Node parent) {
+        this.node = parent;
+    }
+
+    XmlNode child(final String name) {
+        final NodeList children = this.node.getChildNodes();
+        for (int index = 0; index < children.getLength(); ++index) {
+            final Node current = children.item(index);
+            if (current.getNodeName().equals(name)) {
+                return new XmlNode(current);
+            }
+        }
+        throw this.notFound(name);
+    }
+
+    XmlClass toClass() {
+        return new XmlClass(this.node);
+    }
+
+    XmlNode clean() {
+        while (this.node.hasChildNodes()) {
+            this.node.removeChild(this.node.getFirstChild());
+        }
+        return this;
+    }
+
+    XmlNode append(final Node node) {
+        this.node.appendChild(this.node.getOwnerDocument().adoptNode(node.cloneNode(true)));
+        return this;
+    }
+
+    private IllegalStateException notFound(final String name) {
+        return new IllegalStateException(
+            String.format(
+                "Can't find '%s' element in '%s'",
+                name,
+                new XMLDocument(this.node)
+            )
+        );
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.xmir;
 
 import com.jcabi.xml.XMLDocument;
@@ -6,6 +29,11 @@ import org.w3c.dom.NodeList;
 
 /**
  * XML smart element.
+ * Utility class that simplifies work with XML.
+ * @since 0.1
+ * @todo #193:90min Add unit tests for XmlNode.
+ *  Currently we don't have unit tests for XmlNode. So, it makes sense to add
+ *  them to keep code safe and clear.
  */
 final class XmlNode {
 
@@ -14,10 +42,19 @@ final class XmlNode {
      */
     private final Node node;
 
-    public XmlNode(final Node parent) {
+    /**
+     * Constructor.
+     * @param parent Parent node.
+     */
+    XmlNode(final Node parent) {
         this.node = parent;
     }
 
+    /**
+     * Get child node.
+     * @param name Child node name.
+     * @return Child node.
+     */
     XmlNode child(final String name) {
         final NodeList children = this.node.getChildNodes();
         for (int index = 0; index < children.getLength(); ++index) {
@@ -29,10 +66,18 @@ final class XmlNode {
         throw this.notFound(name);
     }
 
+    /**
+     * Convert to class.
+     * @return Class.
+     */
     XmlClass toClass() {
         return new XmlClass(this.node);
     }
 
+    /**
+     * Clean all child nodes.
+     * @return The same node.
+     */
     XmlNode clean() {
         while (this.node.hasChildNodes()) {
             this.node.removeChild(this.node.getFirstChild());
@@ -40,11 +85,21 @@ final class XmlNode {
         return this;
     }
 
-    XmlNode append(final Node node) {
-        this.node.appendChild(this.node.getOwnerDocument().adoptNode(node.cloneNode(true)));
+    /**
+     * Append child node.
+     * @param child Node to append.
+     * @return The same node.
+     */
+    XmlNode append(final Node child) {
+        this.node.appendChild(this.node.getOwnerDocument().adoptNode(child.cloneNode(true)));
         return this;
     }
 
+    /**
+     * Generate exception if element not found.
+     * @param name Element name.
+     * @return Exception.
+     */
     private IllegalStateException notFound(final String name) {
         return new IllegalStateException(
             String.format(

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -67,7 +67,12 @@ public class XmlProgram {
      * @return Class.
      */
     public XmlClass top() {
-        return new XmlClass(XmlProgram.findClass(this.root).orElseThrow(this::notFound));
+        return new XmlNode(this.root)
+            .child("program")
+            .child("objects")
+            .child("o")
+            .toClass();
+//        return new XmlClass(XmlProgram.findClass(this.root).orElseThrow(this::notFound));
     }
 
     /**
@@ -77,25 +82,43 @@ public class XmlProgram {
      */
     public XmlProgram with(final XmlClass clazz) {
         final Node res = new XMLDocument(this.root).node();
-        final NodeList top = res.getChildNodes();
-        for (int index = 0; index < top.getLength(); ++index) {
-            final Node current = top.item(index);
-            if (current.getNodeName().equals("program")) {
-                final NodeList subchildren = current.getChildNodes();
-                for (int indexnext = 0; indexnext < subchildren.getLength(); ++indexnext) {
-                    final Node next = subchildren.item(indexnext);
-                    if (next.getNodeName().equals("objects")) {
-                        while (next.hasChildNodes()) {
-                            next.removeChild(next.getFirstChild());
-                        }
-                        next.appendChild(
-                            next.getOwnerDocument().adoptNode(clazz.node().cloneNode(true))
-                        );
-                    }
-                }
-            }
-        }
+        new XmlNode(res)
+            .child("program")
+            .child("objects")
+            .clean()
+            .append(clazz.node());
         return new XmlProgram(res);
+
+//        final Node next = new XmlNode(
+//            new XmlNode(res, "program").child(),
+//            "objects"
+//        ).child();
+//
+//        while (next.hasChildNodes()) {
+//            next.removeChild(next.getFirstChild());
+//        }
+//        next.appendChild(
+//            next.getOwnerDocument().adoptNode(clazz.node().cloneNode(true))
+//        );
+//
+//        final NodeList top = res.getChildNodes();
+//        for (int index = 0; index < top.getLength(); ++index) {
+//            final Node current = top.item(index);
+//            if (current.getNodeName().equals("program")) {
+//                final NodeList subchildren = current.getChildNodes();
+//                for (int indexnext = 0; indexnext < subchildren.getLength(); ++indexnext) {
+//                    final Node next = subchildren.item(indexnext);
+//                    if (next.getNodeName().equals("objects")) {
+//                        while (next.hasChildNodes()) {
+//                            next.removeChild(next.getFirstChild());
+//                        }
+//                        next.appendChild(
+//                            next.getOwnerDocument().adoptNode(clazz.node().cloneNode(true))
+//                        );
+//                    }
+//                }
+//            }
+//        }
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -25,9 +25,7 @@ package org.eolang.jeo.representation.xmir;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
-import java.util.Optional;
 import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
  * XMIR Program.
@@ -35,9 +33,6 @@ import org.w3c.dom.NodeList;
  * @todo #174:90min Add unit tests for XmlProgram.
  *  Currently we don't have unit tests for XmlProgram. So, it makes sense to add
  *  them to keep code safe and clear.
- * @todo #174:90min Refactor XmlProgram.
- *  Currently some methods of XmlProgram have high code complexity. It makes sense to
- *  simplify this code in order to make it more readable and maintainable.
  */
 public class XmlProgram {
 
@@ -72,7 +67,6 @@ public class XmlProgram {
             .child("objects")
             .child("o")
             .toClass();
-//        return new XmlClass(XmlProgram.findClass(this.root).orElseThrow(this::notFound));
     }
 
     /**
@@ -88,37 +82,6 @@ public class XmlProgram {
             .clean()
             .append(clazz.node());
         return new XmlProgram(res);
-
-//        final Node next = new XmlNode(
-//            new XmlNode(res, "program").child(),
-//            "objects"
-//        ).child();
-//
-//        while (next.hasChildNodes()) {
-//            next.removeChild(next.getFirstChild());
-//        }
-//        next.appendChild(
-//            next.getOwnerDocument().adoptNode(clazz.node().cloneNode(true))
-//        );
-//
-//        final NodeList top = res.getChildNodes();
-//        for (int index = 0; index < top.getLength(); ++index) {
-//            final Node current = top.item(index);
-//            if (current.getNodeName().equals("program")) {
-//                final NodeList subchildren = current.getChildNodes();
-//                for (int indexnext = 0; indexnext < subchildren.getLength(); ++indexnext) {
-//                    final Node next = subchildren.item(indexnext);
-//                    if (next.getNodeName().equals("objects")) {
-//                        while (next.hasChildNodes()) {
-//                            next.removeChild(next.getFirstChild());
-//                        }
-//                        next.appendChild(
-//                            next.getOwnerDocument().adoptNode(clazz.node().cloneNode(true))
-//                        );
-//                    }
-//                }
-//            }
-//        }
     }
 
     /**
@@ -127,49 +90,5 @@ public class XmlProgram {
      */
     public XML toXmir() {
         return new XMLDocument(this.root);
-    }
-
-    /**
-     * Find class node in the current node.
-     * @param node Current node.
-     * @return Class node.
-     */
-    private static Optional<Node> findClass(final Node node) {
-        Optional<Node> res = Optional.empty();
-        if (XmlProgram.isClass(node)) {
-            res = Optional.of(node);
-        } else {
-            final NodeList children = node.getChildNodes();
-            for (int index = 0; index < children.getLength(); ++index) {
-                final Optional<Node> child = XmlProgram.findClass(children.item(index));
-                if (child.isPresent()) {
-                    res = child;
-                }
-            }
-        }
-        return res;
-    }
-
-    /**
-     * Check if the node is a class.
-     * @param node Node.
-     * @return True if the node is a class.
-     */
-    private static boolean isClass(final Node node) {
-        return node.getNodeName().equals("o")
-            && node.getParentNode().getNodeName().equals("objects");
-    }
-
-    /**
-     * Create exception if top-level class wasn't found.
-     * @return IllegalStateException exception.
-     */
-    private IllegalStateException notFound() {
-        return new IllegalStateException(
-            String.format(
-                "No top-level class found in '%s'",
-                this.root
-            )
-        );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -66,22 +66,8 @@ public class XmlProgram {
      * Find top-level class.
      * @return Class.
      */
-    public XmlClass topClass() {
-        final Node result;
-        if (XmlProgram.isClass(this.root)) {
-            result = this.root;
-        } else {
-            result = XmlProgram.findClass(this.root)
-                .orElseThrow(
-                    () -> new IllegalStateException(
-                        String.format(
-                            "No top-level class found in '%s'",
-                            this.root
-                        )
-                    )
-                );
-        }
-        return new XmlClass(result);
+    public XmlClass top() {
+        return new XmlClass(XmlProgram.findClass(this.root).orElseThrow(this::notFound));
     }
 
     /**
@@ -89,7 +75,7 @@ public class XmlProgram {
      * @param clazz Class.
      * @return New XmlProgram.
      */
-    public XmlProgram withTopClass(final XmlClass clazz) {
+    public XmlProgram with(final XmlClass clazz) {
         final Node res = new XMLDocument(this.root).node();
         final NodeList top = res.getChildNodes();
         for (int index = 0; index < top.getLength(); ++index) {
@@ -149,5 +135,18 @@ public class XmlProgram {
     private static boolean isClass(final Node node) {
         return node.getNodeName().equals("o")
             && node.getParentNode().getNodeName().equals("objects");
+    }
+
+    /**
+     * Create exception if top-level class wasn't found.
+     * @return IllegalStateException exception.
+     */
+    private IllegalStateException notFound() {
+        return new IllegalStateException(
+            String.format(
+                "No top-level class found in '%s'",
+                this.root
+            )
+        );
     }
 }


### PR DESCRIPTION
Refactor XmlProgram class by adding XmlNode class.

Closes: #193.
____
History:
- feat(#193): simplify methods in XmlProgram
- feat(#193): fix all integration tests
- feat(#193): remove redundant code
- feat(#193): add one more puzzle for unit tests


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The PR focuses on making changes to the `XmlProgram` class and related classes in the `org.eolang.jeo.representation.xmir` package.
- Changes include refactoring methods in `XmlProgram`, introducing a new `XmlNode` utility class, and updating method names and signatures.
- The `topClass` method in `XmlProgram` is renamed to `top` and now returns an instance of `XmlClass`.
- The `withTopClass` method in `XmlProgram` is renamed to `with` and now takes an instance of `XmlClass` as a parameter.
- The `findClass` and `isClass` methods in `XmlProgram` are removed and replaced by the `child` method in the new `XmlNode` class.
- The `XmlNode` class provides utility methods for working with XML nodes, such as finding child nodes, cleaning nodes, and appending nodes.
- Unit tests for `XmlProgram` and `XmlNode` are mentioned as a future improvement.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->