### PR TITLE
feat(#188): Add Integration Test for Generics (failed)

### DIFF
--- a/src/it/generics/invoker.properties
+++ b/src/it/generics/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean process-classes -e

--- a/src/it/generics/pom.xml
+++ b/src/it/generics/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2023 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eolang</groupId>
+  <artifactId>jeo-it</artifactId>
+  <version>@project.version@</version>
+  <packaging>jar</packaging>
+  <description>
+    Integration test that checks correct transformation Java generics from
+    bytecode into EO and back
+  </description>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <phase>
+              process-classes
+            </phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>org.eolang.jeo.Application</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/generics/src/main/java/org/eolang/jeo/Application.java
+++ b/src/it/generics/src/main/java/org/eolang/jeo/Application.java
@@ -2,7 +2,7 @@ package org.eolang.jeo;
 
 public class Application {
     public static void main(String[] args) {
-        new Developer(
+        new Developer<>(
             "Yegor",
             new Language() {
                 public String name() {
@@ -10,25 +10,28 @@ public class Application {
                 }
             }
         ).writeCode();
-        new Developer(
+        new Developer<>(
             "Lev",
             new Language() {
+                @Override
                 public String name() {
                     return "Rust";
                 }
             }
         ).writeCode();
-        new Developer(
+        new Developer<>(
             "Maxim",
             new Language() {
+                @Override
                 public String name() {
                     return "PHP";
                 }
             }
         ).writeCode();
-        new Developer(
+        new Developer<>(
             "Roman",
             new Language() {
+                @Override
                 public String name() {
                     return "Kotlin";
                 }

--- a/src/it/generics/src/main/java/org/eolang/jeo/Application.java
+++ b/src/it/generics/src/main/java/org/eolang/jeo/Application.java
@@ -1,0 +1,38 @@
+package org.eolang.jeo;
+
+public class Application {
+    public static void main(String[] args) {
+        new Developer(
+            "Yegor",
+            new Language() {
+                public String name() {
+                    return "EO";
+                }
+            }
+        ).writeCode();
+        new Developer(
+            "Lev",
+            new Language() {
+                public String name() {
+                    return "Rust";
+                }
+            }
+        ).writeCode();
+        new Developer(
+            "Maxim",
+            new Language() {
+                public String name() {
+                    return "PHP";
+                }
+            }
+        ).writeCode();
+        new Developer(
+            "Roman",
+            new Language() {
+                public String name() {
+                    return "Kotlin";
+                }
+            }
+        ).writeCode();
+    }
+}

--- a/src/it/generics/src/main/java/org/eolang/jeo/Developer.java
+++ b/src/it/generics/src/main/java/org/eolang/jeo/Developer.java
@@ -1,0 +1,21 @@
+package org.eolang.jeo;
+
+import java.lang.String;
+import java.lang.System;
+
+public class Developer<T extends Language> {
+
+    private final String name;
+    private final T lang;
+
+    public Developer(final String name, final T lang) {
+        this.name = name;
+        this.lang = lang;
+    }
+
+    void writeCode() {
+        System.out.println(
+            String.format("%s likes write code in %s", this.name, lang.name())
+        );
+    }
+}

--- a/src/it/generics/src/main/java/org/eolang/jeo/Language.java
+++ b/src/it/generics/src/main/java/org/eolang/jeo/Language.java
@@ -1,0 +1,7 @@
+package org.eolang.jeo;
+
+import java.lang.String;
+
+public abstract class Language {
+    public abstract String name();
+}

--- a/src/it/generics/verify.groovy
+++ b/src/it/generics/verify.groovy
@@ -32,4 +32,38 @@ assert log.contains("Roman likes write code in Kotlin")
 //assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/Application.xmir').exists()
 //assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/Developer.xmir').exists()
 //assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/Language.xmir').exists()
+/**
+ * @todo #188:30min Enable Integration Test for Generics.
+ *  First of all, we have to implement Java Generics support in JEO.
+ *  Then, we need to add JEO plugin into pom.xml of that test, the
+ *  plugin setup you can find below. After that we need to add some
+ *  assertions to this file. For example, we need to check that we have
+ *  generated EO object files (see commented checks above).
+ *
+ * <p>
+ * {@code
+ * <plugin>
+ *   <groupId>org.eolang</groupId>
+ *   <artifactId>jeo-maven-plugin</artifactId>
+ *   <version>@project.version@</version>
+ *   <executions>
+ *     <execution>
+ *       <id>bytecode-to-eo</id>
+ *       <goals>
+ *         <goal>bytecode-to-eo</goal>
+ *       </goals>
+ *     </execution>
+ *     <execution>
+ *       <id>eo-to-bytecode</id>
+ *       <goals>
+ *         <goal>eo-to-bytecode</goal>
+ *       </goals>
+ *     </execution>
+ *   </executions>
+ * </plugin>
+ *
+ *}
+ * </p>
+ */
+
 true

--- a/src/it/generics/verify.groovy
+++ b/src/it/generics/verify.groovy
@@ -1,0 +1,35 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+//Check logs first.
+String log = new File(basedir, 'build.log').text;
+assert log.contains("BUILD SUCCESS")
+assert log.contains("Yegor likes write code in EO")
+assert log.contains("Lev likes write code in Rust")
+assert log.contains("Maxim likes write code in PHP")
+assert log.contains("Roman likes write code in Kotlin")
+//Check that we have generated EO object files.
+//assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/Application.xmir').exists()
+//assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/Developer.xmir').exists()
+//assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/Language.xmir').exists()
+true


### PR DESCRIPTION
Add integration test (failed) for checking correct transformation Java bytecode with Generics into EO and then back into Java. The test should check that we don't break anything after transformation. Since we haven't implemented that feature yet, I've added one puzzle in order to enable this test in the future. 

Closes: #188.
____
History:
- feat(#188): Add simple integration test for generics
- feat(#188): Add new puzzle

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for Java generics in the `org.eolang.jeo` package. 

### Detailed summary
- Added `Language` abstract class with an abstract `name()` method.
- Added `Developer` class with a generic type parameter `T extends Language`.
- Added `writeCode()` method in the `Developer` class to print a message using the `name()` method of the `lang` object.
- Added `Application` class with a `main` method to create instances of `Developer` and call the `writeCode()` method.
- Added `pom.xml` file with Maven configuration for the integration test.
- Added `verify.groovy` file with test assertions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->