### PR TITLE
feat(#189): Takes IT Test (fails)

### DIFF
--- a/src/it/takes/invoker.properties
+++ b/src/it/takes/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean process-classes -e

--- a/src/it/takes/pom.xml
+++ b/src/it/takes/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2023 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eolang</groupId>
+  <artifactId>jeo-it</artifactId>
+  <version>@project.version@</version>
+  <packaging>jar</packaging>
+  <description>
+    Integration test that checks correct transformation simple Java application
+    written with using Takes Framework. This application starts HTTP server,
+    sends single HTTP request and prints response to the console.
+    If you need to run only this test, use the following command:
+    "mvn clean integration-test invoker:run -Dinvoker.test=takes -DskipTests"
+  </description>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.takes</groupId>
+      <artifactId>takes</artifactId>
+      <version>1.24.4</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <phase>
+              process-classes
+            </phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>start-server</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>org.eolang.jeo.takes.Application</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/takes/src/main/java/org/eolang/jeo/takes/Application.java
+++ b/src/it/takes/src/main/java/org/eolang/jeo/takes/Application.java
@@ -1,7 +1,7 @@
-package org.eolang.jeo;
+package org.eolang.jeo.takes;
 
 public class Application {
     public static void main(String[] args) {
-        System.out.println("Hello, world!");
+        System.out.println("Hello from Takes Framework!");
     }
 }

--- a/src/it/takes/src/main/java/org/eolang/jeo/takes/Application.java
+++ b/src/it/takes/src/main/java/org/eolang/jeo/takes/Application.java
@@ -1,7 +1,59 @@
 package org.eolang.jeo.takes;
 
+import org.takes.Request;
+import org.takes.Response;
+import org.takes.facets.fork.Fork;
+import org.takes.http.Exit;
+import org.takes.http.FtBasic;
+import org.takes.facets.fork.FkRegex;
+import org.takes.facets.fork.TkFork;
+import java.io.IOException;
+import org.takes.misc.Opt;
+
 public class Application {
-    public static void main(String[] args) {
-        System.out.println("Hello from Takes Framework!");
+    public static void main(String[] args) throws IOException {
+        new FtBasic(
+            new TkFork(
+                new RequestCounter(
+                    new TimeLog(
+                        new FkRegex("/", "It is the Takes Framework"))
+                )
+            ),
+            8080
+        ).start(Exit.NEVER);
     }
+
+    private static class TimeLog implements Fork {
+
+        private final Fork origin;
+
+        TimeLog(final Fork origin) {
+            this.origin = origin;
+        }
+
+        @Override
+        public Opt<Response> route(final Request req) throws Exception {
+            System.out.printf("Request time: %d%n", System.currentTimeMillis());
+            return this.origin.route(req);
+        }
+    }
+
+    private static class RequestCounter implements Fork {
+
+        private final Fork origin;
+        private int counter = 0;
+
+        RequestCounter(final Fork origin) {
+            this.origin = origin;
+        }
+
+        @Override
+        public Opt<Response> route(final Request req) throws Exception {
+            this.counter += 1;
+            System.out.printf("Request #%d%n", this.counter);
+            return this.origin.route(req);
+        }
+    }
+
+
 }

--- a/src/it/takes/src/main/java/org/eolang/jeo/takes/Application.java
+++ b/src/it/takes/src/main/java/org/eolang/jeo/takes/Application.java
@@ -1,0 +1,7 @@
+package org.eolang.jeo;
+
+public class Application {
+    public static void main(String[] args) {
+        System.out.println("Hello, world!");
+    }
+}

--- a/src/it/takes/src/main/java/org/eolang/jeo/takes/Application.java
+++ b/src/it/takes/src/main/java/org/eolang/jeo/takes/Application.java
@@ -1,32 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.takes;
 
 import org.takes.Request;
 import org.takes.Response;
+import org.takes.Take;
 import org.takes.facets.fork.Fork;
 import org.takes.http.Exit;
 import org.takes.http.FtBasic;
 import org.takes.facets.fork.FkRegex;
 import org.takes.facets.fork.TkFork;
 import java.io.IOException;
+import org.takes.http.FtRemote;
 import org.takes.misc.Opt;
+import org.takes.rq.RqFake;
+import org.takes.rq.RqSimple;
+import org.takes.rs.RsPrint;
 
+/**
+ * Takes Application Entry Point.
+ * @since 0.1
+ */
 public class Application {
-    public static void main(String[] args) throws IOException {
-        new FtBasic(
-            new TkFork(
-                new RequestCounter(
-                    new TimeLog(
-                        new FkRegex("/", "It is the Takes Framework"))
-                )
-            ),
-            8080
-        ).start(Exit.NEVER);
+    public static void main(String[] args) throws Exception {
+        final String path = "/";
+        System.out.println(
+            new RsPrint(
+                new TkFork(
+                    new RequestCounter(
+                        new TimeLog(
+                            new FkRegex(path, "It is the Takes Framework"))
+                    )
+                ).act(new RqFake("GET", path))).asString()
+        );
     }
 
+    /**
+     * Prints the request time in the console.
+     * @since 0.1
+     */
     private static class TimeLog implements Fork {
 
+        /**
+         * Original fork.
+         */
         private final Fork origin;
 
+        /**
+         * Constructor.
+         * @param origin Original fork.
+         */
         TimeLog(final Fork origin) {
             this.origin = origin;
         }
@@ -38,11 +82,27 @@ public class Application {
         }
     }
 
+    /**
+     * Counts the requests.
+     * @since 0.1
+     */
     private static class RequestCounter implements Fork {
 
+        /**
+         * Original fork.
+         */
         private final Fork origin;
+
+        /**
+         * Request counter.
+         * Counts each request.
+         */
         private int counter = 0;
 
+        /**
+         * Constructor.
+         * @param origin Original fork.
+         */
         RequestCounter(final Fork origin) {
             this.origin = origin;
         }
@@ -54,6 +114,4 @@ public class Application {
             return this.origin.route(req);
         }
     }
-
-
 }

--- a/src/it/takes/verify.groovy
+++ b/src/it/takes/verify.groovy
@@ -24,10 +24,7 @@
 //Check logs first.
 String log = new File(basedir, 'build.log').text;
 assert log.contains("BUILD SUCCESS")
-assert log.contains("Yegor likes write code in EO")
-assert log.contains("Lev likes write code in Rust")
-assert log.contains("Maxim likes write code in PHP")
-assert log.contains("Roman likes write code in Kotlin")
+assert log.contains("Hello from Takes Framework!")
 //Check that we have generated EO object files.
 //assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/Application.xmir').exists()
 //assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/Developer.xmir').exists()

--- a/src/it/takes/verify.groovy
+++ b/src/it/takes/verify.groovy
@@ -24,11 +24,13 @@
 //Check logs first.
 String log = new File(basedir, 'build.log').text;
 assert log.contains("BUILD SUCCESS")
-assert log.contains("Hello from Takes Framework!")
+assert log.contains("It is the Takes Framework")
+assert log.contains("Request #1")
+assert log.contains("Request time: ")
 //Check that we have generated EO object files.
-//assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/Application.xmir').exists()
-//assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/Developer.xmir').exists()
-//assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/Language.xmir').exists()
+//assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/takes/Application.xmir').exists()
+//assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/takes/Application$TimeLog.xmir').exists()
+//assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/takes/Application$RequestCounter.xmir').exists()
 /**
  * @todo #189:30min Enable Integration Test for Takes Framework.
  *  First of all, we have to implement all the features required for correct

--- a/src/it/takes/verify.groovy
+++ b/src/it/takes/verify.groovy
@@ -1,0 +1,69 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022-2023 Volodya
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+//Check logs first.
+String log = new File(basedir, 'build.log').text;
+assert log.contains("BUILD SUCCESS")
+assert log.contains("Yegor likes write code in EO")
+assert log.contains("Lev likes write code in Rust")
+assert log.contains("Maxim likes write code in PHP")
+assert log.contains("Roman likes write code in Kotlin")
+//Check that we have generated EO object files.
+//assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/Application.xmir').exists()
+//assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/Developer.xmir').exists()
+//assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/Language.xmir').exists()
+/**
+ * @todo #189:30min Enable Integration Test for Takes Framework.
+ *  First of all, we have to implement all the features required for correct
+ *  transformation. Then, we need to add JEO plugin into pom.xml of that test,
+ *  the plugin setup you can find below. After that we need to add some
+ *  assertions to this file. For example, we need to check that we have
+ *  generated EO object files (see commented checks above).
+ *
+ * <p>
+ * {@code
+ * <plugin>
+ *   <groupId>org.eolang</groupId>
+ *   <artifactId>jeo-maven-plugin</artifactId>
+ *   <version>@project.version@</version>
+ *   <executions>
+ *     <execution>
+ *       <id>bytecode-to-eo</id>
+ *       <goals>
+ *         <goal>bytecode-to-eo</goal>
+ *       </goals>
+ *     </execution>
+ *     <execution>
+ *       <id>eo-to-bytecode</id>
+ *       <goals>
+ *         <goal>eo-to-bytecode</goal>
+ *       </goals>
+ *     </execution>
+ *   </executions>
+ * </plugin>
+ *
+ *}
+ * </p>
+ */
+
+true


### PR DESCRIPTION
Add integration test that utilizes Takes Framework together with several decorators. The test is disabled, since we haven't implemented full transformation for all bytecode instructions yet. 
I added one more puzzle to enable the test.

Closes: #189.
____
History:
- feat(#189): Add the skeleton for the funutre takes it
- feat(#189): make it pass
- feat(#189): Add more classes for Takes Framework
- feat(#189): Add more Takes Classes


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enabling an integration test for the Takes Framework. 

### Detailed summary
- Added invoker.goals property in invoker.properties file.
- Added MIT License to verify.groovy file.
- Added comments and assertions to verify.groovy file for testing purposes.
- Added pom.xml file for the integration test.
- Added Application.java file for the Takes application entry point.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->