### PR TITLE
feat(#175): Simplify ImprovementDistilledObjects

### DIFF
--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -245,33 +245,35 @@ public final class ImprovementDistilledObjects implements Improvement {
          * @return List of NEW instructions.
          */
         private List<XmlInstruction> targetNew() {
-            final String firstname = this.decorated.name();
-            final Node first = new XMLDocument(
-                new StringBuilder()
-                    .append("<o base=\"opcode\" name=\"NEW-187-50\">")
-                    .append("<o base=\"string\" data=\"bytes\">")
-                    .append(new HexData(firstname).value())
-                    .append("</o>")
-                    .append("</o>")
-                    .toString()
-            ).node().getFirstChild();
-            final String secondname = this.decorator.name();
-            final Node second = new XMLDocument(
-                new StringBuilder()
-                    .append("<o base=\"opcode\" name=\"NEW-187-50\">")
-                    .append("<o base=\"string\" data=\"bytes\">")
-                    .append(new HexData(secondname).value())
-                    .append("</o>")
-                    .append("</o>")
-                    .toString()
-            ).node().getFirstChild();
-            final Node dup = new XMLDocument("<o base=\"opcode\" name=\"DUP-89-53\"/>")
+            final Node dup = new XMLDocument("<o base='opcode' name='DUP-89-53'/>")
                 .node()
                 .getFirstChild();
             return Arrays.asList(
-                new XmlInstruction(second),
+                new XmlInstruction(
+                    new XMLDocument(
+                        String.join(
+                            "",
+                            "<o base='opcode' name='NEW-187-50'>",
+                            "<o base='string' data='bytes'>",
+                            new HexData(this.decorator.name()).value(),
+                            "</o>",
+                            "</o>"
+                        )
+                    ).node().getFirstChild()
+                ),
                 new XmlInstruction(dup),
-                new XmlInstruction(first),
+                new XmlInstruction(
+                    new XMLDocument(
+                        String.join(
+                            "",
+                            "<o base='opcode' name='NEW-187-50'>",
+                            "<o base='string' data='bytes'>",
+                            new HexData(this.decorated.name()).value(),
+                            "</o>",
+                            "</o>"
+                        )
+                    ).node().getFirstChild()
+                ),
                 new XmlInstruction(dup)
             );
         }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -299,38 +299,36 @@ public final class ImprovementDistilledObjects implements Improvement {
         private List<XmlInstruction> targetSpecial() {
             return Arrays.asList(
                 new XmlInstruction(
-                    new XMLDocument(
-                        new StringBuilder()
-                            .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">")
-                            .append("<o base=\"string\" data=\"bytes\">")
-                            .append(new HexData(this.decorated.name()).value())
-                            .append("</o>")
-                            .append("<o base=\"string\" data=\"bytes\">")
-                            .append(new HexData("<init>").value())
-                            .append("</o>")
-                            .append("<o base=\"string\" data=\"bytes\">")
-                            .append(new HexData("(I)V").value())
-                            .append("</o>")
-                            .append("</o>")
-                            .toString()
-                    ).node().getFirstChild()
+                    String.join(
+                        "",
+                        "<o base='opcode' name='INVOKESPECIAL-183-55'>",
+                        "<o base='string' data='bytes'>",
+                        new HexData(this.decorated.name()).value(),
+                        "</o>",
+                        "<o base='string' data='bytes'>",
+                        new HexData("<init>").value(),
+                        "</o>",
+                        "<o base='string' data='bytes'>",
+                        new HexData("(I)V").value(),
+                        "</o>",
+                        "</o>"
+                    )
                 ),
                 new XmlInstruction(
-                    new XMLDocument(
-                        new StringBuilder()
-                            .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">")
-                            .append("<o base=\"string\" data=\"bytes\">")
-                            .append(new HexData(this.decorator.name()).value())
-                            .append("</o>")
-                            .append("<o base=\"string\" data=\"bytes\">")
-                            .append(new HexData("<init>").value())
-                            .append("</o>")
-                            .append("<o base=\"string\" data=\"bytes\">")
-                            .append(new HexData("(Lorg/eolang/jeo/A;)V").value())
-                            .append("</o>")
-                            .append("</o>")
-                            .toString()
-                    ).node().getFirstChild()
+                    String.join(
+                        "",
+                        "<o base='opcode' name='INVOKESPECIAL-183-55'>",
+                        "<o base='string' data='bytes'>",
+                        new HexData(this.decorator.name()).value(),
+                        "</o>",
+                        "<o base='string' data='bytes'>",
+                        new HexData("<init>").value(),
+                        "</o>",
+                        "<o base='string' data='bytes'>",
+                        new HexData("(Lorg/eolang/jeo/A;)V").value(),
+                        "</o>",
+                        "</o>"
+                    )
                 )
             );
         }
@@ -342,23 +340,20 @@ public final class ImprovementDistilledObjects implements Improvement {
         private List<XmlInstruction> replacementSpecial() {
             return Collections.singletonList(
                 new XmlInstruction(
-                    new XMLDocument(
-                        new StringBuilder()
-                            .append("<o base=\"opcode\" name=\"INVOKESPECIAL-183-55\">")
-                            .append("<o base=\"string\" data=\"bytes\">")
-                            .append(
-                                new DecoratorCompositionName(this.decorated, this.decorator).hex()
-                            )
-                            .append("</o>")
-                            .append("<o base=\"string\" data=\"bytes\">")
-                            .append(new HexData("<init>").value())
-                            .append("</o>")
-                            .append("<o base=\"string\" data=\"bytes\">")
-                            .append(new HexData("(I)V").value())
-                            .append("</o>")
-                            .append("</o>")
-                            .toString()
-                    ).node().getFirstChild()
+                    String.join(
+                        "",
+                        "<o base='opcode' name='INVOKESPECIAL-183-55'>",
+                        "<o base='string' data='bytes'>",
+                        new DecoratorCompositionName(this.decorated, this.decorator).hex(),
+                        "</o>",
+                        "<o base='string' data='bytes'>",
+                        new HexData("<init>").value(),
+                        "</o>",
+                        "<o base='string' data='bytes'>",
+                        new HexData("(I)V").value(),
+                        "</o>",
+                        "</o>"
+                    )
                 )
             );
         }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -368,7 +368,7 @@ public final class ImprovementDistilledObjects implements Improvement {
         private Representation combine() {
             return new EoRepresentation(
                 new XMLDocument(
-                    this.skeleton(
+                    this.combine(
                         this.decorator.toEO(),
                         new DecoratorCompositionName(this.decorated, this.decorator).value()
                     ).toString()
@@ -378,12 +378,12 @@ public final class ImprovementDistilledObjects implements Improvement {
 
         /**
          * Skeleton.
-         * @param decor Decorator.
+         * @param skeleton Decorator.
          * @param name Class name.
          * @return Combined XMIR representation.
          */
-        private XML skeleton(final XML decor, final String name) {
-            final List<XML> roots = decor.nodes("/program");
+        private XML combine(final XML skeleton, final String name) {
+            final List<XML> roots = skeleton.nodes("/program");
             final Node root = roots.get(0).node();
             final NamedNodeMap attributes = root.getAttributes();
             attributes.getNamedItem("name").setNodeValue(name);

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -179,14 +179,13 @@ public final class ImprovementDistilledObjects implements Improvement {
      *  It's not correct, because we need to handle arguments correctly.
      */
     private static void replaceArguments(final XmlClass clazz) {
-        clazz.methods().stream()
+        clazz.methods()
+            .stream()
             .map(XmlMethod::instructions)
             .flatMap(Collection::stream)
             .forEach(
-                instruction -> instruction.replaceArguementsValues(
-                    "org/eolang/jeo/B",
-                    "org/eolang/jeo/A$B"
-                )
+                instruction ->
+                    instruction.replaceArguementsValues("org/eolang/jeo/B", "org/eolang/jeo/A$B")
             );
     }
 
@@ -441,11 +440,9 @@ public final class ImprovementDistilledObjects implements Improvement {
                                 if (base.getNodeValue().equals("seq")) {
                                     final NodeList instructions = item.getChildNodes();
                                     for (int inst = 0; inst < instructions.getLength(); ++inst) {
-                                        new XmlInstruction(instructions.item(inst))
-                                            .replaceArguementsValues(
-                                                this.decorated.name(),
-                                                bytename
-                                            );
+                                        new XmlInstruction(
+                                            instructions.item(inst)
+                                        ).replaceArguementsValues(this.decorated.name(), bytename);
                                     }
                                 }
                             }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -128,10 +128,6 @@ public final class ImprovementDistilledObjects implements Improvement {
      * @param clazz Class where to replace.
      * @param target What should be replaced.
      * @param replacement Replacement.
-     * @todo #161:90min Refactor replace method.
-     *  Right now it's a big method with a lot of repetition and high complexity.
-     *  Moreover, some constants are hardcoded and it's not good.
-     *  We need to refactor it into a set of smaller methods and remove all linter warnings.
      * @checkstyle ModifiedControlVariableCheck (200 lines)
      */
     private static void replace(

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -245,34 +245,28 @@ public final class ImprovementDistilledObjects implements Improvement {
          * @return List of NEW instructions.
          */
         private List<XmlInstruction> targetNew() {
-            final Node dup = new XMLDocument("<o base='opcode' name='DUP-89-53'/>")
-                .node()
-                .getFirstChild();
+            final String dup = "<o base='opcode' name='DUP-89-53'/>";
             return Arrays.asList(
                 new XmlInstruction(
-                    new XMLDocument(
-                        String.join(
-                            "",
-                            "<o base='opcode' name='NEW-187-50'>",
-                            "<o base='string' data='bytes'>",
-                            new HexData(this.decorator.name()).value(),
-                            "</o>",
-                            "</o>"
-                        )
-                    ).node().getFirstChild()
+                    String.join(
+                        "",
+                        "<o base='opcode' name='NEW-187-50'>",
+                        "<o base='string' data='bytes'>",
+                        new HexData(this.decorator.name()).value(),
+                        "</o>",
+                        "</o>"
+                    )
                 ),
                 new XmlInstruction(dup),
                 new XmlInstruction(
-                    new XMLDocument(
-                        String.join(
-                            "",
-                            "<o base='opcode' name='NEW-187-50'>",
-                            "<o base='string' data='bytes'>",
-                            new HexData(this.decorated.name()).value(),
-                            "</o>",
-                            "</o>"
-                        )
-                    ).node().getFirstChild()
+                    String.join(
+                        "",
+                        "<o base='opcode' name='NEW-187-50'>",
+                        "<o base='string' data='bytes'>",
+                        new HexData(this.decorated.name()).value(),
+                        "</o>",
+                        "</o>"
+                    )
                 ),
                 new XmlInstruction(dup)
             );
@@ -283,21 +277,18 @@ public final class ImprovementDistilledObjects implements Improvement {
          * @return Replacement.
          */
         private List<XmlInstruction> replacementNew() {
-            final Node second = new XMLDocument(
-                new StringBuilder()
-                    .append("<o base=\"opcode\" name=\"NEW-187-50\">")
-                    .append("<o base=\"string\" data=\"bytes\">")
-                    .append(new DecoratorCompositionName(this.decorated, this.decorator).hex())
-                    .append("</o>")
-                    .append("</o>")
-                    .toString()
-            ).node().getFirstChild();
-            final Node dup = new XMLDocument("<o base=\"opcode\" name=\"DUP-89-53\"/>")
-                .node()
-                .getFirstChild();
             return Arrays.asList(
-                new XmlInstruction(second),
-                new XmlInstruction(dup)
+                new XmlInstruction(
+                    String.join(
+                        "",
+                        "<o base='opcode' name='NEW-187-50'>",
+                        "<o base='string' data='bytes'>",
+                        new DecoratorCompositionName(this.decorated, this.decorator).hex(),
+                        "</o>",
+                        "</o>"
+                    )
+                ),
+                new XmlInstruction("<o base='opcode' name='DUP-89-53'/>")
             );
         }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -46,6 +46,10 @@ public final class XmlInstruction {
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     private final Node node;
 
+    public XmlInstruction(final String xml) {
+        this(new XMLDocument(xml).node().getFirstChild());
+    }
+
     /**
      * Constructor.
      * @param node Instruction node.

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -67,14 +67,6 @@ public final class XmlInstruction {
     }
 
     /**
-     * Instruction arguments.
-     * @return Arguments.
-     */
-    public Object[] arguments() {
-        return XmlInstruction.arguments(this.node);
-    }
-
-    /**
      * XML node.
      * @return XML node.
      * @todo #157:90min Hide internal node representation in XmlInstruction.
@@ -85,6 +77,14 @@ public final class XmlInstruction {
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     public Node node() {
         return this.node;
+    }
+
+    /**
+     * Instruction arguments.
+     * @return Arguments.
+     */
+    public Object[] arguments() {
+        return XmlInstruction.arguments(this.node);
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -72,31 +72,20 @@ public final class XmlInstruction {
     }
 
     /**
-     * XML node.
-     * @return XML node.
-     * @todo #157:90min Hide internal node representation in XmlInstruction.
-     *  This class should not expose internal node representation.
-     *  We have to consider to add methods or classes in order to avoid
-     *  exposing internal node representation.
+     * Replace values of instruction arguments.
+     * @param old Old value.
+     * @param replacement Which value to set instead.
      */
-    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
-    public Node node() {
-        return this.node;
-    }
-
-
     public void replaceArguementsValues(final String old, final String replacement) {
-        final NodeList children = this.node.getChildNodes();
-        for (int index = 0; index < children.getLength(); ++index) {
-            final Node child = children.item(index);
-            if (child.getNodeName().equals("o")) {
-                final String oldname = new HexData(old).value();
-                final String content = child.getTextContent();
+        final String oldname = new HexData(old).value();
+        new XmlNode(this.node).children().forEach(
+            child -> {
+                final String content = child.text();
                 if (oldname.equals(content)) {
-                    child.setTextContent(new HexData(replacement).value());
+                    child.withText(new HexData(replacement).value());
                 }
             }
-        }
+        );
     }
 
     /**
@@ -105,6 +94,19 @@ public final class XmlInstruction {
      */
     public Object[] arguments() {
         return XmlInstruction.arguments(this.node);
+    }
+
+    /**
+     * XML node.
+     * @return XML node.
+     * @todo #157:90min Hide internal node representation in XmlInstruction.
+     *  This class should not expose internal node representation.
+     *  We have to consider to add methods or classes in order to avoid
+     *  exposing internal node representation.
+     */
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
+    Node node() {
+        return this.node;
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -47,6 +47,10 @@ public final class XmlInstruction {
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     private final Node node;
 
+    /**
+     * Constructor.
+     * @param xml XML node as String.
+     */
     public XmlInstruction(final String xml) {
         this(new XMLDocument(xml).node().getFirstChild());
     }
@@ -96,19 +100,6 @@ public final class XmlInstruction {
         return XmlInstruction.arguments(this.node);
     }
 
-    /**
-     * XML node.
-     * @return XML node.
-     * @todo #157:90min Hide internal node representation in XmlInstruction.
-     *  This class should not expose internal node representation.
-     *  We have to consider to add methods or classes in order to avoid
-     *  exposing internal node representation.
-     */
-    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
-    Node node() {
-        return this.node;
-    }
-
     @Override
     public boolean equals(final Object other) {
         final boolean result;
@@ -131,6 +122,19 @@ public final class XmlInstruction {
     @Override
     public String toString() {
         return new XMLDocument(this.node).toString();
+    }
+
+    /**
+     * XML node.
+     * @return XML node.
+     * @todo #157:90min Hide internal node representation in XmlInstruction.
+     *  This class should not expose internal node representation.
+     *  We have to consider to add methods or classes in order to avoid
+     *  exposing internal node representation.
+     */
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
+    Node node() {
+        return this.node;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.IntStream;
+import org.eolang.jeo.representation.HexData;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -81,6 +82,21 @@ public final class XmlInstruction {
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     public Node node() {
         return this.node;
+    }
+
+
+    public void replaceArguementsValues(final String old, final String replacement) {
+        final NodeList children = this.node.getChildNodes();
+        for (int index = 0; index < children.getLength(); ++index) {
+            final Node child = children.item(index);
+            if (child.getNodeName().equals("o")) {
+                final String oldname = new HexData(old).value();
+                final String content = child.getTextContent();
+                if (oldname.equals(content)) {
+                    child.setTextContent(new HexData(replacement).value());
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -69,6 +69,10 @@ final class XmlNode {
         throw this.notFound(name);
     }
 
+    /**
+     * Get all child nodes.
+     * @return Child nodes.
+     */
     Stream<XmlNode> children() {
         return this.objects().map(XmlNode::new);
     }
@@ -81,10 +85,18 @@ final class XmlNode {
         return new XmlClass(this.node);
     }
 
+    /**
+     * Retrieve node text content.
+     * @return Text content.
+     */
     String text() {
         return this.node.getTextContent();
     }
 
+    /**
+     * Set node text content.
+     * @param text Text content.
+     */
     void withText(final String text) {
         this.node.setTextContent(text);
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -24,6 +24,9 @@
 package org.eolang.jeo.representation.xmir;
 
 import com.jcabi.xml.XMLDocument;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -66,12 +69,24 @@ final class XmlNode {
         throw this.notFound(name);
     }
 
+    Stream<XmlNode> children() {
+        return this.objects().map(XmlNode::new);
+    }
+
     /**
      * Convert to class.
      * @return Class.
      */
     XmlClass toClass() {
         return new XmlClass(this.node);
+    }
+
+    String text() {
+        return this.node.getTextContent();
+    }
+
+    void withText(final String text) {
+        this.node.setTextContent(text);
     }
 
     /**
@@ -108,5 +123,21 @@ final class XmlNode {
                 new XMLDocument(this.node)
             )
         );
+    }
+
+    /**
+     * Objects.
+     * @return Stream of class objects.
+     */
+    private Stream<Node> objects() {
+        final NodeList children = this.node.getChildNodes();
+        final List<Node> res = new ArrayList<>(children.getLength());
+        for (int index = 0; index < children.getLength(); ++index) {
+            final Node child = children.item(index);
+            if (child.getNodeName().equals("o")) {
+                res.add(child);
+            }
+        }
+        return res.stream();
     }
 }


### PR DESCRIPTION
It is refactoring related to ImprovementDistilledObjects.
That PR isn't directly addresses the #175 issue, but it is part of it.
Actually we have one more puzzle for refactoring of ImprovementDistilledObjects, so we can close this one.

Closes: #175.
____
History:
- feat(#175): simplify targetNew method
- feat(#175): simplify xml nodes creatation
- feat(#175): simplify xml nodes creatation
- feat(#175): remove redundant code
- feat(#175): set text content for XmlNode
- feat(#175): rename methods
- feat(#175): remove the puzzle for 175 issue
- feat(#175): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `children()` method to `XmlNode` class to retrieve all child nodes.
- Added `text()` method to `XmlNode` class to retrieve node text content.
- Added `withText()` method to `XmlNode` class to set node text content.
- Added `replaceArguementsValues()` method to `XmlInstruction` class to replace argument values.
- Refactored `replaceArguments()` method in `ImprovementDistilledObjects` class to handle arguments correctly during inlining optimization.

> The following files were skipped due to too many changes: `src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->