### PR TITLE
feat(#207): Simplify XmlMethod Class

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -131,7 +131,7 @@ public final class XmlMethod {
     @SafeVarargs
     public final List<XmlInstruction> instructions(final Predicate<XmlInstruction>... predicates) {
 //        final List<XmlInstruction> result;
-        return new XmlNode(this.node).child("seq").children()
+        return new XmlNode(this.node).child("base", "seq").children()
             .filter(XmlMethod::isInstruction)
             .map(XmlNode::toInstruction)
             .filter(instr -> Arrays.stream(predicates).allMatch(predicate -> predicate.test(instr)))

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -25,9 +25,7 @@ package org.eolang.jeo.representation.xmir;
 
 import com.jcabi.log.Logger;
 import com.jcabi.xml.XMLDocument;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -123,35 +121,15 @@ public final class XmlMethod {
      * Method instructions.
      * @param predicates Filters.
      * @return Instructions.
-     * @todo #162:30min Simplify instructions method.
-     *  This method is too complex. We should simplify it.
-     *  In order to do so we can use {@link XmlNode} class.
-     *  Don't forget to remove the puzzle.
      */
     @SafeVarargs
     public final List<XmlInstruction> instructions(final Predicate<XmlInstruction>... predicates) {
-//        final List<XmlInstruction> result;
-        return new XmlNode(this.node).child("base", "seq").children()
-            .filter(XmlMethod::isInstruction)
+        return new XmlNode(this.node).child("base", "seq")
+            .children()
+            .filter(element -> element.attribute("name").isPresent())
             .map(XmlNode::toInstruction)
             .filter(instr -> Arrays.stream(predicates).allMatch(predicate -> predicate.test(instr)))
             .collect(Collectors.toList());
-//        final Optional<Node> sequence = this.sequence();
-//        if (sequence.isPresent()) {
-//            final Node seq = sequence.get();
-//            final List<XmlInstruction> instructions = new ArrayList<>(0);
-//            for (int index = 0; index < seq.getChildNodes().getLength(); ++index) {
-//                final Node instruction = seq.getChildNodes().item(index);
-//                if (XmlMethod.isInstruction(instruction) && Arrays.stream(predicates)
-//                    .allMatch(predicate -> predicate.test(new XmlInstruction(instruction)))) {
-//                    instructions.add(new XmlInstruction(instruction));
-//                }
-//            }
-//            result = instructions;
-//        } else {
-//            result = Collections.emptyList();
-//        }
-//        return result;
     }
 
     /**
@@ -204,40 +182,6 @@ public final class XmlMethod {
                 result = Optional.of(item);
                 break;
             }
-        }
-        return result;
-    }
-
-    /**
-     * Check if node is an instruction.
-     * @param node Node.
-     * @return True if node is an instruction.
-     */
-    private static boolean isInstruction(final XmlNode node) {
-        return node.attribute("name").isPresent();
-
-//        final boolean result;
-//        final NamedNodeMap attrs = node.getAttributes();
-//        if (attrs == null || attrs.getNamedItem("name") == null) {
-//            result = false;
-//        } else {
-//            result = true;
-//        }
-//        return result;
-    }
-
-    /**
-     * Check if node is an instruction.
-     * @param node Node.
-     * @return True if node is an instruction.
-     */
-    private static boolean isInstruction(final Node node) {
-        final boolean result;
-        final NamedNodeMap attrs = node.getAttributes();
-        if (attrs == null || attrs.getNamedItem("name") == null) {
-            result = false;
-        } else {
-            result = true;
         }
         return result;
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -130,23 +130,28 @@ public final class XmlMethod {
      */
     @SafeVarargs
     public final List<XmlInstruction> instructions(final Predicate<XmlInstruction>... predicates) {
-        final List<XmlInstruction> result;
-        final Optional<Node> sequence = this.sequence();
-        if (sequence.isPresent()) {
-            final Node seq = sequence.get();
-            final List<XmlInstruction> instructions = new ArrayList<>(0);
-            for (int index = 0; index < seq.getChildNodes().getLength(); ++index) {
-                final Node instruction = seq.getChildNodes().item(index);
-                if (XmlMethod.isInstruction(instruction) && Arrays.stream(predicates)
-                    .allMatch(predicate -> predicate.test(new XmlInstruction(instruction)))) {
-                    instructions.add(new XmlInstruction(instruction));
-                }
-            }
-            result = instructions;
-        } else {
-            result = Collections.emptyList();
-        }
-        return result;
+//        final List<XmlInstruction> result;
+        return new XmlNode(this.node).child("seq").children()
+            .filter(XmlMethod::isInstruction)
+            .map(XmlNode::toInstruction)
+            .filter(instr -> Arrays.stream(predicates).allMatch(predicate -> predicate.test(instr)))
+            .collect(Collectors.toList());
+//        final Optional<Node> sequence = this.sequence();
+//        if (sequence.isPresent()) {
+//            final Node seq = sequence.get();
+//            final List<XmlInstruction> instructions = new ArrayList<>(0);
+//            for (int index = 0; index < seq.getChildNodes().getLength(); ++index) {
+//                final Node instruction = seq.getChildNodes().item(index);
+//                if (XmlMethod.isInstruction(instruction) && Arrays.stream(predicates)
+//                    .allMatch(predicate -> predicate.test(new XmlInstruction(instruction)))) {
+//                    instructions.add(new XmlInstruction(instruction));
+//                }
+//            }
+//            result = instructions;
+//        } else {
+//            result = Collections.emptyList();
+//        }
+//        return result;
     }
 
     /**
@@ -201,6 +206,24 @@ public final class XmlMethod {
             }
         }
         return result;
+    }
+
+    /**
+     * Check if node is an instruction.
+     * @param node Node.
+     * @return True if node is an instruction.
+     */
+    private static boolean isInstruction(final XmlNode node) {
+        return node.attribute("name").isPresent();
+
+//        final boolean result;
+//        final NamedNodeMap attrs = node.getAttributes();
+//        if (attrs == null || attrs.getNamedItem("name") == null) {
+//            result = false;
+//        } else {
+//            result = true;
+//        }
+//        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -40,6 +40,7 @@ import org.w3c.dom.NodeList;
  *  Currently we don't have unit tests for XmlNode. So, it makes sense to add
  *  them to keep code safe and clear.
  */
+@SuppressWarnings("PMD.TooManyMethods")
 final class XmlNode {
 
     /**
@@ -72,14 +73,19 @@ final class XmlNode {
     }
 
     /**
-     * Get child node by attribute
+     * Get child node by attribute.
+     * @param attribute Attribute name.
+     * @param value Attribute value.
+     * @return Child node.
      */
     XmlNode child(final String attribute, final String value) {
         return this.children()
             .filter(xmlnode -> xmlnode.hasAttribute(attribute, value))
             .findFirst()
-            .orElseThrow(() -> this.notFound(
-                String.format("object with attribute %s='%s'", attribute, value))
+            .orElseThrow(
+                () -> this.notFound(
+                    String.format("object with attribute %s='%s'", attribute, value)
+                )
             );
     }
 
@@ -159,6 +165,22 @@ final class XmlNode {
     }
 
     /**
+     * Get attribute.
+     * @param name Attribute name.
+     * @return Attribute.
+     */
+    Optional<String> attribute(final String name) {
+        final Optional<String> result;
+        final NamedNodeMap attrs = this.node.getAttributes();
+        if (attrs == null) {
+            result = Optional.empty();
+        } else {
+            result = Optional.ofNullable(attrs.getNamedItem(name)).map(Node::getTextContent);
+        }
+        return result;
+    }
+
+    /**
      * Generate exception if element not found.
      * @param name Element name.
      * @return Exception.
@@ -173,29 +195,17 @@ final class XmlNode {
         );
     }
 
-    boolean hasAttribute(final String name, final String value) {
-        XMLDocument doc = new XMLDocument(this.node);
-        System.out.println(doc);
+    /**
+     * Check if attribute exists.
+     * @param name Attribute name.
+     * @param value Attribute value.
+     * @return True if attribute with specified value exists.
+     */
+    private boolean hasAttribute(final String name, final String value) {
         return this.attribute(name)
             .map(String::valueOf)
             .map(val -> val.equals(value))
             .orElse(false);
-    }
-
-    /**
-     * Get attribute.
-     * @param name Attribute name.
-     * @return Attribute.
-     */
-    Optional<String> attribute(final String name) {
-        final Optional<String> result;
-        final NamedNodeMap attrs = this.node.getAttributes();
-        if (attrs == null) {
-            result = Optional.empty();
-        } else {
-            result = Optional.ofNullable(attrs.getNamedItem(name)).map(Node::getTextContent);
-        }
-        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -26,6 +26,7 @@ package org.eolang.jeo.representation.xmir;
 import com.jcabi.xml.XMLDocument;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -71,6 +72,19 @@ final class XmlNode {
     }
 
     /**
+     * Get child node by attribute
+     */
+    XmlNode child(final String attribute, final String value) {
+        return this.children()
+            .map(child -> child.attribute(attribute))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .filter(child -> child.equals(value))
+            .findFirst()
+            .orElseThrow(() -> this.notFound(String.format("%s:%s", attribute, value)));
+    }
+
+    /**
      * Get all child nodes.
      * @return Child nodes.
      */
@@ -84,6 +98,14 @@ final class XmlNode {
      */
     XmlClass toClass() {
         return new XmlClass(this.node);
+    }
+
+    /**
+     * Convert to an instruction.
+     * @return Instruction.
+     */
+    XmlInstruction toInstruction() {
+        return new XmlInstruction(this.node);
     }
 
     /**
@@ -145,11 +167,27 @@ final class XmlNode {
     private IllegalStateException notFound(final String name) {
         return new IllegalStateException(
             String.format(
-                "Can't find '%s' element in '%s'",
+                "Can't find %s in '%s'",
                 name,
                 new XMLDocument(this.node)
             )
         );
+    }
+
+    /**
+     * Get attribute.
+     * @param name Attribute name.
+     * @return Attribute.
+     */
+    Optional<Object> attribute(final String name) {
+        final Optional<Object> result;
+        final NamedNodeMap attrs = this.node.getAttributes();
+        if (attrs == null) {
+            result = Optional.empty();
+        } else {
+            result = Optional.ofNullable(attrs.getNamedItem(name));
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -76,12 +76,11 @@ final class XmlNode {
      */
     XmlNode child(final String attribute, final String value) {
         return this.children()
-            .map(child -> child.attribute(attribute))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .filter(child -> child.equals(value))
+            .filter(xmlnode -> xmlnode.hasAttribute(attribute, value))
             .findFirst()
-            .orElseThrow(() -> this.notFound(String.format("%s:%s", attribute, value)));
+            .orElseThrow(() -> this.notFound(
+                String.format("object with attribute %s='%s'", attribute, value))
+            );
     }
 
     /**
@@ -174,18 +173,27 @@ final class XmlNode {
         );
     }
 
+    boolean hasAttribute(final String name, final String value) {
+        XMLDocument doc = new XMLDocument(this.node);
+        System.out.println(doc);
+        return this.attribute(name)
+            .map(String::valueOf)
+            .map(val -> val.equals(value))
+            .orElse(false);
+    }
+
     /**
      * Get attribute.
      * @param name Attribute name.
      * @return Attribute.
      */
-    Optional<Object> attribute(final String name) {
-        final Optional<Object> result;
+    Optional<String> attribute(final String name) {
+        final Optional<String> result;
         final NamedNodeMap attrs = this.node.getAttributes();
         if (attrs == null) {
             result = Optional.empty();
         } else {
-            result = Optional.ofNullable(attrs.getNamedItem(name));
+            result = Optional.ofNullable(attrs.getNamedItem(name)).map(Node::getTextContent);
         }
         return result;
     }


### PR DESCRIPTION
Simplify `XmlMethod` class methods.

Closes: #207.
____
History:
- feat(#207): simplify the method
- feat(#207): working sample of the refactored method
- feat(#207): remove the puzzle for 207 issue
- feat(#207): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Simplified the `instructions` method in `XmlMethod` class by using the `XmlNode` class.
- Removed the `isInstruction` method in `XmlMethod` class.
- Added the `toInstruction` method in `XmlNode` class.
- Added the `child` method with attribute filtering in `XmlNode` class.
- Added the `attribute` method in `XmlNode` class.
- Added the `hasAttribute` method in `XmlNode` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->