### PR TITLE
feat(#166): Rewrite Instructions Arguments After Optimization

### DIFF
--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -153,10 +153,6 @@ public final class ImprovementDistilledObjects implements Improvement {
                     final XmlInstruction current = instructions.get(index);
                     if (current.equals(targeted)) {
                         if (inner == size - 1) {
-                            Logger.info(
-                                ImprovementDistilledObjects.class,
-                                "Constructor inlining happened"
-                            );
                             updated.addAll(replacement);
                             stack.clear();
                         } else {

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -110,7 +110,6 @@ public final class ImprovementDistilledObjects implements Improvement {
                 decorator.targetSpecial(),
                 decorator.replacementSpecial()
             );
-
             clazz.methods()
                 .stream()
                 .map(XmlMethod::instructions)
@@ -118,8 +117,8 @@ public final class ImprovementDistilledObjects implements Improvement {
                 .forEach(
                     instruction ->
                         instruction.replaceArguementsValues(
-                            "org/eolang/jeo/B",
-                            "org/eolang/jeo/A$B"
+                            decorator.originalDecoratorName(),
+                            decorator.combinedName()
                         )
                 );
         }
@@ -342,15 +341,20 @@ public final class ImprovementDistilledObjects implements Improvement {
             );
         }
 
+        private String originalDecoratorName() {
+            return this.decorator.name();
+        }
+
+        private String combinedName() {
+            return new DecoratorCompositionName(this.decorated, this.decorator).value();
+        }
+
         /**
          * Combine two representations into one.
          * @return Combined representation.
          */
         private Representation combine() {
-            final String name = new DecoratorCompositionName(
-                this.decorated,
-                this.decorator
-            ).value();
+            final String name = this.combinedName();
             final XmlProgram program = new XmlProgram(this.decorator.toEO())
                 .copy()
                 .withName(name)

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -337,10 +337,18 @@ public final class ImprovementDistilledObjects implements Improvement {
             );
         }
 
+        /**
+         * Original decorator name.
+         * @return Decorator name.
+         */
         private String originalDecoratorName() {
             return this.decorator.name();
         }
 
+        /**
+         * Combined name.
+         * @return Name of combined class.
+         */
         private String combinedName() {
             return new DecoratorCompositionName(this.decorated, this.decorator).value();
         }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -110,7 +110,18 @@ public final class ImprovementDistilledObjects implements Improvement {
                 decorator.targetSpecial(),
                 decorator.replacementSpecial()
             );
-            ImprovementDistilledObjects.replaceArguments(clazz);
+
+            clazz.methods()
+                .stream()
+                .map(XmlMethod::instructions)
+                .flatMap(Collection::stream)
+                .forEach(
+                    instruction ->
+                        instruction.replaceArguementsValues(
+                            "org/eolang/jeo/B",
+                            "org/eolang/jeo/A$B"
+                        )
+                );
         }
         return new EoRepresentation(new XmlProgram(xmir).with(clazz).toXmir());
     }
@@ -162,24 +173,6 @@ public final class ImprovementDistilledObjects implements Improvement {
             }
             method.setInstructions(updated);
         }
-    }
-
-    /**
-     * Replace arguments.
-     * @param clazz Class where to replace.
-     * @todo #157:90min Handle arguments correctly during inlining optimization.
-     *  Right now we just replace all arguments with the new class name.
-     *  It's not correct, because we need to handle arguments correctly.
-     */
-    private static void replaceArguments(final XmlClass clazz) {
-        clazz.methods()
-            .stream()
-            .map(XmlMethod::instructions)
-            .flatMap(Collection::stream)
-            .forEach(
-                instruction ->
-                    instruction.replaceArguementsValues("org/eolang/jeo/B", "org/eolang/jeo/A$B")
-            );
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -23,14 +23,12 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import com.jcabi.log.Logger;
 import com.jcabi.xml.XMLDocument;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -145,19 +145,11 @@ public final class XmlMethod {
                 String.format("Can't find bytecode of the method %s", new XMLDocument(this.node))
             )
         );
-        final Document owner = root.getOwnerDocument();
-        Logger.info(
-            this,
-            String.format(
-                "Set new method instructions %n%s%n",
-                updated.stream().map(XmlInstruction::toString).collect(Collectors.joining("\n"))
-            )
-        );
         while (root.hasChildNodes()) {
             root.removeChild(root.getFirstChild());
         }
         for (final XmlInstruction instruction : updated) {
-            root.appendChild(owner.adoptNode(instruction.node()));
+            root.appendChild(root.getOwnerDocument().adoptNode(instruction.node()));
         }
     }
 


### PR DESCRIPTION
Remove hardcoded values from ImprovementDistilledObjects.
Now we replace old instruction arguments with new generated values. 

Closes: #166.
____
History:
- feat(#166): inline method
- feat(#166): remove hardcoded values
- feat(#166): remove excessive logging
- feat(#166): remove hardcoded values from the code generation


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Removed unused imports in `XmlMethod.java`
- Replaced `ImprovementDistilledObjects.replaceArguments(clazz)` with a stream operation in `ImprovementDistilledObjects.java`
- Added `originalDecoratorName()` and `combinedName()` methods in `ImprovementDistilledObjects.java`
- Updated `combine()` method in `ImprovementDistilledObjects.java` to use `combinedName()` method

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->