### PR TITLE
feat(#211): Fix Bug With Broken Decorator

### DIFF
--- a/src/it/distilled/verify.groovy
+++ b/src/it/distilled/verify.groovy
@@ -25,6 +25,7 @@
 String log = new File(basedir, 'build.log').text;
 assert log.contains("BUILD SUCCESS")
 assert log.contains("Result: 31")
+assert !log.contains("java.lang.ClassNotFoundException")
 //Check that we have generated all the required XMIR object files.
 assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/Main.xmir').exists()
 assert new File(basedir, 'target/jeo/xmir/org/eolang/jeo/A.xmir').exists()

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -100,6 +100,9 @@ public final class ImprovementDistilledObjects implements Improvement {
         final XML xmir = representation.toEO();
         final XmlClass clazz = new XmlProgram(xmir).top();
         for (final DecoratorPair decorator : decorators) {
+            if (representation.name().equals(decorator.originalDecoratorName())) {
+                continue;
+            }
             ImprovementDistilledObjects.replace(
                 clazz,
                 decorator.targetNew(),

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -66,21 +66,21 @@ public final class ImprovementDistilledObjects implements Improvement {
                         .collect(Collectors.toList())
                 )
         );
-        final List<Representation> additional = decorators.stream()
+        final List<Representation> generated = decorators.stream()
             .map(DecoratorPair::combine)
             .collect(Collectors.toList());
         Logger.info(
             this,
             String.format(
                 "Distilled objects improvement is successfully applied. Generated classes: %s, total %d",
-                additional.stream().map(Representation::name).collect(Collectors.toList()),
-                additional.size()
+                generated.stream().map(Representation::name).collect(Collectors.toList()),
+                generated.size()
             )
         );
         return Stream.concat(
+            generated.stream(),
             representations.stream()
-                .map(repr -> ImprovementDistilledObjects.replaceConstructors(decorators, repr)),
-            additional.stream()
+                .map(repr -> ImprovementDistilledObjects.replaceConstructors(decorators, repr))
         ).collect(Collectors.toList());
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -27,10 +27,6 @@ import com.jcabi.xml.XML;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 import org.eolang.jeo.representation.BytecodeRepresentation;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -152,13 +148,7 @@ public final class BytecodeClass {
         this.methods.forEach(BytecodeMethod::write);
         this.writer.visitEnd();
         final byte[] bytes = this.writer.toByteArray();
-        verification.defineClass(name, bytes);
-        CheckClassAdapter.verify(
-            new ClassReader(bytes),
-            verification,
-            false,
-            new PrintWriter(System.err)
-        );
+        CheckClassAdapter.verify(new ClassReader(bytes), false, new PrintWriter(System.err));
         return new Bytecode(bytes);
     }
 
@@ -275,28 +265,5 @@ public final class BytecodeClass {
             result = raw;
         }
         return result;
-    }
-
-
-    private static DynamicClassLoader verification = new DynamicClassLoader();
-
-    private static class DynamicClassLoader extends ClassLoader {
-
-        private Set<String> defined = Collections.synchronizedSet(new HashSet<>());
-
-        synchronized Class<?> defineClass(String name, byte[] b) {
-            try {
-                if (this.defined.contains(name.replace('/', '.'))
-                    || this.findLoadedClass(name.replace('/', '.')) != null) {
-                    return loadClass(name.replace('/', '.'));
-                }
-            } catch (ClassNotFoundException ex) {
-                this.defined.add(name.replace('/', '.'));
-                return this.defineClass(name.replace('/', '.'), b, 0, b.length);
-            }
-            this.defined.add(name.replace('/', '.'));
-            return this.defineClass(name.replace('/', '.'), b, 0, b.length);
-
-        }
     }
 }


### PR DESCRIPTION
Original problem wasn't related to bytecode check. Actually bytecode check alarmed about broken decorator class after transformation.
So, I fixed the bug and the problem is gone.

Closes: #211.
____
History:
- feat(#211): use ugly classloader to check bytecode correctly
- feat(#211): ignore original decorator
- feat(#211): fix all qulice suggestions

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the generation of distilled objects. 

### Detailed summary
- Added an assertion to check that a specific error message is not present in the log.
- Renamed the variable `additional` to `generated`.
- Updated the log message to include the names and count of the generated classes.
- Replaced the usage of `additional` with `generated` in the return statement.
- Added a condition to skip a specific decorator during object replacement.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->