### PR TITLE
feat(#221): Integrate EO Footprint

### DIFF
--- a/src/it/betecode-to-eo/verify.groovy
+++ b/src/it/betecode-to-eo/verify.groovy
@@ -26,4 +26,5 @@ String log = new File(basedir, 'build.log').text;
 assert log.contains("BUILD SUCCESS")
 //Check that we have generated XMIR object file.
 assert new File(basedir, 'target/generated-sources/xmir/org/eolang/jeo/Application.xmir').exists()
+assert new File(basedir, 'target/generated-sources/eo/org/eolang/jeo/Application.eo').exists()
 true

--- a/src/it/distilled/verify.groovy
+++ b/src/it/distilled/verify.groovy
@@ -31,6 +31,10 @@ assert new File(basedir, 'target/generated-sources/xmir/org/eolang/jeo/Main.xmir
 assert new File(basedir, 'target/generated-sources/xmir/org/eolang/jeo/A.xmir').exists()
 assert new File(basedir, 'target/generated-sources/xmir/org/eolang/jeo/B.xmir').exists()
 assert new File(basedir, 'target/generated-sources/xmir/org/eolang/jeo/A$B.xmir').exists()
+assert new File(basedir, 'target/generated-sources/eo/org/eolang/jeo/Main.eo').exists()
+assert new File(basedir, 'target/generated-sources/eo/org/eolang/jeo/A.eo').exists()
+assert new File(basedir, 'target/generated-sources/eo/org/eolang/jeo/B.eo').exists()
+assert new File(basedir, 'target/generated-sources/eo/org/eolang/jeo/A$B.eo').exists()
 assert new File(basedir, 'target/classes/org/eolang/jeo/A$B.class').exists()
 //Check that class file was changed
 assert log.contains("Main.class was recompiled successfully.")

--- a/src/it/optimization/verify.groovy
+++ b/src/it/optimization/verify.groovy
@@ -27,6 +27,7 @@ assert log.contains("BUILD SUCCESS")
 assert log.contains("Hello, World!")
 //Check that we have generated XMIR object file.
 assert new File(basedir, 'target/generated-sources/xmir/org/eolang/jeo/Application.xmir').exists()
+assert new File(basedir, 'target/generated-sources/eo/org/eolang/jeo/Application.eo').exists()
 //Check that class file was changed
 assert log.contains("Application.class was recompiled successfully.")
 true

--- a/src/main/java/org/eolang/jeo/JeoMojo.java
+++ b/src/main/java/org/eolang/jeo/JeoMojo.java
@@ -32,6 +32,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.eolang.jeo.improvement.ImprovementBytecodeFootprint;
 import org.eolang.jeo.improvement.ImprovementDistilledObjects;
+import org.eolang.jeo.improvement.ImprovementEoFootprint;
 import org.eolang.jeo.improvement.ImprovementLogged;
 import org.eolang.jeo.improvement.ImprovementSet;
 import org.eolang.jeo.improvement.ImprovementXmirFootprint;
@@ -73,6 +74,7 @@ public final class JeoMojo extends AbstractMojo {
                     new ImprovementLogged(),
                     new ImprovementDistilledObjects(),
                     new ImprovementXmirFootprint(this.generated.toPath()),
+                    new ImprovementEoFootprint(this.generated.toPath()),
                     new ImprovementBytecodeFootprint(this.classes.toPath())
                 )
             ).apply();

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementEoFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementEoFootprint.java
@@ -53,7 +53,7 @@ public final class ImprovementEoFootprint implements Improvement {
      * Constructor.
      * @param generated Where to save the EO, usually it's target/generated-sources folder.
      */
-    ImprovementEoFootprint(final Path generated) {
+    public ImprovementEoFootprint(final Path generated) {
         this.target = generated;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/BytecodeTransformation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeTransformation.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import org.eolang.jeo.BytecodeClasses;
 import org.eolang.jeo.improvement.ImprovementEoFootprint;
 import org.eolang.jeo.improvement.ImprovementSet;

--- a/src/main/java/org/eolang/jeo/representation/BytecodeTransformation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeTransformation.java
@@ -25,7 +25,10 @@ package org.eolang.jeo.representation;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import org.eolang.jeo.BytecodeClasses;
+import org.eolang.jeo.improvement.ImprovementEoFootprint;
+import org.eolang.jeo.improvement.ImprovementSet;
 import org.eolang.jeo.improvement.ImprovementXmirFootprint;
 
 /**
@@ -63,8 +66,9 @@ public class BytecodeTransformation {
      * @throws IOException If some I/O problem arises.
      */
     public void transpile() throws IOException {
-        new ImprovementXmirFootprint(this.target).apply(
-            new BytecodeClasses(this.classes).bytecode()
-        );
+        new ImprovementSet(
+            new ImprovementEoFootprint(this.target),
+            new ImprovementXmirFootprint(this.target)
+        ).apply(new BytecodeClasses(this.classes).bytecode());
     }
 }


### PR DESCRIPTION
Previousely we wrote only `.xmir` files. Now we write `.eo` files too. 
It makes it easier to "see" the transformation results for a human bieng. 

Closes: #221.
____
History:
- feat(#221): add ImprovementEoFootprint into Mojos
- feat(#221): add checks for integration tests

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Add support for generating EO files in addition to XMIR files during the build process.

### Detailed summary:
- Added `ImprovementEoFootprint` class to generate EO files.
- Updated `JeoMojo` to use `ImprovementEoFootprint` in addition to `ImprovementXmirFootprint`.
- Updated `BytecodeTransformation` to use `ImprovementEoFootprint` and `ImprovementXmirFootprint` together.
- Added assertions in test files to check for the existence of EO files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->