### PR TITLE
feat(#213): Add GitHub pipeline that updates versions in README

### DIFF
--- a/.github/workflows/up.yaml
+++ b/.github/workflows/up.yaml
@@ -1,0 +1,28 @@
+---
+name: up
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+concurrency:
+  group: up-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  up:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - run: |-
+          git fetch --tags --force && \
+          latest=$(git tag --sort=creatordate | tail -1) && \
+          sed -E -i "s/<version>[^<]+/<version>${latest}/g" README.md
+      - uses: peter-evans/create-pull-request@v5
+        with:
+          branch: version-up
+          commit-message: 'chore: new version in README'
+          delete-branch: true
+          title: 'chore: New version in README'
+          assignees: volodya-lombrozo
+          base: master


### PR DESCRIPTION
Add short stript that will send PR to update plugin version in README.

Closes: #213.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on automating the process of updating the version number in the README file. 

### Detailed summary:
- Added a new workflow file `.github/workflows/up.yaml`
- Configured the workflow to trigger on push events to the `master` branch and all tags
- Set concurrency options for the workflow
- Defined a job `up` to run on Ubuntu 22.04
- Added steps to checkout the code, fetch tags, update the version number in the README file, and create a pull request
- Configured the pull request details such as branch name, commit message, delete branch option, title, assignees, and base branch

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->