### PR TITLE
feat(#206): Move inline method from optimization into XmlMethod

### DIFF
--- a/src/it/distilled/pom.xml
+++ b/src/it/distilled/pom.xml
@@ -28,7 +28,11 @@ SOFTWARE.
   <artifactId>jeo-it</artifactId>
   <version>@project.version@</version>
   <packaging>jar</packaging>
-  <description>Integration test for distilled objects optimization</description>
+  <description>
+    Integration test for distilled objects optimization.
+    If you need to run only this test, use the following command:
+    "mvn clean integration-test invoker:run -Dinvoker.test=distilled -DskipTests"
+  </description>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -386,7 +386,8 @@ public final class ImprovementDistilledObjects implements Improvement {
             for (final XmlMethod method : clazz.methods()) {
                 if (method.isConstructor()) {
                     for (final XmlInstruction instruction : method.instructions()) {
-                        instruction.replaceArguementsValues(this.decorated.name(),
+                        instruction.replaceArguementsValues(
+                            this.decorated.name(),
                             this.combinedName()
                         );
                     }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -41,10 +41,8 @@ import org.eolang.jeo.representation.HexData;
 import org.eolang.jeo.representation.xmir.XmlClass;
 import org.eolang.jeo.representation.xmir.XmlField;
 import org.eolang.jeo.representation.xmir.XmlInstruction;
-import org.eolang.jeo.representation.xmir.XmlInvokeVirtual;
 import org.eolang.jeo.representation.xmir.XmlMethod;
 import org.eolang.jeo.representation.xmir.XmlProgram;
-import org.objectweb.asm.Opcodes;
 import org.w3c.dom.Node;
 
 /**

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -41,6 +41,7 @@ import org.eolang.jeo.representation.HexData;
 import org.eolang.jeo.representation.xmir.XmlClass;
 import org.eolang.jeo.representation.xmir.XmlField;
 import org.eolang.jeo.representation.xmir.XmlInstruction;
+import org.eolang.jeo.representation.xmir.XmlInvokeVirtual;
 import org.eolang.jeo.representation.xmir.XmlMethod;
 import org.eolang.jeo.representation.xmir.XmlProgram;
 import org.objectweb.asm.Opcodes;
@@ -448,7 +449,9 @@ public final class ImprovementDistilledObjects implements Improvement {
         ) {
             final String old = this.decorated.name();
             for (final XmlMethod candidate : where.methods()) {
-                final List<XmlInstruction> res = new ArrayList<>(0);
+//                final List<XmlInstruction> res = new ArrayList<>(0);
+//                final List<XmlInvokeVirtual> calls = candidate.copy().invokeVirtuals();
+                candidate.inline(what, old, this.combinedName());
 //                for (final XmlInstruction instruction : candidate.instructionsWithout(
 //                    Opcodes.GETFIELD)) {
 //                    if (instruction.code() == Opcodes.INVOKEVIRTUAL) {
@@ -461,10 +464,10 @@ public final class ImprovementDistilledObjects implements Improvement {
 //                    }
 //                }
 
-                for (final XmlInstruction instruction : candidate.instructions()) {
-                    res.add(instruction);
-                }
-                candidate.setInstructions(res);
+//                for (final XmlInstruction instruction : candidate.instructions()) {
+//                    res.add(instruction);
+//                }
+//                candidate.setInstructions(res);
             }
         }
     }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -439,9 +439,6 @@ public final class ImprovementDistilledObjects implements Improvement {
          * and then b.foo() will be inlined.
          * @param where To replace.
          * @param what To inline.
-         * @todo #162:90min Refactor replaceMethodContent method.
-         *  Right now it's a method with high complexity and it's hard to read it.
-         *  We need to refactor it or inline into some other method.
          */
         private void replaceOldInvokationsWithNewInvocations(
             final XmlClass where,
@@ -449,25 +446,7 @@ public final class ImprovementDistilledObjects implements Improvement {
         ) {
             final String old = this.decorated.name();
             for (final XmlMethod candidate : where.methods()) {
-//                final List<XmlInstruction> res = new ArrayList<>(0);
-//                final List<XmlInvokeVirtual> calls = candidate.copy().invokeVirtuals();
                 candidate.inline(what, old, this.combinedName());
-//                for (final XmlInstruction instruction : candidate.instructionsWithout(
-//                    Opcodes.GETFIELD)) {
-//                    if (instruction.code() == Opcodes.INVOKEVIRTUAL) {
-//                        what.instructionsWithout(Opcodes.RETURN, Opcodes.IRETURN, Opcodes.ALOAD)
-//                            .stream()
-//                            .peek(instr -> instr.replaceArguementsValues(old, this.combinedName()))
-//                            .forEach(res::add);
-//                    } else {
-//                        res.add(instruction);
-//                    }
-//                }
-
-//                for (final XmlInstruction instruction : candidate.instructions()) {
-//                    res.add(instruction);
-//                }
-//                candidate.setInstructions(res);
             }
         }
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInvokeVirtual.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInvokeVirtual.java
@@ -33,32 +33,63 @@ import org.objectweb.asm.Opcodes;
  */
 public class XmlInvokeVirtual {
 
+    /**
+     * Instructions.
+     */
     private final List<XmlInstruction> instructions;
 
-    public XmlInvokeVirtual(final List<XmlInstruction> instructions) {
+    /**
+     * Constructor.
+     * @param instructions Instructions.
+     */
+    XmlInvokeVirtual(final List<XmlInstruction> instructions) {
         this.instructions = instructions;
     }
 
+    /**
+     * GETFIELD instruction.
+     * @return Instruction.
+     */
     XmlInstruction field() {
         return this.instructions.get(0);
     }
 
+    /**
+     * INVOKEVIRTUAL instruction.
+     * @return Instruction.
+     */
     XmlInstruction invocation() {
         return this.instructions.get(this.instructions.size() - 1);
     }
 
+    /**
+     * Get field name.
+     * @return Field name.
+     */
     String fieldName() {
         return String.valueOf(this.field().arguments()[1]);
     }
 
+    /**
+     * Get field type.
+     * @return Field type.
+     */
     String fieldType() {
         return String.valueOf(this.field().arguments()[2]);
     }
 
+    /**
+     * Get method name.
+     * @return Method name.
+     */
     String methodName() {
         return String.valueOf(this.invocation().arguments()[1]);
     }
 
+    /**
+     * Get method arguments.
+     * @return Method arguments.
+     */
     public List<XmlInstruction> arguments() {
         final List<XmlInstruction> result;
         if (this.instructions.size() < 3) {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInvokeVirtual.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInvokeVirtual.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.xmir;
 
 import java.util.Collections;
 import java.util.List;
+import org.objectweb.asm.Opcodes;
 
 /**
  * Abstraction over invoke virtual call.
@@ -38,16 +39,24 @@ public class XmlInvokeVirtual {
         this.instructions = instructions;
     }
 
-    public String fieldName() {
-        return String.valueOf(this.instructions.get(0).arguments()[1]);
+    XmlInstruction field() {
+        return this.instructions.get(0);
     }
 
-    public String fieldType() {
-        return String.valueOf(this.instructions.get(0).arguments()[2]);
+    XmlInstruction invocation() {
+        return this.instructions.get(this.instructions.size() - 1);
     }
 
-    public String methodName() {
-        return String.valueOf(this.instructions.get(this.instructions.size() - 1).arguments()[1]);
+    String fieldName() {
+        return String.valueOf(this.field().arguments()[1]);
+    }
+
+    String fieldType() {
+        return String.valueOf(this.field().arguments()[2]);
+    }
+
+    String methodName() {
+        return String.valueOf(this.invocation().arguments()[1]);
     }
 
     public List<XmlInstruction> arguments() {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInvokeVirtual.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInvokeVirtual.java
@@ -32,19 +32,31 @@ import java.util.List;
  */
 public class XmlInvokeVirtual {
 
+    private final List<XmlInstruction> instructions;
+
+    public XmlInvokeVirtual(final List<XmlInstruction> instructions) {
+        this.instructions = instructions;
+    }
+
     public String fieldName() {
-        return "";
+        return String.valueOf(this.instructions.get(0).arguments()[1]);
     }
 
     public String fieldType() {
-        return "";
+        return String.valueOf(this.instructions.get(0).arguments()[2]);
     }
 
     public String methodName() {
-        return "";
+        return String.valueOf(this.instructions.get(this.instructions.size() - 1).arguments()[1]);
     }
 
     public List<XmlInstruction> arguments() {
-        return Collections.emptyList();
+        final List<XmlInstruction> result;
+        if (this.instructions.size() < 3) {
+            result = Collections.emptyList();
+        } else {
+            result = this.instructions.subList(1, this.instructions.size() - 1);
+        }
+        return result;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInvokeVirtual.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInvokeVirtual.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.xmir;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Abstraction over invoke virtual call.
+ * @since 0.1
+ */
+public class XmlInvokeVirtual {
+
+    public String fieldName() {
+        return "";
+    }
+
+    public String fieldType() {
+        return "";
+    }
+
+    public String methodName() {
+        return "";
+    }
+
+    public List<XmlInstruction> arguments() {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInvokeVirtual.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInvokeVirtual.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation.xmir;
 
 import java.util.Collections;
 import java.util.List;
-import org.objectweb.asm.Opcodes;
 
 /**
  * Abstraction over invoke virtual call.
@@ -90,7 +89,7 @@ public class XmlInvokeVirtual {
      * Get method arguments.
      * @return Method arguments.
      */
-    public List<XmlInstruction> arguments() {
+    List<XmlInstruction> arguments() {
         final List<XmlInstruction> result;
         if (this.instructions.size() < 3) {
             result = Collections.emptyList();

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.xmir;
 
 import com.jcabi.xml.XMLDocument;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -45,11 +46,16 @@ public final class XmlMethod {
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     private final Node node;
 
+
+    public XmlMethod(String... xml) {
+        this(new XMLDocument(String.join("", xml)).node());
+    }
+
     /**
      * Constructor.
      * @param node Method node.
      */
-    public XmlMethod(final Node node) {
+    XmlMethod(final Node node) {
         this.node = node;
     }
 
@@ -128,6 +134,20 @@ public final class XmlMethod {
             .map(XmlNode::toInstruction)
             .filter(instr -> Arrays.stream(predicates).allMatch(predicate -> predicate.test(instr)))
             .collect(Collectors.toList());
+    }
+
+    /**
+     * Retrieves the list of all invocations of other object methods.
+     * Usually they are invoke virtual instructions which look like this:
+     * - GET FIELD: foo
+     * - LIST OF ARGUMENTS
+     * - INVOKEVIRTUAL: bar
+     * This list represents the following command:
+     * foo.bar(a, b);
+     * @return List of invocations.
+     */
+    public List<XmlInvokeVirtual> invokeVirtuals() {
+        return Collections.emptyList();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -24,12 +24,14 @@
 package org.eolang.jeo.representation.xmir;
 
 import com.jcabi.xml.XMLDocument;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.objectweb.asm.Opcodes;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -146,8 +148,21 @@ public final class XmlMethod {
      * foo.bar(a, b);
      * @return List of invocations.
      */
-    public List<XmlInvokeVirtual> invokeVirtuals() {
-        return Collections.emptyList();
+    List<XmlInvokeVirtual> invokeVirtuals() {
+        final List<XmlInstruction> all = this.instructions();
+        final List<XmlInvokeVirtual> res = new ArrayList<>();
+        for (int index = 0; index < all.size(); ++index) {
+            final XmlInstruction top = all.get(index);
+            if (top.code() == Opcodes.GETFIELD) {
+                for (int inner = index + 1; inner < all.size(); ++inner) {
+                    final XmlInstruction bottom = all.get(inner);
+                    if (bottom.code() == Opcodes.INVOKEVIRTUAL) {
+                        res.add(new XmlInvokeVirtual(all.subList(index, inner + 1)));
+                    }
+                }
+            }
+        }
+        return res;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -26,9 +26,7 @@ package org.eolang.jeo.representation.xmir;
 import com.jcabi.xml.XMLDocument;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -50,8 +48,11 @@ public final class XmlMethod {
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     private final Node node;
 
-
-    public XmlMethod(String... xml) {
+    /**
+     * Constructor.
+     * @param xml XML node as String.
+     */
+    XmlMethod(final String... xml) {
         this(new XMLDocument(String.join("", xml)).node());
     }
 
@@ -160,7 +161,7 @@ public final class XmlMethod {
      */
     public List<XmlInvokeVirtual> invokeVirtuals() {
         final List<XmlInstruction> all = this.instructions();
-        final List<XmlInvokeVirtual> res = new ArrayList<>();
+        final List<XmlInvokeVirtual> res = new ArrayList<>(0);
         for (int index = 0; index < all.size(); ++index) {
             final XmlInstruction top = all.get(index);
             if (top.code() == Opcodes.GETFIELD) {
@@ -175,7 +176,6 @@ public final class XmlMethod {
         return res;
     }
 
-
     /**
      * Inline all method invocations.
      * @param inline Method to inline.
@@ -189,7 +189,7 @@ public final class XmlMethod {
      *  - ALOAD
      *  We have to move it into a separate method and use it in 'inline' method.
      */
-    public void inline(XmlMethod inline, final String old, final String combined) {
+    public void inline(final XmlMethod inline, final String old, final String combined) {
         final List<XmlInvokeVirtual> invocations = this.invokeVirtuals();
         final Set<XmlInstruction> ignored = invocations.stream()
             .map(XmlInvokeVirtual::field)

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
@@ -1,0 +1,112 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.xmir;
+
+import java.util.List;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link XmlMethod}.
+ * @since 0.1
+ */
+class XmlMethodTest {
+
+    @Test
+    public void retrievesSimpleInvokeVirtualCalls() {
+        MatcherAssert.assertThat(
+            "Excatly one invoke virtual call is expected",
+            new XmlMethod(
+                "<o>",
+                "<o base='opcode' name='GETFIELD-180-31'>",
+                "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 42</o>\n",
+                "  <o base='string' data='bytes'>61</o>\n",
+                "  <o base='string' data='bytes'>4C 6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41 3B</o>\n",
+                "</o>\n",
+                "<o base='opcode' name='INVOKEVIRTUAL-182-32'>\n",
+                "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41</o>\n",
+                "  <o base='string' data='bytes'>66 6F 6F</o>\n",
+                "  <o base='string' data='bytes'>28 29 49</o>\n",
+                "</o></o>"
+            ).invokeVirtuals(),
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
+    void retrievesInvokeVirtualCallsWithArguments() {
+        final List<XmlInvokeVirtual> all = new XmlMethod(
+            "<o>",
+            "<o base='opcode' name='GETFIELD-180-31'>",
+            "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 42</o>\n",
+            "  <o base='string' data='bytes'>61</o>\n",
+            "  <o base='string' data='bytes'>4C 6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41 3B</o>\n",
+            "</o>\n",
+            "<o base='opcode' name='ICONST_1-4-32'",
+            "<o base='opcode' name='INVOKEVIRTUAL-182-33'>\n",
+            "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41</o>\n",
+            "  <o base='string' data='bytes'>66 6F 6F</o>\n",
+            "  <o base='string' data='bytes'>28 29 49</o>\n",
+            "</o></o>"
+        ).invokeVirtuals();
+        final XmlInvokeVirtual call = all.get(0);
+        MatcherAssert.assertThat(
+            call.arguments(),
+            Matchers.hasSize(1)
+        );
+        MatcherAssert.assertThat(
+            "Field name should be 'a' in hex",
+            call.fieldName(),
+            Matchers.equalTo("61")
+        );
+        MatcherAssert.assertThat(
+            "Field type should be 'Lorg/eolang/jeo/A;' in hex",
+            call.fieldType(),
+            Matchers.equalTo("4C 6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41 3B")
+        );
+        MatcherAssert.assertThat(
+            "Method name should be 'foo' in hex",
+            call.methodName(),
+            Matchers.equalTo("66 6F 6F")
+        );
+    }
+
+    @Test
+    void retrievesEmptyListOfInvokeVirtualCalls() {
+        MatcherAssert.assertThat(
+            "No invoke virtual calls are expected",
+            new XmlMethod(
+                "<o>",
+                "<o base='opcode' name='GETFIELD-180-31'>",
+                "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 42</o>\n",
+                "  <o base='string' data='bytes'>61</o>\n",
+                "  <o base='string' data='bytes'>4C 6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41 3B</o>\n",
+                "</o>\n",
+                "</o></o>"
+            ).invokeVirtuals(),
+            Matchers.empty()
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
@@ -60,15 +60,15 @@ class XmlMethodTest {
         final List<XmlInvokeVirtual> all = new XmlMethod(
             "<o>",
             "<o base='opcode' name='GETFIELD-180-31'>",
-            "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 42</o>\n",
-            "  <o base='string' data='bytes'>61</o>\n",
-            "  <o base='string' data='bytes'>4C 6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41 3B</o>\n",
-            "</o>\n",
-            "<o base='opcode' name='ICONST_1-4-32'",
-            "<o base='opcode' name='INVOKEVIRTUAL-182-33'>\n",
-            "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41</o>\n",
-            "  <o base='string' data='bytes'>66 6F 6F</o>\n",
-            "  <o base='string' data='bytes'>28 29 49</o>\n",
+            "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 42</o>",
+            "  <o base='string' data='bytes'>61</o>",
+            "  <o base='string' data='bytes'>4C 6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41 3B</o>",
+            "</o>",
+            "<o base='opcode' name='ICONST_1-4-32'/>",
+            "<o base='opcode' name='INVOKEVIRTUAL-182-33'>",
+            "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41</o>",
+            "  <o base='string' data='bytes'>66 6F 6F</o>",
+            "  <o base='string' data='bytes'>28 29 49</o>",
             "</o></o>"
         ).invokeVirtuals();
         final XmlInvokeVirtual call = all.get(0);
@@ -100,10 +100,9 @@ class XmlMethodTest {
             new XmlMethod(
                 "<o>",
                 "<o base='opcode' name='GETFIELD-180-31'>",
-                "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 42</o>\n",
-                "  <o base='string' data='bytes'>61</o>\n",
-                "  <o base='string' data='bytes'>4C 6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41 3B</o>\n",
-                "</o>\n",
+                "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 42</o>",
+                "  <o base='string' data='bytes'>61</o>",
+                "  <o base='string' data='bytes'>4C 6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41 3B</o>",
                 "</o></o>"
             ).invokeVirtuals(),
             Matchers.empty()

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
@@ -35,11 +35,11 @@ import org.junit.jupiter.api.Test;
 class XmlMethodTest {
 
     @Test
-    public void retrievesSimpleInvokeVirtualCalls() {
+    void retrievesSimpleInvokeVirtualCalls() {
         MatcherAssert.assertThat(
-            "Excatly one invoke virtual call is expected",
+            "Exactly one invoke virtual call is expected",
             new XmlMethod(
-                "<o>",
+                "<o base='seq'>",
                 "<o base='opcode' name='GETFIELD-180-31'>",
                 "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 42</o>\n",
                 "  <o base='string' data='bytes'>61</o>\n",
@@ -58,7 +58,7 @@ class XmlMethodTest {
     @Test
     void retrievesInvokeVirtualCallsWithArguments() {
         final List<XmlInvokeVirtual> all = new XmlMethod(
-            "<o>",
+            "<o base='seq'>",
             "<o base='opcode' name='GETFIELD-180-31'>",
             "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 42</o>",
             "  <o base='string' data='bytes'>61</o>",
@@ -73,23 +73,24 @@ class XmlMethodTest {
         ).invokeVirtuals();
         final XmlInvokeVirtual call = all.get(0);
         MatcherAssert.assertThat(
+            "Exactly one invoke argument is expected",
             call.arguments(),
             Matchers.hasSize(1)
         );
         MatcherAssert.assertThat(
             "Field name should be 'a' in hex",
             call.fieldName(),
-            Matchers.equalTo("61")
+            Matchers.equalTo("a")
         );
         MatcherAssert.assertThat(
             "Field type should be 'Lorg/eolang/jeo/A;' in hex",
             call.fieldType(),
-            Matchers.equalTo("4C 6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41 3B")
+            Matchers.equalTo("Lorg/eolang/jeo/A;")
         );
         MatcherAssert.assertThat(
             "Method name should be 'foo' in hex",
             call.methodName(),
-            Matchers.equalTo("66 6F 6F")
+            Matchers.equalTo("foo")
         );
     }
 
@@ -98,7 +99,7 @@ class XmlMethodTest {
         MatcherAssert.assertThat(
             "No invoke virtual calls are expected",
             new XmlMethod(
-                "<o>",
+                "<o base='seq'>",
                 "<o base='opcode' name='GETFIELD-180-31'>",
                 "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 42</o>",
                 "  <o base='string' data='bytes'>61</o>",


### PR DESCRIPTION
Move inline method from optimization into XmlMethod.

Closes: #206.
____
History:
- feat(#206): remove redundant method parameters
- feat(#206): add XmlInvokeVirtualCall
- feat(#206): fix all test cases
- feat(#206): finish with test for XmlInvokeVirtual
- feat(#206): move inlining into XmlMethod
- feat(#206): remove the puzzle for 206 issue
- feat(#206): add one more puzzle for the future refactoring
- feat(#206): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on improving the handling of decorator classes and inlining method invocations in the `ImprovementDistilledObjects` class.

### Detailed summary:
- Added a description for an integration test in the `pom.xml` file.
- Added a new class `XmlInvokeVirtual` in the `XmlMethod.java` file.
- Refactored the `handleClass` method in `ImprovementDistilledObjects.java`.
- Refactored the `replaceMethodContent` method in `ImprovementDistilledObjects.java`.
- Added a new method `copy` in `XmlMethod.java`.
- Added a new method `invokeVirtuals` in `XmlMethod.java`.
- Added a new method `inline` in `XmlMethod.java`.
- Added a new test case in `XmlMethodTest.java`.

> The following files were skipped due to too many changes: `src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->