### PR TITLE
feat(#228): Simplify Inlining Method

### DIFF
--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -385,26 +385,12 @@ public final class ImprovementDistilledObjects implements Improvement {
             clazz.fields().forEach(decor::withField);
             for (final XmlMethod method : clazz.methods()) {
                 if (method.isConstructor()) {
-                    for (final XmlInstruction instruction : method.instructions()) {
-                        instruction.replaceArguementsValues(
-                            this.decorated.name(),
-                            this.combinedName()
-                        );
-                    }
                     decor.withConstructor(method);
                 } else {
-                    this.replaceOldInvokationsWithNewInvocations(decor, method);
+                    decor.inline(method);
                 }
             }
-
-            for (final XmlMethod method : decor.methods()) {
-                for (final XmlInstruction instruction : method.instructions()) {
-                    instruction.replaceArguementsValues(
-                        this.decorated.name(),
-                        this.combinedName()
-                    );
-                }
-            }
+            decor.replaceArguments(this.decorated.name(), this.combinedName());
         }
 
         /**
@@ -434,27 +420,6 @@ public final class ImprovementDistilledObjects implements Improvement {
                 .stream()
                 .map(XmlField::node)
                 .forEach(root::removeChild);
-        }
-
-        /**
-         * Replace method content.
-         * This function scans all the class methods and tries to find all invocations of the old
-         * object methods. If it finds any, it replaces them with the new object invocations.
-         * For example, if we had the next code:
-         * a.foo();
-         * it will be replaced with
-         * b.foo();
-         * and then b.foo() will be inlined.
-         * @param where To replace.
-         * @param what To inline.
-         */
-        private void replaceOldInvokationsWithNewInvocations(
-            final XmlClass where,
-            final XmlMethod what
-        ) {
-            for (final XmlMethod candidate : where.methods()) {
-                candidate.inline(what);
-            }
         }
     }
 }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -396,6 +396,15 @@ public final class ImprovementDistilledObjects implements Improvement {
                     this.replaceOldInvokationsWithNewInvocations(decor, method);
                 }
             }
+
+            for (final XmlMethod method : decor.methods()) {
+                for (final XmlInstruction instruction : method.instructions()) {
+                    instruction.replaceArguementsValues(
+                        this.decorated.name(),
+                        this.combinedName()
+                    );
+                }
+            }
         }
 
         /**
@@ -443,9 +452,8 @@ public final class ImprovementDistilledObjects implements Improvement {
             final XmlClass where,
             final XmlMethod what
         ) {
-            final String old = this.decorated.name();
             for (final XmlMethod candidate : where.methods()) {
-                candidate.inline(what, old, this.combinedName());
+                candidate.inline(what);
             }
         }
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -36,6 +36,7 @@ import org.w3c.dom.NodeList;
  * XML class.
  * @since 0.1
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class XmlClass {
 
     /**
@@ -135,7 +136,7 @@ public final class XmlClass {
      * Try to inline method into all possible places.
      * @param method Other method.
      */
-    public void inline(XmlMethod method) {
+    public void inline(final XmlMethod method) {
         this.methods().forEach(inner -> inner.inline(method));
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation.xmir;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -128,6 +129,27 @@ public final class XmlClass {
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     public Node node() {
         return this.node;
+    }
+
+    /**
+     * Try to inline method into all possible places.
+     * @param method Other method.
+     */
+    public void inline(XmlMethod method) {
+        this.methods().forEach(inner -> inner.inline(method));
+    }
+
+    /**
+     * Replace all instruction arguments that have "old" value with "replacement".
+     * @param old Old value.
+     * @param replacement Replacement value.
+     */
+    public void replaceArguments(final String old, final String replacement) {
+        this.methods()
+            .stream()
+            .map(XmlMethod::instructions)
+            .flatMap(Collection::stream)
+            .forEach(instruction -> instruction.replaceArguementsValues(old, replacement));
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.objectweb.asm.Opcodes;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -189,7 +190,7 @@ public final class XmlMethod {
      *  - ALOAD
      *  We have to move it into a separate method and use it in 'inline' method.
      */
-    public void inline(final XmlMethod inline, final String old, final String combined) {
+    public void inline(final XmlMethod inline) {
         final List<XmlInvokeVirtual> invocations = this.invokeVirtuals();
         final Set<XmlInstruction> ignored = invocations.stream()
             .map(XmlInvokeVirtual::field)
@@ -201,16 +202,17 @@ public final class XmlMethod {
         for (final XmlInstruction instruction : this.instructions()) {
             if (!ignored.contains(instruction)) {
                 if (where.contains(instruction)) {
-                    inline.instructionsWithout(Opcodes.RETURN, Opcodes.IRETURN, Opcodes.ALOAD)
-                        .stream()
-                        .peek(instr -> instr.replaceArguementsValues(old, combined))
-                        .forEach(body::add);
+                    inline.instructionsToInline().forEach(body::add);
                 } else {
                     body.add(instruction);
                 }
             }
         }
         this.setInstructions(body);
+    }
+
+    private Stream<XmlInstruction> instructionsToInline() {
+        return this.instructionsWithout(Opcodes.RETURN, Opcodes.IRETURN, Opcodes.ALOAD).stream();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -41,6 +41,7 @@ import org.w3c.dom.NodeList;
  * XML method.
  * @since 0.1
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class XmlMethod {
 
     /**
@@ -203,19 +204,6 @@ public final class XmlMethod {
     }
 
     /**
-     * Method instructions that might be inlined.
-     * @return Instructions.
-     * @todo #228:90min. Create more suitable method for determining instructions to inline.
-     *  Currently we are using a method that returns all instructions except return statements,
-     *  which is working for simple examples, but might fail on more complex cases.
-     *  We have to write more tests and create a more suitable method for determining instructions
-     *  to inline.
-     */
-    private Stream<XmlInstruction> instructionsToInline() {
-        return this.instructionsWithout(Opcodes.RETURN, Opcodes.IRETURN, Opcodes.ALOAD).stream();
-    }
-
-    /**
      * Set instructions for method.
      * @param updated New instructions.
      * @todo #176:60min Add unit test for 'setInstructions' method.
@@ -234,6 +222,19 @@ public final class XmlMethod {
         for (final XmlInstruction instruction : updated) {
             root.appendChild(root.getOwnerDocument().adoptNode(instruction.node()));
         }
+    }
+
+    /**
+     * Method instructions that might be inlined.
+     * @return Instructions.
+     * @todo #228:90min. Create more suitable method for determining instructions to inline.
+     *  Currently we are using a method that returns all instructions except return statements,
+     *  which is working for simple examples, but might fail on more complex cases.
+     *  We have to write more tests and create a more suitable method for determining instructions
+     *  to inline.
+     */
+    private Stream<XmlInstruction> instructionsToInline() {
+        return this.instructionsWithout(Opcodes.RETURN, Opcodes.IRETURN, Opcodes.ALOAD).stream();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -180,8 +180,6 @@ public final class XmlMethod {
     /**
      * Inline all method invocations.
      * @param inline Method to inline.
-     * @param old Old name.
-     * @param combined Combined name.
      * @todo #206:60min Simplify 'inline' method.
      *  Right now we use raw "inline" method instructions and trying to filter instructions
      *  that we don't need to inline. Like:

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -180,13 +180,6 @@ public final class XmlMethod {
     /**
      * Inline all method invocations.
      * @param inline Method to inline.
-     * @todo #206:60min Simplify 'inline' method.
-     *  Right now we use raw "inline" method instructions and trying to filter instructions
-     *  that we don't need to inline. Like:
-     *  - RETURN
-     *  - IRETURN
-     *  - ALOAD
-     *  We have to move it into a separate method and use it in 'inline' method.
      */
     public void inline(final XmlMethod inline) {
         final List<XmlInvokeVirtual> invocations = this.invokeVirtuals();
@@ -209,6 +202,15 @@ public final class XmlMethod {
         this.setInstructions(body);
     }
 
+    /**
+     * Method instructions that might be inlined.
+     * @return Instructions.
+     * @todo #228:90min. Create more suitable method for determining instructions to inline.
+     *  Currently we are using a method that returns all instructions except return statements,
+     *  which is working for simple examples, but might fail on more complex cases.
+     *  We have to write more tests and create a more suitable method for determining instructions
+     *  to inline.
+     */
     private Stream<XmlInstruction> instructionsToInline() {
         return this.instructionsWithout(Opcodes.RETURN, Opcodes.IRETURN, Opcodes.ALOAD).stream();
     }


### PR DESCRIPTION
Simplify inlining method and remove redundand  parameters.

Closes: #228.
____
History:
- feat(#228): remove redundant parameters from several methods
- feat(#228): add several supplementary method
- feat(#228): add one more puzzle
- feat(#228): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the inlining and argument replacement functionality in the XmlClass and XmlMethod classes. 

### Detailed summary
- Added `inline` method to XmlClass to inline a method into all possible places.
- Added `replaceArguments` method to XmlClass to replace instruction arguments with new values.
- Modified `replaceOldInvokationsWithNewInvocations` method in ImprovementDistilledObjects to use `inline` method instead of manual replacement.
- Added `instructionsToInline` method to XmlMethod to determine which instructions can be inlined.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->