### PR TITLE
feat(#240): simplify 'arguments' method

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -108,12 +108,6 @@ public final class XmlInstruction implements XmlCommand {
     /**
      * Instruction arguments.
      * @return Arguments.
-     * @todo #234:90min Refactor XmlInstruction#arguments method.
-     *  This method is too complex and has too many responsibilities.
-     *  Moreover, it uses static field LABELS. We have to refactor this method in order
-     *  to avoid all that problems. Don't forget to remove PMD and checkstyle comments about
-     *  suppressed warnings.
-     * @checkstyle NestedIfDepthCheck (100 lines)
      */
     public Object[] arguments() {
         return new XmlNode(this.node)

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -25,10 +25,8 @@ package org.eolang.jeo.representation.xmir;
 
 import com.jcabi.xml.XMLDocument;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.IntStream;
 import org.eolang.jeo.representation.HexData;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
@@ -116,30 +114,6 @@ public final class XmlInstruction implements XmlCommand {
             .toArray();
     }
 
-    /**
-     * Extract argument value from XmlNode.
-     * @param node XmlNode with argument value.
-     * @return Argument value.
-     */
-    private Object argument(final XmlNode node) {
-        final String attr = node.attribute("base")
-            .orElseThrow(
-                () -> new IllegalStateException(
-                    String.format(
-                        "'%s' is not an argument because it doesn't have 'base' attribute",
-                        node
-                    )
-                )
-            );
-        if (attr.equals("int")) {
-            return new HexString(node.text()).decodeAsInt();
-        } else if (attr.equals("label")) {
-            return this.labels.label(node.text());
-        } else {
-            return new HexString(node.text()).decode();
-        }
-    }
-
     @Override
     public boolean equals(final Object other) {
         final boolean result;
@@ -175,6 +149,32 @@ public final class XmlInstruction implements XmlCommand {
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     Node node() {
         return this.node;
+    }
+
+    /**
+     * Extract argument value from XmlNode.
+     * @param argument XmlNode with argument value.
+     * @return Argument value.
+     */
+    private Object argument(final XmlNode argument) {
+        final String attr = argument.attribute("base")
+            .orElseThrow(
+                () -> new IllegalStateException(
+                    String.format(
+                        "'%s' is not an argument because it doesn't have 'base' attribute",
+                        argument
+                    )
+                )
+            );
+        final Object result;
+        if (attr.equals("int")) {
+            result = new HexString(argument.text()).decodeAsInt();
+        } else if (attr.equals("label")) {
+            result = this.labels.label(argument.text());
+        } else {
+            result = new HexString(argument.text()).decode();
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -118,18 +118,32 @@ public final class XmlInstruction implements XmlCommand {
     public Object[] arguments() {
         return new XmlNode(this.node)
             .children()
-            .map(xmlnode -> {
-                final Optional<String> base = xmlnode.attribute("base");
-                if (base.isPresent()) {
-                    final String data = base.get();
-                    if (data.equals("int")) {
-                        return new HexString(xmlnode.text()).decodeAsInt();
-                    } else if (data.equals("label")) {
-                        return this.labels.label(xmlnode.text());
-                    }
-                }
-                return new HexString(xmlnode.text()).decode();
-            }).toArray();
+            .map(this::argument)
+            .toArray();
+    }
+
+    /**
+     * Extract argument value from XmlNode.
+     * @param node XmlNode with argument value.
+     * @return Argument value.
+     */
+    private Object argument(final XmlNode node) {
+        final String attr = node.attribute("base")
+            .orElseThrow(
+                () -> new IllegalStateException(
+                    String.format(
+                        "'%s' is not an argument because it doesn't have 'base' attribute",
+                        node
+                    )
+                )
+            );
+        if (attr.equals("int")) {
+            return new HexString(node.text()).decodeAsInt();
+        } else if (attr.equals("label")) {
+            return this.labels.label(node.text());
+        } else {
+            return new HexString(node.text()).decode();
+        }
     }
 
     @Override


### PR DESCRIPTION
Simplify `XmlInstruction#arguments()` method.

Closes: #240.
____
History:
- feat(#240): use XmlNode in arguments function
- feat(#240): create simple method
- feat(#240): remove the puzzle for 240 issue
- feat(#240): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Refactored the `arguments()` method in `XmlInstruction` class to improve readability and reduce complexity.
- Replaced the use of `NodeList` and `Collection` with `XmlNode` and `Stream` for better handling of XML nodes.
- Extracted the logic for extracting argument values into a separate private method `argument()`.
- Improved error handling by throwing an exception when an argument does not have a required attribute.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->