### PR TITLE
feat(#236): Check Labels in Generated Xmir

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/HexData.java
+++ b/src/main/java/org/eolang/jeo/representation/HexData.java
@@ -26,7 +26,6 @@ package org.eolang.jeo.representation;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.StringJoiner;
-import org.eolang.jeo.representation.xmir.AllLabels;
 import org.objectweb.asm.Label;
 
 /**

--- a/src/main/java/org/eolang/jeo/representation/HexData.java
+++ b/src/main/java/org/eolang/jeo/representation/HexData.java
@@ -26,6 +26,8 @@ package org.eolang.jeo.representation;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.StringJoiner;
+import org.eolang.jeo.representation.xmir.AllLabels;
+import org.objectweb.asm.Label;
 
 /**
  * Hexadecimal data.
@@ -94,6 +96,8 @@ public final class HexData {
             res = "float";
         } else if (this.data instanceof Boolean) {
             res = "bool";
+        } else if (this.data instanceof Label) {
+            res = "label";
         } else {
             res = "bytes";
         }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -23,11 +23,9 @@
  */
 package org.eolang.jeo.representation.directives;
 
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.UUID;
 import org.eolang.jeo.representation.DefaultVersion;
+import org.eolang.jeo.representation.xmir.AllLabels;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -45,7 +43,7 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
     /**
      * All labels inside a method.
      */
-    private final Map<Label, String> labels;
+    private final AllLabels labels;
 
     /**
      * Xembly directives.
@@ -63,7 +61,7 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
     ) {
         super(new DefaultVersion().api(), visitor);
         this.directives = directives;
-        this.labels = new HashMap<>(0);
+        this.labels = new AllLabels();
     }
 
     @Override
@@ -91,8 +89,7 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
 
     @Override
     public void visitJumpInsn(final int opcode, final Label label) {
-        final String id = UUID.randomUUID().toString();
-        this.labels.putIfAbsent(label, id);
+        final String id = this.labels.uid(label);
         this.opcodeWithLabel(opcode, id);
         super.visitJumpInsn(opcode, label);
     }
@@ -129,7 +126,7 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
 
     @Override
     public void visitLabel(final Label label) {
-        this.label(this.labels.getOrDefault(label, UUID.randomUUID().toString()));
+        this.label(this.labels.uid(label));
         super.visitLabel(label);
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/AllLabels.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/AllLabels.java
@@ -24,14 +24,17 @@
 package org.eolang.jeo.representation.xmir;
 
 import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import org.objectweb.asm.Label;
 
 /**
  * All the labels that have been found in bytecode.
  * @since 0.1
  */
-final class AllLabels {
+public final class AllLabels {
 
     /**
      * The common cache for all the labels.
@@ -55,7 +58,7 @@ final class AllLabels {
     /**
      * Constructor.
      */
-    AllLabels() {
+    public AllLabels() {
         this(AllLabels.CACHE);
     }
 
@@ -72,8 +75,26 @@ final class AllLabels {
      * @param uid UID.
      * @return Label.
      */
-    Label label(final String uid) {
+    public Label label(final String uid) {
         return this.labels.computeIfAbsent(AllLabels.clean(uid), id -> new Label());
+    }
+
+    /**
+     * Find UID of Label
+     * @param label Label.
+     * @return UID.
+     */
+    public String uid(final Label label) {
+        final Optional<Map.Entry<String, Label>> found = this.labels.entrySet().stream()
+            .filter(e -> e.getValue().equals(label))
+            .findFirst();
+        if (found.isPresent()) {
+            return found.get().getKey();
+        } else {
+            final String generated = UUID.randomUUID().toString();
+            this.labels.put(generated, label);
+            return generated;
+        }
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/AllLabels.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/AllLabels.java
@@ -24,10 +24,8 @@
 package org.eolang.jeo.representation.xmir;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import org.objectweb.asm.Label;
 
 /**
@@ -80,18 +78,20 @@ public final class AllLabels {
     }
 
     /**
-     * Find UID of Label
+     * Find UID of Label.
      * @param label Label.
      * @return UID.
      */
     public String uid(final Label label) {
         return this.labels.entrySet().stream()
             .filter(e -> e.getValue().equals(label))
-            .findFirst().orElseGet(() -> {
-                final String generated = UUID.randomUUID().toString();
-                this.labels.put(generated, label);
-                return Map.entry(generated, label);
-            }).getKey();
+            .findFirst().orElseGet(
+                () -> {
+                    final String generated = UUID.randomUUID().toString();
+                    this.labels.put(generated, label);
+                    return Map.entry(generated, label);
+                }
+            ).getKey();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/AllLabels.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/AllLabels.java
@@ -85,16 +85,13 @@ public final class AllLabels {
      * @return UID.
      */
     public String uid(final Label label) {
-        final Optional<Map.Entry<String, Label>> found = this.labels.entrySet().stream()
+        return this.labels.entrySet().stream()
             .filter(e -> e.getValue().equals(label))
-            .findFirst();
-        if (found.isPresent()) {
-            return found.get().getKey();
-        } else {
-            final String generated = UUID.randomUUID().toString();
-            this.labels.put(generated, label);
-            return generated;
-        }
+            .findFirst().orElseGet(() -> {
+                final String generated = UUID.randomUUID().toString();
+                this.labels.put(generated, label);
+                return Map.entry(generated, label);
+            }).getKey();
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -24,7 +24,9 @@
 package org.eolang.jeo.representation.directives;
 
 import com.jcabi.xml.XMLDocument;
+import java.util.UUID;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
+import org.eolang.jeo.representation.xmir.AllLabels;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.ClassReader;
@@ -261,14 +263,13 @@ class DirectivesMethodTest {
      *     }
      * }
      * </p>
-     * @todo #226:90min Check Labels.
-     *  In this test we don't check that labels are parsed correctly, but we should.
-     *  Moreover, we have to check that IFLE bytecode instruction has correct label pointer
-     *  to the existing label.
+     * Pay Attention! That we just can't verify exact id's of labels since ASM library doesn't
+     * allow it. Hence, we can just check the presence of a label.
      */
     @Test
     void parsesIfStatementCorrectly() {
-        final Label label = new Label();
+        final AllLabels labels = new AllLabels();
+        final Label label = labels.label(UUID.randomUUID().toString());
         final String xml = new BytecodeClass("Foo")
             .withMethod("bar", "(D)I", 0)
             .instruction(Opcodes.DLOAD, 1)
@@ -290,7 +291,8 @@ class DirectivesMethodTest {
             xml,
             new HasMethod("bar")
                 .inside("Foo")
-                .withInstruction(Opcodes.IFLE)
+                .withInstruction(Opcodes.IFLE, label)
+                .withLabel()
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
@@ -38,7 +38,11 @@ import org.objectweb.asm.Label;
  * Matcher to check if the received XMIR document has a method inside a class with a given name.
  * @since 0.1.0
  */
-@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleCorrectTestName"})
+@SuppressWarnings({
+    "PMD.TooManyMethods",
+    "JTCOP.RuleAllTestsHaveProductionClass",
+    "JTCOP.RuleCorrectTestName"
+})
 public final class HasMethod extends TypeSafeMatcher<String> {
 
     /**
@@ -64,7 +68,7 @@ public final class HasMethod extends TypeSafeMatcher<String> {
     /**
      * Method labels.
      */
-    private final List<HasLabel> labels;
+    private final List<HasLabel> lbls;
 
     /**
      * Constructor.
@@ -84,7 +88,7 @@ public final class HasMethod extends TypeSafeMatcher<String> {
         this.name = method;
         this.params = new ArrayList<>(0);
         this.instr = new ArrayList<>(0);
-        this.labels = new ArrayList<>(0);
+        this.lbls = new ArrayList<>(0);
     }
 
     @Override
@@ -137,7 +141,7 @@ public final class HasMethod extends TypeSafeMatcher<String> {
      * @return The same matcher that checks label.
      */
     public HasMethod withLabel() {
-        this.labels.add(new HasLabel());
+        this.lbls.add(new HasLabel());
         return this;
     }
 
@@ -195,13 +199,13 @@ public final class HasMethod extends TypeSafeMatcher<String> {
     }
 
     /**
-     * Labels xpaths
+     * Labels xpaths.
      * @return List of XPaths to check.
      */
     private Stream<String> labels() {
         final String root = this.root();
-        return this.labels.stream()
-            .flatMap(label -> label.checks(root));
+        return this.lbls.stream()
+            .flatMap(label -> HasLabel.checks(root));
     }
 
     /**
@@ -278,23 +282,25 @@ public final class HasMethod extends TypeSafeMatcher<String> {
             return this.args.stream()
                 .map(
                     arg -> {
+                        final String result;
                         if (arg instanceof Label) {
                             final String uid = new AllLabels().uid((Label) arg);
                             final HexData data = new HexData(uid);
-                            return String.format(
+                            result = String.format(
                                 "%s/o[@base='label']/o[@base='%s' and @data='bytes' and text()]/@data",
                                 instruction,
                                 data.type()
                             );
                         } else {
                             final HexData hex = new HexData(arg);
-                            return String.format(
+                            result = String.format(
                                 "%s/o[@base='%s' and @data='bytes' and text()='%s']/@data",
                                 instruction,
                                 hex.type(),
                                 hex.value()
                             );
                         }
+                        return result;
                     }
                 );
         }
@@ -307,15 +313,15 @@ public final class HasMethod extends TypeSafeMatcher<String> {
      * allow it. Hence, we can just check the presence of a label.
      * @since 0.1
      */
-    private static class HasLabel {
-
+    @SuppressWarnings("PMD.UseUtilityClass")
+    private static final class HasLabel {
 
         /**
          * Checks of label.
          * @param root Root Method XPath.
          * @return List of XPaths to check.
          */
-        Stream<String> checks(final String root) {
+        static Stream<String> checks(final String root) {
             return Stream.of(
                 String.format(
                     "%s/o[@base='seq']/o[@base='label']/o[@base='string' and @data='bytes']/@data",

--- a/src/test/java/org/eolang/jeo/representation/xmir/AllLabelsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/AllLabelsTest.java
@@ -61,4 +61,30 @@ class AllLabelsTest {
             Matchers.sameInstance(second)
         );
     }
+
+    @Test
+    void generatesUidForNewLabel() {
+        MatcherAssert.assertThat(
+            "We should generate uid for new label",
+            new AllLabels().uid(new Label()),
+            Matchers.notNullValue()
+        );
+    }
+
+    @Test
+    void retrievesSameUidForSameLabel() {
+        final AllLabels all = new AllLabels();
+        final Label label = new Label();
+        final String first = all.uid(label);
+        final String second = all.uid(label);
+        MatcherAssert.assertThat(
+            String.format(
+                "We should retrieve the same uid for the same label, but we got %s and %s",
+                first,
+                second
+            ),
+            first,
+            Matchers.equalTo(second)
+        );
+    }
 }


### PR DESCRIPTION
Check labels in XMIR as instructions and as instructions parameters.
(In some cases a label is a point among intructions and sometimes it is parameter of other instructions like IFLE)

Closes: #236.
____
History:
- feat(#236): check labels presence in the XMIR
- feat(#236): add tests for AllLabels#uid
- feat(#236): fix all tests
- feat(#236): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding support for labels in the XMIR representation.

### Detailed summary:
- Added support for `Label` data type in `HexData` class.
- Added `AllLabels` class to manage all labels found in bytecode.
- Added `uid` method in `AllLabels` class to find the UID of a label.
- Updated `DirectivesMethod` class to use `AllLabels` for managing labels.
- Added tests to verify the generation and retrieval of UID for labels.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->