### PR TITLE
feat(#235): Fix Code Duplication Bewtween `instructions` and `commands`

### DIFF
--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -116,7 +116,7 @@ public final class ImprovementDistilledObjects implements Improvement {
             );
             clazz.methods()
                 .stream()
-                .map(XmlMethod::commands)
+                .map(XmlMethod::instructions)
                 .flatMap(Collection::stream)
                 .forEach(
                     instruction ->
@@ -143,7 +143,7 @@ public final class ImprovementDistilledObjects implements Improvement {
         final List<XmlInstruction> replacement
     ) {
         for (final XmlMethod method : clazz.methods()) {
-            final List<XmlCommand> instructions = method.commands();
+            final List<XmlCommand> instructions = method.instructions();
             final List<XmlCommand> updated = new ArrayList<>(0);
             final int size = target.size();
             for (int index = 0; index < instructions.size(); ++index) {

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -39,6 +39,7 @@ import org.eolang.jeo.Representation;
 import org.eolang.jeo.representation.EoRepresentation;
 import org.eolang.jeo.representation.HexData;
 import org.eolang.jeo.representation.xmir.XmlClass;
+import org.eolang.jeo.representation.xmir.XmlCommand;
 import org.eolang.jeo.representation.xmir.XmlField;
 import org.eolang.jeo.representation.xmir.XmlInstruction;
 import org.eolang.jeo.representation.xmir.XmlMethod;
@@ -142,18 +143,18 @@ public final class ImprovementDistilledObjects implements Improvement {
         final List<XmlInstruction> replacement
     ) {
         for (final XmlMethod method : clazz.methods()) {
-            final List<XmlInstruction> instructions = method.instructions();
-            final List<XmlInstruction> updated = new ArrayList<>(0);
+            final List<XmlCommand> instructions = method.commands();
+            final List<XmlCommand> updated = new ArrayList<>(0);
             final int size = target.size();
             for (int index = 0; index < instructions.size(); ++index) {
-                final List<XmlInstruction> stack = new ArrayList<>(0);
+                final List<XmlCommand> stack = new ArrayList<>(0);
                 for (
                     int inner = 0;
                     inner < size && index < instructions.size();
                     ++inner
                 ) {
                     final XmlInstruction targeted = target.get(inner);
-                    final XmlInstruction current = instructions.get(index);
+                    final XmlCommand current = instructions.get(index);
                     if (current.equals(targeted)) {
                         if (inner == size - 1) {
                             updated.addAll(replacement);

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -116,7 +116,7 @@ public final class ImprovementDistilledObjects implements Improvement {
             );
             clazz.methods()
                 .stream()
-                .map(XmlMethod::instructions)
+                .map(XmlMethod::commands)
                 .flatMap(Collection::stream)
                 .forEach(
                     instruction ->

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
@@ -72,7 +72,7 @@ public final class XmlBytecode {
                 xmlmethod.descriptor(),
                 xmlmethod.access()
             );
-            xmlmethod.commands()
+            xmlmethod.instructions()
                 .forEach(inst -> inst.writeTo(method));
         }
         return bytecode.bytecode();

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -148,7 +148,7 @@ public final class XmlClass {
     public void replaceArguments(final String old, final String replacement) {
         this.methods()
             .stream()
-            .map(XmlMethod::instructions)
+            .map(XmlMethod::commands)
             .flatMap(Collection::stream)
             .forEach(instruction -> instruction.replaceArguementsValues(old, replacement));
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -148,7 +148,7 @@ public final class XmlClass {
     public void replaceArguments(final String old, final String replacement) {
         this.methods()
             .stream()
-            .map(XmlMethod::commands)
+            .map(XmlMethod::instructions)
             .flatMap(Collection::stream)
             .forEach(instruction -> instruction.replaceArguementsValues(old, replacement));
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlCommand.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlCommand.java
@@ -42,6 +42,12 @@ public interface XmlCommand {
      */
     void writeTo(BytecodeMethod method);
 
+    /**
+     * Check if instruction has opcode.
+     * @param opcode Opcode comparing with.
+     * @return True if instruction has opcode.
+     */
+    boolean hasOpcode(int opcode);
 
     Node node();
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlCommand.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlCommand.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation.xmir;
 
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
+import org.w3c.dom.Node;
 
 /**
  * XML representation of bytecode instruction or a label.
@@ -40,4 +41,7 @@ public interface XmlCommand {
      * @param method Bytecode Method where instruction should be written.
      */
     void writeTo(BytecodeMethod method);
+
+
+    Node node();
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlCommand.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlCommand.java
@@ -49,5 +49,16 @@ public interface XmlCommand {
      */
     boolean hasOpcode(int opcode);
 
+    /**
+     * Replace values of instruction arguments.
+     * @param old Old value.
+     * @param replacement Which value to set instead.
+     */
+    void replaceArguementsValues(String old, String replacement);
+
+    /**
+     * Xml node.
+     * @return Xml node.
+     */
     Node node();
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -37,6 +37,10 @@ import org.w3c.dom.NodeList;
 /**
  * Bytecode instruction from XML.
  * @since 0.1
+ * @todo #157:90min Hide internal node representation in XmlInstruction.
+ *  This class should not expose internal node representation.
+ *  We have to consider to add methods or classes in order to avoid
+ *  exposing internal node representation.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class XmlInstruction implements XmlCommand {
@@ -67,18 +71,6 @@ public final class XmlInstruction implements XmlCommand {
     XmlInstruction(final Node node) {
         this.node = node;
         this.labels = new AllLabels();
-    }
-
-    /**
-     * Instruction code.
-     * @return Code.
-     */
-    public int code() {
-        return Integer.parseInt(
-            this.node.getAttributes()
-                .getNamedItem("name")
-                .getNodeValue().split("-")[1]
-        );
     }
 
     @Override
@@ -139,18 +131,22 @@ public final class XmlInstruction implements XmlCommand {
         return new XMLDocument(this.node).toString();
     }
 
-    /**
-     * XML node.
-     * @return XML node.
-     * @todo #157:90min Hide internal node representation in XmlInstruction.
-     *  This class should not expose internal node representation.
-     *  We have to consider to add methods or classes in order to avoid
-     *  exposing internal node representation.
-     */
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     @Override
     public Node node() {
         return this.node;
+    }
+
+    /**
+     * Instruction code.
+     * @return Code.
+     */
+    private int code() {
+        return Integer.parseInt(
+            this.node.getAttributes()
+                .getNamedItem("name")
+                .getNodeValue().split("-")[1]
+        );
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -86,6 +86,11 @@ public final class XmlInstruction implements XmlCommand {
         method.instruction(this.code(), this.arguments());
     }
 
+    @Override
+    public boolean hasOpcode(final int opcode) {
+        return this.code() == opcode;
+    }
+
     /**
      * Replace values of instruction arguments.
      * @param old Old value.

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -147,7 +147,8 @@ public final class XmlInstruction implements XmlCommand {
      *  exposing internal node representation.
      */
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
-    Node node() {
+    @Override
+    public Node node() {
         return this.node;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -91,11 +91,7 @@ public final class XmlInstruction implements XmlCommand {
         return this.code() == opcode;
     }
 
-    /**
-     * Replace values of instruction arguments.
-     * @param old Old value.
-     * @param replacement Which value to set instead.
-     */
+    @Override
     public void replaceArguementsValues(final String old, final String replacement) {
         final String oldname = new HexData(old).value();
         new XmlNode(this.node).children().forEach(

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInvokeVirtual.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInvokeVirtual.java
@@ -35,13 +35,13 @@ public class XmlInvokeVirtual {
     /**
      * Instructions.
      */
-    private final List<XmlInstruction> instructions;
+    private final List<XmlCommand> instructions;
 
     /**
      * Constructor.
      * @param instructions Instructions.
      */
-    XmlInvokeVirtual(final List<XmlInstruction> instructions) {
+    XmlInvokeVirtual(final List<XmlCommand> instructions) {
         this.instructions = instructions;
     }
 
@@ -49,7 +49,7 @@ public class XmlInvokeVirtual {
      * GETFIELD instruction.
      * @return Instruction.
      */
-    XmlInstruction field() {
+    XmlCommand field() {
         return this.instructions.get(0);
     }
 
@@ -57,40 +57,16 @@ public class XmlInvokeVirtual {
      * INVOKEVIRTUAL instruction.
      * @return Instruction.
      */
-    XmlInstruction invocation() {
+    XmlCommand invocation() {
         return this.instructions.get(this.instructions.size() - 1);
-    }
-
-    /**
-     * Get field name.
-     * @return Field name.
-     */
-    String fieldName() {
-        return String.valueOf(this.field().arguments()[1]);
-    }
-
-    /**
-     * Get field type.
-     * @return Field type.
-     */
-    String fieldType() {
-        return String.valueOf(this.field().arguments()[2]);
-    }
-
-    /**
-     * Get method name.
-     * @return Method name.
-     */
-    String methodName() {
-        return String.valueOf(this.invocation().arguments()[1]);
     }
 
     /**
      * Get method arguments.
      * @return Method arguments.
      */
-    List<XmlInstruction> arguments() {
-        final List<XmlInstruction> result;
+    List<XmlCommand> arguments() {
+        final List<XmlCommand> result;
         if (this.instructions.size() < 3) {
             result = Collections.emptyList();
         } else {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
@@ -35,6 +35,7 @@ public final class XmlLabel implements XmlCommand {
     /**
      * Label node.
      */
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     private final XmlNode node;
 
     /**
@@ -63,7 +64,7 @@ public final class XmlLabel implements XmlCommand {
 
     @Override
     public void replaceArguementsValues(final String old, final String replacement) {
-
+        // Nothing to replace
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
@@ -57,6 +57,11 @@ public final class XmlLabel implements XmlCommand {
     }
 
     @Override
+    public boolean hasOpcode(final int opcode) {
+        return false;
+    }
+
+    @Override
     public Node node() {
         return this.node.node();
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
@@ -62,6 +62,11 @@ public final class XmlLabel implements XmlCommand {
     }
 
     @Override
+    public void replaceArguementsValues(final String old, final String replacement) {
+
+    }
+
+    @Override
     public Node node() {
         return this.node.node();
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation.xmir;
 
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
+import org.w3c.dom.Node;
 
 /**
  * XML representation of bytecode label.
@@ -53,5 +54,10 @@ public final class XmlLabel implements XmlCommand {
     @Override
     public void writeTo(final BytecodeMethod method) {
         method.markLabel(this.labels.label(this.node.child("base", "string").text()));
+    }
+
+    @Override
+    public Node node() {
+        return this.node.node();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -116,19 +116,6 @@ public final class XmlMethod {
     }
 
     /**
-     * Retrieves instructions except for the ones with the given opcodes.
-     * @param opcodes Opcodes to exclude.
-     * @return Instructions.
-     */
-    public List<XmlInstruction> instructionsWithout(final int... opcodes) {
-        return this.instructions(
-            instruction -> Arrays.stream(opcodes).noneMatch(
-                opcode -> instruction.code() == opcode
-            )
-        );
-    }
-
-    /**
      * All method instructions.
      * @return Instructions.
      * @todo #226:90min Code duplication with 'instructions' method.
@@ -251,8 +238,8 @@ public final class XmlMethod {
      *  We have to write more tests and create a more suitable method for determining instructions
      *  to inline.
      */
-    private Stream<XmlInstruction> instructionsToInline() {
-        return this.instructionsWithout(Opcodes.RETURN, Opcodes.IRETURN, Opcodes.ALOAD).stream();
+    private Stream<XmlCommand> instructionsToInline() {
+        return this.commands(new Without(Opcodes.RETURN, Opcodes.IRETURN, Opcodes.ALOAD)).stream();
     }
 
     /**
@@ -278,5 +265,31 @@ public final class XmlMethod {
             }
         }
         return result;
+    }
+
+    /**
+     * Predicated for filtering commands.
+     * Filters commands that have specified opcodes.
+     * @since 0.1.
+     */
+    private static final class Without implements Predicate<XmlCommand> {
+
+        /**
+         * Opcodes to exclude.
+         */
+        private final int[] opcodes;
+
+        /**
+         * Constructor.
+         * @param opcodes Opcodes to exclude.
+         */
+        private Without(final int... opcodes) {
+            this.opcodes = opcodes;
+        }
+
+        @Override
+        public boolean test(final XmlCommand xmlCommand) {
+            return Arrays.stream(this.opcodes).noneMatch(xmlCommand::hasOpcode);
+        }
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -117,6 +117,7 @@ public final class XmlMethod {
 
     /**
      * All method instructions.
+     * @param predicates Predicates to filter instructions.
      * @return Instructions.
      */
     @SafeVarargs
@@ -220,7 +221,8 @@ public final class XmlMethod {
      *  to inline.
      */
     private Stream<XmlCommand> instructionsToInline() {
-        return this.instructions(new Without(Opcodes.RETURN, Opcodes.IRETURN, Opcodes.ALOAD)).stream();
+        return this.instructions(new Without(Opcodes.RETURN, Opcodes.IRETURN, Opcodes.ALOAD))
+            .stream();
     }
 
     /**
@@ -251,7 +253,7 @@ public final class XmlMethod {
     /**
      * Predicated for filtering commands.
      * Filters commands that have specified opcodes.
-     * @since 0.1.
+     * @since 0.1
      */
     private static final class Without implements Predicate<XmlCommand> {
 
@@ -265,12 +267,12 @@ public final class XmlMethod {
          * @param opcodes Opcodes to exclude.
          */
         private Without(final int... opcodes) {
-            this.opcodes = opcodes;
+            this.opcodes = Arrays.copyOf(opcodes, opcodes.length);
         }
 
         @Override
-        public boolean test(final XmlCommand xmlCommand) {
-            return Arrays.stream(this.opcodes).noneMatch(xmlCommand::hasOpcode);
+        public boolean test(final XmlCommand instr) {
+            return Arrays.stream(this.opcodes).noneMatch(instr::hasOpcode);
         }
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -134,21 +134,6 @@ public final class XmlMethod {
     }
 
     /**
-     * Method instructions.
-     * @param predicates Filters.
-     * @return Instructions.
-     */
-    @SafeVarargs
-    public final List<XmlInstruction> instructions(final Predicate<XmlInstruction>... predicates) {
-        return new XmlNode(this.node).child("base", "seq")
-            .children()
-            .filter(element -> element.attribute("name").isPresent())
-            .map(XmlNode::toInstruction)
-            .filter(instr -> Arrays.stream(predicates).allMatch(predicate -> predicate.test(instr)))
-            .collect(Collectors.toList());
-    }
-
-    /**
      * Copy method node.
      * @return Instructions.
      */

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -118,13 +118,9 @@ public final class XmlMethod {
     /**
      * All method instructions.
      * @return Instructions.
-     * @todo #226:90min Code duplication with 'instructions' method.
-     *  Currently we have two methods that return instructions. They are 'instructions' and
-     *  'commads'. We have to remove code duplication between them. Maybe it makes sense to
-     *  leave only one method and remove the other one.
      */
     @SafeVarargs
-    public final List<XmlCommand> commands(final Predicate<XmlCommand>... predicates) {
+    public final List<XmlCommand> instructions(final Predicate<XmlCommand>... predicates) {
         return new XmlNode(this.node).child("base", "seq")
             .children()
             .filter(element -> element.attribute("base").isPresent())
@@ -152,7 +148,7 @@ public final class XmlMethod {
      * @return List of invocations.
      */
     public List<XmlInvokeVirtual> invokeVirtuals() {
-        final List<XmlCommand> all = this.commands();
+        final List<XmlCommand> all = this.instructions();
         final List<XmlInvokeVirtual> res = new ArrayList<>(0);
         for (int index = 0; index < all.size(); ++index) {
             final XmlCommand top = all.get(index);
@@ -181,7 +177,7 @@ public final class XmlMethod {
             .map(XmlInvokeVirtual::invocation)
             .collect(Collectors.toSet());
         final List<XmlCommand> body = new ArrayList<>(0);
-        for (final XmlCommand instruction : this.commands()) {
+        for (final XmlCommand instruction : this.instructions()) {
             if (!ignored.contains(instruction)) {
                 if (where.contains(instruction)) {
                     inline.instructionsToInline().forEach(body::add);
@@ -224,7 +220,7 @@ public final class XmlMethod {
      *  to inline.
      */
     private Stream<XmlCommand> instructionsToInline() {
-        return this.commands(new Without(Opcodes.RETURN, Opcodes.IRETURN, Opcodes.ALOAD)).stream();
+        return this.instructions(new Without(Opcodes.RETURN, Opcodes.IRETURN, Opcodes.ALOAD)).stream();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -180,14 +180,14 @@ public final class XmlMethod {
      * @return List of invocations.
      */
     public List<XmlInvokeVirtual> invokeVirtuals() {
-        final List<XmlInstruction> all = this.instructions();
+        final List<XmlCommand> all = this.commands();
         final List<XmlInvokeVirtual> res = new ArrayList<>(0);
         for (int index = 0; index < all.size(); ++index) {
-            final XmlInstruction top = all.get(index);
-            if (top.code() == Opcodes.GETFIELD) {
+            final XmlCommand top = all.get(index);
+            if (top.hasOpcode(Opcodes.GETFIELD)) {
                 for (int inner = index + 1; inner < all.size(); ++inner) {
-                    final XmlInstruction bottom = all.get(inner);
-                    if (bottom.code() == Opcodes.INVOKEVIRTUAL) {
+                    final XmlCommand bottom = all.get(inner);
+                    if (bottom.hasOpcode(Opcodes.INVOKEVIRTUAL)) {
                         res.add(new XmlInvokeVirtual(all.subList(index, inner + 1)));
                     }
                 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -46,6 +46,7 @@ final class XmlNode {
     /**
      * Parent node.
      */
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     private final Node node;
 
     /**
@@ -125,14 +126,6 @@ final class XmlNode {
             result = new XmlLabel(this);
         }
         return result;
-    }
-
-    /**
-     * Convert to an instruction.
-     * @return Instruction.
-     */
-    XmlInstruction toInstruction() {
-        return new XmlInstruction(this.node);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -57,6 +57,14 @@ final class XmlNode {
     }
 
     /**
+     * To XML node.
+     * @return Xml node
+     */
+    public Node node() {
+        return this.node;
+    }
+
+    /**
      * Get child node.
      * @param name Child node name.
      * @return Child node.

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
@@ -77,21 +77,6 @@ class XmlMethodTest {
             call.arguments(),
             Matchers.hasSize(1)
         );
-        MatcherAssert.assertThat(
-            "Field name should be 'a' in hex",
-            call.fieldName(),
-            Matchers.equalTo("a")
-        );
-        MatcherAssert.assertThat(
-            "Field type should be 'Lorg/eolang/jeo/A;' in hex",
-            call.fieldType(),
-            Matchers.equalTo("Lorg/eolang/jeo/A;")
-        );
-        MatcherAssert.assertThat(
-            "Method name should be 'foo' in hex",
-            call.methodName(),
-            Matchers.equalTo("foo")
-        );
     }
 
     @Test


### PR DESCRIPTION
Remove code duplication beween `XmlMethod#instructions()` and `XmlMethod#commands()` methods.

Closes: #235.
____
History:
- feat(#235): replace some instruction invokations
- feat(#235): remove redundant code
- feat(#235): remove one more redundant method
- feat(#235): remove duplicated method
- feat(#235): remove the puzzle for 235 issue
- feat(#235): fix all qulice suggestions
