### PR TITLE
feat(#233): rename `Command` to `Entry`

### DIFF
--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -38,8 +38,8 @@ import org.eolang.jeo.Improvement;
 import org.eolang.jeo.Representation;
 import org.eolang.jeo.representation.EoRepresentation;
 import org.eolang.jeo.representation.HexData;
+import org.eolang.jeo.representation.xmir.XmlBytecodeEntry;
 import org.eolang.jeo.representation.xmir.XmlClass;
-import org.eolang.jeo.representation.xmir.XmlCommand;
 import org.eolang.jeo.representation.xmir.XmlField;
 import org.eolang.jeo.representation.xmir.XmlInstruction;
 import org.eolang.jeo.representation.xmir.XmlMethod;
@@ -143,18 +143,18 @@ public final class ImprovementDistilledObjects implements Improvement {
         final List<XmlInstruction> replacement
     ) {
         for (final XmlMethod method : clazz.methods()) {
-            final List<XmlCommand> instructions = method.instructions();
-            final List<XmlCommand> updated = new ArrayList<>(0);
+            final List<XmlBytecodeEntry> instructions = method.instructions();
+            final List<XmlBytecodeEntry> updated = new ArrayList<>(0);
             final int size = target.size();
             for (int index = 0; index < instructions.size(); ++index) {
-                final List<XmlCommand> stack = new ArrayList<>(0);
+                final List<XmlBytecodeEntry> stack = new ArrayList<>(0);
                 for (
                     int inner = 0;
                     inner < size && index < instructions.size();
                     ++inner
                 ) {
                     final XmlInstruction targeted = target.get(inner);
-                    final XmlCommand current = instructions.get(index);
+                    final XmlBytecodeEntry current = instructions.get(index);
                     if (current.equals(targeted)) {
                         if (inner == size - 1) {
                             updated.addAll(replacement);

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeEntry.java
@@ -23,30 +23,17 @@
  */
 package org.eolang.jeo.representation.bytecode;
 
-import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 
 /**
- * Mark label instruction.
+ * Bytecode instruction or a label.
+ * Might be a label, a jump, a method call, etc.
  * @since 0.1
  */
-public final class MarkLabelInstruction implements BytecodeInstruction {
-
+public interface BytecodeEntry {
     /**
-     * Label.
+     * Write instruction to the method visitor.
+     * @param visitor Method visitor.
      */
-    private final Label label;
-
-    /**
-     * Constructor.
-     * @param label Label.
-     */
-    MarkLabelInstruction(final Label label) {
-        this.label = label;
-    }
-
-    @Override
-    public void generate(final MethodVisitor visitor) {
-        visitor.visitLabel(this.label);
-    }
+    void generate(MethodVisitor visitor);
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionEntry.java
@@ -33,7 +33,7 @@ import org.objectweb.asm.Opcodes;
  * Bytecode instruction.
  * @since 0.1.0
  */
-final class CommandInstruction implements BytecodeInstruction {
+final class BytecodeInstructionEntry implements BytecodeEntry {
 
     /**
      * Opcode.
@@ -50,7 +50,7 @@ final class CommandInstruction implements BytecodeInstruction {
      * @param opcode Opcode.
      * @param args Arguments.
      */
-    CommandInstruction(
+    BytecodeInstructionEntry(
         final int opcode,
         final Object... args
     ) {
@@ -62,7 +62,7 @@ final class CommandInstruction implements BytecodeInstruction {
      * @param opcode Opcode.
      * @param args Arguments.
      */
-    CommandInstruction(
+    BytecodeInstructionEntry(
         final int opcode,
         final List<Object> args
     ) {

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabelEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabelEntry.java
@@ -23,17 +23,30 @@
  */
 package org.eolang.jeo.representation.bytecode;
 
+import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 
 /**
- * Bytecode instruction.
- * Might be a label, a jump, a method call, etc.
+ * Mark label instruction.
  * @since 0.1
  */
-public interface BytecodeInstruction {
+public final class BytecodeLabelEntry implements BytecodeEntry {
+
     /**
-     * Write instruction to the method visitor.
-     * @param visitor Method visitor.
+     * Label.
      */
-    void generate(MethodVisitor visitor);
+    private final Label label;
+
+    /**
+     * Constructor.
+     * @param label Label.
+     */
+    BytecodeLabelEntry(final Label label) {
+        this.label = label;
+    }
+
+    @Override
+    public void generate(final MethodVisitor visitor) {
+        visitor.visitLabel(this.label);
+    }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -55,7 +55,7 @@ public final class BytecodeMethod {
     /**
      * Method Instructions.
      */
-    private final List<BytecodeInstruction> instructions;
+    private final List<BytecodeEntry> instructions;
 
     /**
      * Access.
@@ -105,7 +105,7 @@ public final class BytecodeMethod {
      * @return This object.
      */
     public BytecodeMethod markLabel(final Label label) {
-        this.instructions.add(new MarkLabelInstruction(label));
+        this.instructions.add(new BytecodeLabelEntry(label));
         return this;
     }
 
@@ -116,7 +116,7 @@ public final class BytecodeMethod {
      * @return This object.
      */
     public BytecodeMethod instruction(final int opcode, final Object... args) {
-        this.instructions.add(new CommandInstruction(opcode, args));
+        this.instructions.add(new BytecodeInstructionEntry(opcode, args));
         return this;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
@@ -28,13 +28,11 @@ import org.w3c.dom.Node;
 
 /**
  * XML representation of bytecode instruction or a label.
+ * Usually each method in bytecode contains a list of bytecode entries.
+ * Since they aren't always instructions, we call them entries.
  * @since 0.1
- * @todo #226:90min Rename XmlCommand to XmlInstruction.
- *  XmlCommand is a bad name for this class. It is not a command, it is an instruction in general.
- *  Since instruction could be a label or a bytecode instruction, it is better to rename this class
- *  to XmlInstruction. After that, rename all usages of the old XmlInstruction to XmlCommand.
  */
-public interface XmlCommand {
+public interface XmlBytecodeEntry {
 
     /**
      * Write instruction to the bytecode method.

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -43,7 +43,7 @@ import org.w3c.dom.NodeList;
  *  exposing internal node representation.
  */
 @SuppressWarnings("PMD.TooManyMethods")
-public final class XmlInstruction implements XmlCommand {
+public final class XmlInstruction implements XmlBytecodeEntry {
 
     /**
      * Instruction node.

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInvokeVirtual.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInvokeVirtual.java
@@ -35,13 +35,13 @@ public class XmlInvokeVirtual {
     /**
      * Instructions.
      */
-    private final List<XmlCommand> instructions;
+    private final List<XmlBytecodeEntry> instructions;
 
     /**
      * Constructor.
      * @param instructions Instructions.
      */
-    XmlInvokeVirtual(final List<XmlCommand> instructions) {
+    XmlInvokeVirtual(final List<XmlBytecodeEntry> instructions) {
         this.instructions = instructions;
     }
 
@@ -49,7 +49,7 @@ public class XmlInvokeVirtual {
      * GETFIELD instruction.
      * @return Instruction.
      */
-    XmlCommand field() {
+    XmlBytecodeEntry field() {
         return this.instructions.get(0);
     }
 
@@ -57,7 +57,7 @@ public class XmlInvokeVirtual {
      * INVOKEVIRTUAL instruction.
      * @return Instruction.
      */
-    XmlCommand invocation() {
+    XmlBytecodeEntry invocation() {
         return this.instructions.get(this.instructions.size() - 1);
     }
 
@@ -65,8 +65,8 @@ public class XmlInvokeVirtual {
      * Get method arguments.
      * @return Method arguments.
      */
-    List<XmlCommand> arguments() {
-        final List<XmlCommand> result;
+    List<XmlBytecodeEntry> arguments() {
+        final List<XmlBytecodeEntry> result;
         if (this.instructions.size() < 3) {
             result = Collections.emptyList();
         } else {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
@@ -30,7 +30,7 @@ import org.w3c.dom.Node;
  * XML representation of bytecode label.
  * @since 0.1
  */
-public final class XmlLabel implements XmlCommand {
+public final class XmlLabel implements XmlBytecodeEntry {
 
     /**
      * Label node.

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -118,8 +118,8 @@ final class XmlNode {
      * Convert to a command.
      * @return Command.
      */
-    XmlCommand toCommand() {
-        final XmlCommand result;
+    XmlBytecodeEntry toCommand() {
+        final XmlBytecodeEntry result;
         if (this.attribute("name").isPresent()) {
             result = new XmlInstruction(this.node);
         } else {


### PR DESCRIPTION
Rename `Command`, `Instruction` and `Label` related classes -> `BytecodeEntry`, `Instruction`, `Label` in both packages: `xmir` and `bytecode`.
Closes: #233.
____
History:
- feat(#233): rename XmlCommand -> XmlBytecodeEntry
- feat(#233): rename classes in bytecode package according with the new naming strategy


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming and refactoring the `XmlCommand` class to `XmlBytecodeEntry` and related changes. 

### Detailed summary
- Renamed `XmlCommand` to `XmlBytecodeEntry` in multiple files.
- Updated method signatures and return types accordingly.
- Renamed `BytecodeInstruction` to `BytecodeEntry`.
- Updated references and usages of the old class names.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->