### PR TITLE
feat(#232): Remove Code Duplication in `DirectivesMethod` Class

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesLabel.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
@@ -6,16 +29,36 @@ import org.objectweb.asm.Label;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
-public class DirectivesLabel implements Iterable<Directive> {
+/**
+ * Xml directives for label entry in byrecode.
+ * @since 0.1
+ */
+public final class DirectivesLabel implements Iterable<Directive> {
 
+    /**
+     * Bytecode label.
+     */
     private final Label label;
+
+    /**
+     * All labels.
+     */
     private final AllLabels all;
 
-    public DirectivesLabel(final Label label) {
+    /**
+     * Constructor.
+     * @param label Bytecode label.
+     */
+    DirectivesLabel(final Label label) {
         this(label, new AllLabels());
     }
 
-    public DirectivesLabel(final Label label, final AllLabels all) {
+    /**
+     * Constructor.
+     * @param label Bytecode label.
+     * @param all All labels.
+     */
+    private DirectivesLabel(final Label label, final AllLabels all) {
         this.label = label;
         this.all = all;
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesLabel.java
@@ -1,0 +1,32 @@
+package org.eolang.jeo.representation.directives;
+
+import java.util.Iterator;
+import org.eolang.jeo.representation.xmir.AllLabels;
+import org.objectweb.asm.Label;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+public class DirectivesLabel implements Iterable<Directive> {
+
+    private final Label label;
+    private final AllLabels all;
+
+    public DirectivesLabel(final Label label) {
+        this(label, new AllLabels());
+    }
+
+    public DirectivesLabel(final Label label, final AllLabels all) {
+        this.label = label;
+        this.all = all;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        final String uid = this.all.uid(this.label);
+        return new Directives().add("o")
+            .attr("base", "label")
+            .append(new DirectivesData(uid))
+            .up()
+            .iterator();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
 import org.eolang.jeo.representation.DefaultVersion;
-import org.eolang.jeo.representation.xmir.AllLabels;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -39,11 +38,6 @@ import org.xembly.Directives;
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class DirectivesMethod extends MethodVisitor implements Iterable<Directive> {
-
-    /**
-     * All labels inside a method.
-     */
-    private final AllLabels labels;
 
     /**
      * Xembly directives.
@@ -61,7 +55,6 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
     ) {
         super(new DefaultVersion().api(), visitor);
         this.directives = directives;
-        this.labels = new AllLabels();
     }
 
     @Override
@@ -164,23 +157,25 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
         /**
          * Raw operand.
          */
-        private final Object operand;
+        private final Object raw;
 
         /**
          * Constructor.
          * @param operand Raw operand.
          */
         private Operand(final Object operand) {
-            this.operand = operand;
+            this.raw = operand;
         }
 
         @Override
         public Iterator<Directive> iterator() {
-            if (this.operand instanceof Label) {
-                return new DirectivesLabel((Label) this.operand).iterator();
+            final Iterator<Directive> result;
+            if (this.raw instanceof Label) {
+                result = new DirectivesLabel((Label) this.raw).iterator();
             } else {
-                return new DirectivesData(this.operand).iterator();
+                result = new DirectivesData(this.raw).iterator();
             }
+            return result;
         }
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -89,7 +89,7 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
 
     @Override
     public void visitJumpInsn(final int opcode, final Label label) {
-        this.opcodeWithLabel(opcode, label);
+        this.opcode(opcode, label);
         super.visitJumpInsn(opcode, label);
     }
 
@@ -126,7 +126,7 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
     @Override
     public void visitLabel(final Label label) {
 //        this.label(this.labels.uid(label));
-        this.directives.append(new DirectivesLabel(label));
+        this.directives.append(new Operand(label));
         super.visitLabel(label);
     }
 
@@ -151,7 +151,7 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
             .attr("name", new OpcodeName(opcode).asString())
             .attr("base", "opcode");
         for (final Object operand : operands) {
-            this.directives.append(new DirectivesData(operand));
+            this.directives.append(new Operand(operand));
         }
         this.directives.up();
     }
@@ -184,7 +184,11 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
 
         @Override
         public Iterator<Directive> iterator() {
-            return null;
+            if (this.operand instanceof Label) {
+                return new DirectivesLabel((Label) this.operand).iterator();
+            } else {
+                return new DirectivesData(this.operand).iterator();
+            }
         }
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -89,8 +89,7 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
 
     @Override
     public void visitJumpInsn(final int opcode, final Label label) {
-        final String id = this.labels.uid(label);
-        this.opcodeWithLabel(opcode, id);
+        this.opcodeWithLabel(opcode, label);
         super.visitJumpInsn(opcode, label);
     }
 
@@ -126,7 +125,8 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
 
     @Override
     public void visitLabel(final Label label) {
-        this.label(this.labels.uid(label));
+//        this.label(this.labels.uid(label));
+        this.directives.append(new DirectivesLabel(label));
         super.visitLabel(label);
     }
 
@@ -139,17 +139,6 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
     @Override
     public Iterator<Directive> iterator() {
         return this.directives.iterator();
-    }
-
-    /**
-     * Add label to the directives.
-     * @param id Label id.
-     */
-    private void label(final String id) {
-        this.directives.add("o")
-            .attr("base", "label")
-            .append(new DirectivesData(id))
-            .up();
     }
 
     /**
@@ -176,11 +165,26 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
      *  We have to consider to refactor this code in order to avoid
      *  code duplication.
      */
-    private void opcodeWithLabel(final int opcode, final String label) {
+    private void opcodeWithLabel(final int opcode, final Label label) {
         this.directives.add("o")
             .attr("name", new OpcodeName(opcode).asString())
             .attr("base", "opcode");
-        this.label(label);
+        this.directives.append(new DirectivesLabel(label));
         this.directives.up();
+    }
+
+
+    private static final class Operand implements Iterable<Directive> {
+
+        private final Object operand;
+
+        private Operand(final Object operand) {
+            this.operand = operand;
+        }
+
+        @Override
+        public Iterator<Directive> iterator() {
+            return null;
+        }
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -125,7 +125,6 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
 
     @Override
     public void visitLabel(final Label label) {
-//        this.label(this.labels.uid(label));
         this.directives.append(new Operand(label));
         super.visitLabel(label);
     }
@@ -157,27 +156,20 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
     }
 
     /**
-     * Add opcode with label to the directives.
-     * @param opcode Opcode
-     * @param label Label
-     * @todo #226:90min Code duplication in DirectivesMethod.opcodeWithLabel.
-     *  This method is almost the same as DirectivesMethod.opcode.
-     *  We have to consider to refactor this code in order to avoid
-     *  code duplication.
+     * Operand XML directives.
+     * @since 0.1
      */
-    private void opcodeWithLabel(final int opcode, final Label label) {
-        this.directives.add("o")
-            .attr("name", new OpcodeName(opcode).asString())
-            .attr("base", "opcode");
-        this.directives.append(new DirectivesLabel(label));
-        this.directives.up();
-    }
-
-
     private static final class Operand implements Iterable<Directive> {
 
+        /**
+         * Raw operand.
+         */
         private final Object operand;
 
+        /**
+         * Constructor.
+         * @param operand Raw operand.
+         */
         private Operand(final Object operand) {
             this.operand = operand;
         }


### PR DESCRIPTION
Remove code duplication in `DirectivesMethod` class. Add `Operand` and `DirectivesLabel` classes.

Closes: #232.
____
- feat(#232): replace 'label' method with 'DirectivesLabel' class
- feat(#232): replace duplicated method with Operands class usage
- feat(#232): remove duplicated method
- feat(#232): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added MIT License header to `DirectivesLabel` class.
- Removed unused import statement in `DirectivesMethod` class.
- Refactored `DirectivesMethod` class to remove code duplication and improve readability.
- Created new `DirectivesLabel` class to handle XML directives for label entry in byrecode.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->