### PR TITLE
feat(#208): Fix The Bug With Incorrect Fields Mapping

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
@@ -30,6 +30,26 @@ import org.xembly.Directives;
 
 /**
  * Field directives.
+ * Any java field will be transformed into the following EO object.
+ *  <p>
+ *     {@code
+ *       [access descriptor signature value] > field
+ *     }
+ * </p>
+ * The name of the "field" object is a name of the field in Java class.
+ * For example, the following Java field
+ * <p>
+ *     {@code
+ *        private final int bar = 1;
+ *     }
+ * </p>
+ * will be transformed into the following EO object:
+ * <p>
+ *     {@code
+ *       field 18 "I" "" "01" > bar
+ *     }
+ * </p>
+ *
  * @since 0.1
  */
 final class DirectivesField implements Iterable<Directive> {
@@ -88,10 +108,10 @@ final class DirectivesField implements Iterable<Directive> {
         directives.add("o")
             .attr("base", "field")
             .attr("name", this.name)
-            .append(new DirectivesData("access", this.access))
-            .append(new DirectivesData("descriptor", this.descriptor))
-            .append(new DirectivesData("signature", this.signature))
-            .append(new DirectivesData("value", this.value));
+            .append(new DirectivesData(this.access))
+            .append(new DirectivesData(this.descriptor))
+            .append(new DirectivesData(this.signature))
+            .append(new DirectivesData(this.value));
         return directives.up().iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -26,6 +26,7 @@ package org.eolang.jeo.representation.xmir;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -63,7 +64,7 @@ public class XmlField {
      * @return Access modifiers.
      */
     public int access() {
-        return this.find("access").map(HexString::decodeAsInt).orElse(0);
+        return this.find(Attribute.ACCESS).map(HexString::decodeAsInt).orElse(0);
     }
 
     /**
@@ -71,7 +72,7 @@ public class XmlField {
      * @return Descriptor.
      */
     public String descriptor() {
-        return this.find("descriptor").map(HexString::decode).orElse(null);
+        return this.find(Attribute.DESCRIPTOR).map(HexString::decode).orElse(null);
     }
 
     /**
@@ -79,7 +80,7 @@ public class XmlField {
      * @return Signature.
      */
     public String signature() {
-        return this.find("signature").map(HexString::decode).orElse(null);
+        return this.find(Attribute.SIGNATURE).map(HexString::decode).orElse(null);
     }
 
     /**
@@ -87,7 +88,7 @@ public class XmlField {
      * @return Value.
      */
     public Object value() {
-        return this.find("value").map(HexString::decode).orElse(null);
+        return this.find(Attribute.VALUE).map(HexString::decode).orElse(null);
     }
 
     /**
@@ -122,6 +123,19 @@ public class XmlField {
             .map(HexString::new);
     }
 
+    private Optional<HexString> find(final Attribute attribute) {
+        final int position = attribute.ordinal();
+        final String s = new XmlNode(this.node).children()
+            .map(XmlNode::text)
+            .collect(Collectors.toList())
+            .get(position);
+        if (s.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(new HexString(s));
+        }
+    }
+
     /**
      * Current node child objects.
      * @return Child objects.
@@ -136,5 +150,13 @@ public class XmlField {
             }
         }
         return res.stream();
+    }
+
+    private enum Attribute {
+        ACCESS,
+        DESCRIPTOR,
+        SIGNATURE,
+        VALUE;
+
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -143,11 +143,38 @@ public class XmlField {
 
         /**
          * Field signature.
+         * The field signature is used for defining generic types.
+         * Signature grammar:
+         * <p>
+         * {@code
+         * TypeSignature: Z|C|B|S|I|F|J|D|FieldTypeSignature
+         * FieldTypeSignature: ClassTypeSignature | [ TypeSignature | TypeVar
+         * ClassTypeSignature: L Id ( / Id )* TypeArgs? ( . Id TypeArgs? )* ;
+         * TypeArgs: < TypeArg+ >
+         * TypeArg: * | ( + | - )? FieldTypeSignature
+         * TypeVar: T Id ;
+         * }
+         * </p>
+         * Examples:
+         * <p>
+         * {@code
+         * List<E> -> Ljava/util/List<TE;>;
+         * List<?> -> Ljava/util/List<*>;
+         * List<? extends Number> -> Ljava/util/List<+Ljava/lang/Number;>;
+         * List<? super Integer> -> Ljava/util/List<-Ljava/lang/Integer;>;
+         * List<List<String>[]> -> Ljava/util/List<[Ljava/util/List<Ljava/lang/String;>;>;
+         * HashMap<K, V>.HashIterator<K> -> Ljava/util/HashMap<TK;TV;>.HashIterator<TK;>;
+         * }
+         * </p>
+         * You can read more in 4.1.1 section of the ASM
+         * <a href="https://asm.ow2.io/asm4-guide.pdf">manual </a>
          */
         SIGNATURE,
 
         /**
          * Initial field value.
+         * For example for field of type int with value 19 the value will be "13".
+         * Any data type will be represented as hex string.
          * May not be set.
          */
         VALUE;

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -23,13 +23,9 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
  * XML field.
@@ -105,58 +101,55 @@ public class XmlField {
     }
 
     /**
-     * Find node text by key.
-     * @param key Key.
+     * Find node text by attribute.
+     * @param attribute Attribute.
      * @return Text.
      */
-    private Optional<HexString> find(final String key) {
-        return this.children()
-            .filter(
-                object -> object.getAttributes()
-                    .getNamedItem("name")
-                    .getNodeValue()
-                    .equals(key)
-            )
-            .findFirst()
-            .map(Node::getTextContent)
-            .filter(text -> !text.isEmpty())
-            .map(HexString::new);
-    }
-
     private Optional<HexString> find(final Attribute attribute) {
-        final int position = attribute.ordinal();
-        final String s = new XmlNode(this.node).children()
+        final String text = new XmlNode(this.node).children()
             .map(XmlNode::text)
             .collect(Collectors.toList())
-            .get(position);
-        if (s.isEmpty()) {
-            return Optional.empty();
+            .get(attribute.ordinal());
+        final Optional<HexString> result;
+        if (text.isEmpty()) {
+            result = Optional.empty();
         } else {
-            return Optional.of(new HexString(s));
+            result = Optional.of(new HexString(text));
         }
+        return result;
     }
 
     /**
-     * Current node child objects.
-     * @return Child objects.
+     * Field attribute.
+     * Pay attention that the order of the attributes is important.
+     * They should be in the same order as in the XML representation.
+     * @since 0.1
      */
-    private Stream<Node> children() {
-        final NodeList childs = this.node.getChildNodes();
-        final List<Node> res = new ArrayList<>(childs.getLength());
-        for (int identifier = 0; identifier < childs.getLength(); ++identifier) {
-            final Node child = childs.item(identifier);
-            if (child.getNodeName().equals("o")) {
-                res.add(child);
-            }
-        }
-        return res.stream();
-    }
-
     private enum Attribute {
-        ACCESS,
-        DESCRIPTOR,
-        SIGNATURE,
-        VALUE;
 
+        /**
+         * Access modifier.
+         * It's a number that represents sum of access modifiers.
+         * For example, if the field is public and static, then the value will be 9.
+         * See {@link org.objectweb.asm.Opcodes} for more details.
+         */
+        ACCESS,
+
+        /**
+         * Field descriptor.
+         * For example, for field of type int the descriptor will be "I".
+         */
+        DESCRIPTOR,
+
+        /**
+         * Field signature.
+         */
+        SIGNATURE,
+
+        /**
+         * Initial field value.
+         * May not be set.
+         */
+        VALUE;
     }
 }


### PR DESCRIPTION
Fix the bug with incorrect field attribute mappings. Now, we just omit field attribute names and use the field object attribute positions instead. Simply put, was:
```eo
field > d
  2 > access
  "I" > descriptor
  "" > signature
  "01" > value
```
become:
```eo
field 2 "I" "" "01" > d
```

Closes: #208.
____
History:
- feat(#208): describe what we want to get
- feat(#208): Use field attribute positions instead of fixed names
- feat(#208): fix all qulice suggestions

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on improving the representation of field directives and XML fields in the code.

### Detailed summary:
- Added a new class `DirectivesField` to transform Java fields into EO objects.
- Updated the `DirectivesField` class to use the new `DirectivesData` class for field attributes.
- Updated the `XmlField` class to use an enum for field attributes.
- Updated the `XmlField` class to use the new `XmlNode` class for finding attributes.
- Removed unused imports and variables in the `XmlField` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->