### PR TITLE
feat(#252): Cancel Constructor Inlining

### DIFF
--- a/src/it/distilled/src/main/java/org/eolang/jeo/B.java
+++ b/src/it/distilled/src/main/java/org/eolang/jeo/B.java
@@ -4,13 +4,9 @@ public final class B {
     private final A a;
     private int x;
 
-    B(A a){ this(a, 0); }
-
-    B(A a, int x) {
+    B(A a) {
         this.a = a;
-        this.x = x;
     }
-
     int bar() {
         x = 2;
         return a.foo() + x;

--- a/src/main/java/org/eolang/jeo/improvement/DecoratorConstructors.java
+++ b/src/main/java/org/eolang/jeo/improvement/DecoratorConstructors.java
@@ -23,17 +23,9 @@
  */
 package org.eolang.jeo.improvement;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Stream;
-import org.eolang.jeo.representation.xmir.XmlBytecodeEntry;
 import org.eolang.jeo.representation.xmir.XmlClass;
-import org.eolang.jeo.representation.xmir.XmlInstruction;
-import org.eolang.jeo.representation.xmir.XmlLabel;
 import org.eolang.jeo.representation.xmir.XmlMethod;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 
 /**
  * This class tries to combine constructors of the decorated class and the decorator.
@@ -47,21 +39,13 @@ class DecoratorConstructors {
     private final XmlClass decorated;
 
     /**
-     * Class that decorates {@link #decorated}.
-     */
-    private final XmlClass decorator;
-
-    /**
      * Constructor.
      * @param decorated Decorated class.
-     * @param decorator Class that decorates {@link #decorated}.
      */
     DecoratorConstructors(
-        final XmlClass decorated,
-        final XmlClass decorator
+        final XmlClass decorated
     ) {
         this.decorated = decorated;
-        this.decorator = decorator;
     }
 
     /**
@@ -69,108 +53,6 @@ class DecoratorConstructors {
      * @return List of constructors.
      */
     List<XmlMethod> constructors() {
-        final List<XmlMethod> alldecorated = this.decorated.constructors();
-//        final List<XmlMethod> alldecoratee = this.decorator.constructors();
-//        final List<XmlMethod> result = new ArrayList<>(alldecorated.size() + alldecoratee.size());
-//        for (final XmlMethod origin : alldecorated) {
-//            for (final XmlMethod upper : alldecoratee) {
-//                result.add(
-//                    new XmlMethod(
-//                        upper.name(),
-//                        upper.access(),
-//                        this.combineDescriptors(origin.descriptor(), upper.descriptor()),
-//                        this.combineInstructions(origin, upper)
-//                    )
-//                );
-//            }
-//        }
-//        return result;
-        return alldecorated;
+        return this.decorated.constructors();
     }
-
-    /**
-     * Combines descriptors of the decorated and decorator constructors.
-     * @param decored Decorated constructor descriptor.
-     * @param decoror Decorator constructor descriptor.
-     * @return Combined descriptor.
-     */
-    private String combineDescriptors(
-        final String decored, final String decoror
-    ) {
-        final String aim = this.decorated.name();
-        final Type[] replacement = Type.getType(decored).getArgumentTypes();
-        final Type[] array = Arrays.stream(Type.getType(decoror).getArgumentTypes())
-            .flatMap(
-                type -> {
-                    final Stream<? extends Type> result;
-                    if (type.getClassName().replace('.', '/').equals(aim)) {
-                        result = Arrays.stream(replacement);
-                    } else {
-                        result = Stream.of(type);
-                    }
-                    return result;
-                }
-            ).toArray(Type[]::new);
-        return Type.getMethodType(Type.VOID_TYPE, array).getDescriptor();
-    }
-
-    /**
-     * Combines instructions of the decorated and decorator constructors.
-     * @param decored Decorated constructor.
-     * @param decoror Decorator constructor.
-     * @return Combined instructions.
-     */
-    private XmlBytecodeEntry[] combineInstructions(
-        final XmlMethod decored,
-        final XmlMethod decoror
-    ) {
-        return Stream.concat(
-            decored.instructions(new XmlMethod.Without(Opcodes.RETURN)).stream(),
-            this.decoratorInstructions(decoror)
-        ).toArray(XmlBytecodeEntry[]::new);
-    }
-
-    private Stream<XmlBytecodeEntry> decoratorInstructions(final XmlMethod decoror) {
-        return decoror.instructions()
-            .stream()
-            .filter(instruction -> {
-                if (instruction instanceof XmlInstruction) {
-                    final XmlInstruction xmlinstr = (XmlInstruction) instruction;
-                    if (xmlinstr.hasOpcode(Opcodes.PUTFIELD)) {
-                        final Object what = xmlinstr.arguments()[2];
-                        return !this.decorated.name().equals(
-                            Type.getType((String) what).getClassName().replace('.', '/')
-                        );
-                    }
-                }
-                return true;
-            })
-            .map(instruction -> {
-                    if (instruction instanceof XmlInstruction) {
-                        final XmlInstruction xmlinstr = (XmlInstruction) instruction;
-                        if (xmlinstr.hasOpcode(Opcodes.ALOAD)) {
-                            final Object argument = xmlinstr.arguments()[0];
-                            if (argument instanceof Integer) {
-                                if ((int) argument > 0) {
-                                    return new XmlInstruction(Opcodes.ILOAD, argument);
-                                }
-                            }
-                        }
-                        List<Object> newargs = new ArrayList<>(xmlinstr.arguments().length);
-                        for (final Object argument : xmlinstr.arguments()) {
-                            if (argument instanceof String) {
-                                final String sarg = (String) argument;
-                                newargs.add(sarg.replace("L" + this.decorated.name() + ";", "I"));
-                            } else {
-                                newargs.add(argument);
-                            }
-                        }
-                        return new XmlInstruction(xmlinstr.code(), newargs.toArray());
-                    } else {
-                        return instruction;
-                    }
-                }
-            );
-    }
-
 }

--- a/src/main/java/org/eolang/jeo/improvement/DecoratorConstructors.java
+++ b/src/main/java/org/eolang/jeo/improvement/DecoratorConstructors.java
@@ -30,6 +30,11 @@ import org.eolang.jeo.representation.xmir.XmlMethod;
 /**
  * This class tries to combine constructors of the decorated class and the decorator.
  * @since 0.1
+ * @todo #252:90min The first attempt to inline constructors is failed.
+ *  The constructor inlining is not a straightforward task, since we need to take into
+ *  account the order of arguments and the order of instructions in the constructor.
+ *  Sine we decided to implement inlining using high-level XML representation, maybe it makes sence
+ *  just remove all the related classes to this optimization.
  */
 class DecoratorConstructors {
 

--- a/src/main/java/org/eolang/jeo/improvement/DecoratorConstructors.java
+++ b/src/main/java/org/eolang/jeo/improvement/DecoratorConstructors.java
@@ -35,6 +35,7 @@ import org.eolang.jeo.representation.xmir.XmlMethod;
  *  account the order of arguments and the order of instructions in the constructor.
  *  Sine we decided to implement inlining using high-level XML representation, maybe it makes sence
  *  just remove all the related classes to this optimization.
+ *  see https://github.com/objectionary/jeo-maven-plugin/issues/259
  */
 class DecoratorConstructors {
 

--- a/src/main/java/org/eolang/jeo/improvement/DecoratorConstructors.java
+++ b/src/main/java/org/eolang/jeo/improvement/DecoratorConstructors.java
@@ -51,22 +51,17 @@ class DecoratorConstructors {
      */
     private final XmlClass decorator;
 
-    private final String combined;
-
     /**
      * Constructor.
      * @param decorated Decorated class.
      * @param decorator Class that decorates {@link #decorated}.
-     * @param combined
      */
     DecoratorConstructors(
         final XmlClass decorated,
-        final XmlClass decorator,
-        final String combined
+        final XmlClass decorator
     ) {
         this.decorated = decorated;
         this.decorator = decorator;
-        this.combined = combined;
     }
 
     /**
@@ -75,21 +70,22 @@ class DecoratorConstructors {
      */
     List<XmlMethod> constructors() {
         final List<XmlMethod> alldecorated = this.decorated.constructors();
-        final List<XmlMethod> alldecoratee = this.decorator.constructors();
-        final List<XmlMethod> result = new ArrayList<>(alldecorated.size() + alldecoratee.size());
-        for (final XmlMethod origin : alldecorated) {
-            for (final XmlMethod upper : alldecoratee) {
-                result.add(
-                    new XmlMethod(
-                        upper.name(),
-                        upper.access(),
-                        this.combineDescriptors(origin.descriptor(), upper.descriptor()),
-                        this.combineInstructions(origin, upper)
-                    )
-                );
-            }
-        }
-        return result;
+//        final List<XmlMethod> alldecoratee = this.decorator.constructors();
+//        final List<XmlMethod> result = new ArrayList<>(alldecorated.size() + alldecoratee.size());
+//        for (final XmlMethod origin : alldecorated) {
+//            for (final XmlMethod upper : alldecoratee) {
+//                result.add(
+//                    new XmlMethod(
+//                        upper.name(),
+//                        upper.access(),
+//                        this.combineDescriptors(origin.descriptor(), upper.descriptor()),
+//                        this.combineInstructions(origin, upper)
+//                    )
+//                );
+//            }
+//        }
+//        return result;
+        return alldecorated;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -389,11 +389,16 @@ public final class ImprovementDistilledObjects implements Improvement {
             decor.replaceArguments(this.decorator.name(), this.combinedName());
             final XmlClass clazz = new XmlProgram(this.decorated.toEO()).top();
             clazz.fields().forEach(decor::withField);
+            final List<XmlMethod> constructors = new DecoratorConstructors(
+                clazz,
+                decor,
+                this.combinedName()
+            )
+                .constructors();
             DecoratorPair.removeOldConstructors(root);
+            constructors.forEach(decor::withConstructor);
             for (final XmlMethod method : clazz.methods()) {
-                if (method.isConstructor()) {
-                    decor.withConstructor(method);
-                } else {
+                if (!method.isConstructor()) {
                     decor.inline(method);
                 }
             }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -378,10 +378,6 @@ public final class ImprovementDistilledObjects implements Improvement {
          * @todo #162:90min Refactor handleClass method.
          *  Right now it's a method with high complexity and it's hard to read it.
          *  We need to refactor it or inline into some other method.
-         * @todo #164:90min Use DecoratorConstructors instead of simple copy-paste.
-         *  Currently we use copy-paste constructors from the decorated object.
-         *  We should use DecoratorConstructors instead. In order to apply the solution,
-         *  uncomment the code below and remove the copy-paste code.
          */
         private void handleClass(final XmlClass decor) {
             final Node root = decor.node();
@@ -389,10 +385,7 @@ public final class ImprovementDistilledObjects implements Improvement {
             decor.replaceArguments(this.decorator.name(), this.combinedName());
             final XmlClass clazz = new XmlProgram(this.decorated.toEO()).top();
             clazz.fields().forEach(decor::withField);
-            final List<XmlMethod> constructors = new DecoratorConstructors(
-                clazz,
-                decor
-            ).constructors();
+            final List<XmlMethod> constructors = new DecoratorConstructors(clazz).constructors();
             DecoratorPair.removeOldConstructors(root);
             constructors.forEach(decor::withConstructor);
             for (final XmlMethod method : clazz.methods()) {

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementDistilledObjects.java
@@ -391,10 +391,8 @@ public final class ImprovementDistilledObjects implements Improvement {
             clazz.fields().forEach(decor::withField);
             final List<XmlMethod> constructors = new DecoratorConstructors(
                 clazz,
-                decor,
-                this.combinedName()
-            )
-                .constructors();
+                decor
+            ).constructors();
             DecoratorPair.removeOldConstructors(root);
             constructors.forEach(decor::withConstructor);
             for (final XmlMethod method : clazz.methods()) {

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
@@ -1,22 +1,63 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
-public class DirectivesInstruction implements Iterable<Directive> {
+/**
+ * Instruction directives.
+ * Parses bytecode instruction and transforms it into Xembly directives that further
+ * will be converted into XML.
+ * @since 0.1
+ */
+final class DirectivesInstruction implements Iterable<Directive> {
 
+    /**
+     * Opcode.
+     */
     private final int opcode;
+
+    /**
+     * Instruction arguments.
+     */
     private final Object[] arguments;
 
-    public DirectivesInstruction(final int opcode, final Object... arguments) {
+    /**
+     * Constructor.
+     * @param opcode Opcode
+     * @param arguments Instruction arguments
+     */
+    DirectivesInstruction(final int opcode, final Object... arguments) {
         this.opcode = opcode;
-        this.arguments = arguments;
+        this.arguments = arguments.clone();
     }
 
     @Override
     public Iterator<Directive> iterator() {
-        Directives directives = new Directives();
+        final Directives directives = new Directives();
         directives.add("o")
             .attr("name", new OpcodeName(this.opcode).asString())
             .attr("base", "opcode");

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
@@ -1,0 +1,29 @@
+package org.eolang.jeo.representation.directives;
+
+import java.util.Iterator;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+public class DirectivesInstruction implements Iterable<Directive> {
+
+    private final int opcode;
+    private final Object[] arguments;
+
+    public DirectivesInstruction(final int opcode, final Object... arguments) {
+        this.opcode = opcode;
+        this.arguments = arguments;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        Directives directives = new Directives();
+        directives.add("o")
+            .attr("name", new OpcodeName(this.opcode).asString())
+            .attr("base", "opcode");
+        for (final Object operand : this.arguments) {
+            directives.append(new DirectivesOperand(operand));
+        }
+        directives.up();
+        return directives.iterator();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -140,13 +140,6 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
      */
     private void opcode(final int opcode, final Object... operands) {
         this.directives.append(new DirectivesInstruction(opcode, operands));
-//        this.directives.add("o")
-//            .attr("name", new OpcodeName(opcode).asString())
-//            .attr("base", "opcode");
-//        for (final Object operand : operands) {
-//            this.directives.append(new DirectivesOperand(operand));
-//        }
-//        this.directives.up();
     }
 
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -118,7 +118,7 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
 
     @Override
     public void visitLabel(final Label label) {
-        this.directives.append(new Operand(label));
+        this.directives.append(new DirectivesOperand(label));
         super.visitLabel(label);
     }
 
@@ -139,43 +139,14 @@ public final class DirectivesMethod extends MethodVisitor implements Iterable<Di
      * @param operands Operands
      */
     private void opcode(final int opcode, final Object... operands) {
-        this.directives.add("o")
-            .attr("name", new OpcodeName(opcode).asString())
-            .attr("base", "opcode");
-        for (final Object operand : operands) {
-            this.directives.append(new Operand(operand));
-        }
-        this.directives.up();
+        this.directives.append(new DirectivesInstruction(opcode, operands));
+//        this.directives.add("o")
+//            .attr("name", new OpcodeName(opcode).asString())
+//            .attr("base", "opcode");
+//        for (final Object operand : operands) {
+//            this.directives.append(new DirectivesOperand(operand));
+//        }
+//        this.directives.up();
     }
 
-    /**
-     * Operand XML directives.
-     * @since 0.1
-     */
-    private static final class Operand implements Iterable<Directive> {
-
-        /**
-         * Raw operand.
-         */
-        private final Object raw;
-
-        /**
-         * Constructor.
-         * @param operand Raw operand.
-         */
-        private Operand(final Object operand) {
-            this.raw = operand;
-        }
-
-        @Override
-        public Iterator<Directive> iterator() {
-            final Iterator<Directive> result;
-            if (this.raw instanceof Label) {
-                result = new DirectivesLabel((Label) this.raw).iterator();
-            } else {
-                result = new DirectivesData(this.raw).iterator();
-            }
-            return result;
-        }
-    }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesOperand.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesOperand.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesOperand.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesOperand.java
@@ -1,0 +1,36 @@
+package org.eolang.jeo.representation.directives;
+
+import java.util.Iterator;
+import org.objectweb.asm.Label;
+import org.xembly.Directive;
+
+/**
+ * Operand XML directives.
+ * @since 0.1
+ */
+final class DirectivesOperand implements Iterable<Directive> {
+
+    /**
+     * Raw operand.
+     */
+    private final Object raw;
+
+    /**
+     * Constructor.
+     * @param operand Raw operand.
+     */
+    DirectivesOperand(final Object operand) {
+        this.raw = operand;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        final Iterator<Directive> result;
+        if (this.raw instanceof Label) {
+            result = new DirectivesLabel((Label) this.raw).iterator();
+        } else {
+            result = new DirectivesData(this.raw).iterator();
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -30,12 +30,9 @@ import java.util.Objects;
 import java.util.stream.IntStream;
 import org.eolang.jeo.representation.HexData;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
-import org.eolang.jeo.representation.directives.DirectivesInstruction;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.xembly.Transformers;
-import org.xembly.Xembler;
 
 /**
  * Bytecode instruction from XML.
@@ -58,16 +55,6 @@ public final class XmlInstruction implements XmlBytecodeEntry {
      * All found labels.
      */
     private final AllLabels labels;
-
-
-    public XmlInstruction(final int opcode, Object... arguments) {
-        this(
-            new Xembler(
-                new DirectivesInstruction(opcode, arguments),
-                new Transformers.Node()
-            ).xmlQuietly()
-        );
-    }
 
     /**
      * Constructor.
@@ -106,18 +93,6 @@ public final class XmlInstruction implements XmlBytecodeEntry {
                     child.withText(new HexData(replacement).value());
                 }
             }
-        );
-    }
-
-    /**
-     * Instruction code.
-     * @return Code.
-     */
-    public int code() {
-        return Integer.parseInt(
-            this.node.getAttributes()
-                .getNamedItem("name")
-                .getNodeValue().split("-")[1]
         );
     }
 
@@ -186,6 +161,18 @@ public final class XmlInstruction implements XmlBytecodeEntry {
             result = new HexString(argument.text()).decode();
         }
         return result;
+    }
+
+    /**
+     * Instruction code.
+     * @return Code.
+     */
+    private int code() {
+        return Integer.parseInt(
+            this.node.getAttributes()
+                .getNamedItem("name")
+                .getNodeValue().split("-")[1]
+        );
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -30,9 +30,12 @@ import java.util.Objects;
 import java.util.stream.IntStream;
 import org.eolang.jeo.representation.HexData;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
+import org.eolang.jeo.representation.directives.DirectivesInstruction;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xembly.Transformers;
+import org.xembly.Xembler;
 
 /**
  * Bytecode instruction from XML.
@@ -55,6 +58,16 @@ public final class XmlInstruction implements XmlBytecodeEntry {
      * All found labels.
      */
     private final AllLabels labels;
+
+
+    public XmlInstruction(final int opcode, Object... arguments) {
+        this(
+            new Xembler(
+                new DirectivesInstruction(opcode, arguments),
+                new Transformers.Node()
+            ).xmlQuietly()
+        );
+    }
 
     /**
      * Constructor.
@@ -97,6 +110,18 @@ public final class XmlInstruction implements XmlBytecodeEntry {
     }
 
     /**
+     * Instruction code.
+     * @return Code.
+     */
+    public int code() {
+        return Integer.parseInt(
+            this.node.getAttributes()
+                .getNamedItem("name")
+                .getNodeValue().split("-")[1]
+        );
+    }
+
+    /**
      * Instruction arguments.
      * @return Arguments.
      */
@@ -135,18 +160,6 @@ public final class XmlInstruction implements XmlBytecodeEntry {
     @Override
     public Node node() {
         return this.node;
-    }
-
-    /**
-     * Instruction code.
-     * @return Code.
-     */
-    private int code() {
-        return Integer.parseInt(
-            this.node.getAttributes()
-                .getNamedItem("name")
-                .getNodeValue().split("-")[1]
-        );
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
@@ -47,7 +47,7 @@ public final class XmlLabel implements XmlBytecodeEntry {
      * Constructor.
      * @param node Label node.
      */
-    XmlLabel(final XmlNode node) {
+    public XmlLabel(final XmlNode node) {
         this.node = node;
         this.labels = new AllLabels();
     }

--- a/src/test/java/org/eolang/jeo/improvement/DecoratorConstructorsTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/DecoratorConstructorsTest.java
@@ -59,7 +59,7 @@ class DecoratorConstructorsTest {
                 .withConstructor("(LFoo;)V").instruction(Opcodes.RETURN).up()
                 .xml()
         ).top();
-        final List<XmlMethod> res = new DecoratorConstructors(decorated, decorator)
+        final List<XmlMethod> res = new DecoratorConstructors(decorated, decorator, "Foo$Bar")
             .constructors();
         final List<XmlMethod> expected = new XmlProgram(
             new BytecodeClass("Expected")

--- a/src/test/java/org/eolang/jeo/improvement/DecoratorConstructorsTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/DecoratorConstructorsTest.java
@@ -59,7 +59,7 @@ class DecoratorConstructorsTest {
                 .withConstructor("(LFoo;)V").instruction(Opcodes.RETURN).up()
                 .xml()
         ).top();
-        final List<XmlMethod> res = new DecoratorConstructors(decorated, decorator, "Foo$Bar")
+        final List<XmlMethod> res = new DecoratorConstructors(decorated, decorator)
             .constructors();
         final List<XmlMethod> expected = new XmlProgram(
             new BytecodeClass("Expected")
@@ -76,7 +76,7 @@ class DecoratorConstructorsTest {
         MatcherAssert.assertThat(
             "DecoratorConstructors should combine constructors from decorated and decorator classes, but it didn't",
             res,
-            Matchers.hasSize(4)
+            Matchers.hasSize(2)
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/improvement/DecoratorConstructorsTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/DecoratorConstructorsTest.java
@@ -59,7 +59,7 @@ class DecoratorConstructorsTest {
                 .withConstructor("(LFoo;)V").instruction(Opcodes.RETURN).up()
                 .xml()
         ).top();
-        final List<XmlMethod> res = new DecoratorConstructors(decorated, decorator)
+        final List<XmlMethod> res = new DecoratorConstructors(decorated)
             .constructors();
         final List<XmlMethod> expected = new XmlProgram(
             new BytecodeClass("Expected")


### PR DESCRIPTION
Since we decided to implement inlining using different approach https://github.com/objectionary/jeo-maven-plugin/issues/259, we don't need constructors inlining anymore.

Closes: #252.
____
History:
- feat(#252): add DirectivesInstruction and DirectivesOperand classes
- feat(#252): use constructors from decorated object only
- feat(#252): remove the puzzle for 252 issue
- feat(#252): add one more puzzle
- feat(#252): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the constructor logic in the `DecoratorConstructors` class. 

### Detailed summary
- Removed the `decorator` parameter from the `DecoratorConstructors` constructor.
- Updated the `constructors` method to only use the `decorated` class.
- Removed the `combineDescriptors` method.
- Removed the `combineInstructions` method.

> The following files were skipped due to too many changes: `src/main/java/org/eolang/jeo/improvement/DecoratorConstructors.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->