### PR TITLE
feat(#92): Add Unit Test For OpcodeName

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/OpcodeName.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/OpcodeName.java
@@ -33,10 +33,6 @@ import org.objectweb.asm.Opcodes;
  * The name of bytecode instruction. The name combined with unique number in order to
  * avoid name collisions.
  * @since 0.1.0
- * @todo #84:30min Add unit test for OpcodeName class.
- *  The unit test should check that the name of opcode is correct.
- *  The name should be the same as in {@link Opcodes} class.
- *  When the unit test is ready remove that puzzle.
  */
 final class OpcodeName {
 

--- a/src/test/java/org/eolang/jeo/representation/directives/OpcodeNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/OpcodeNameTest.java
@@ -49,8 +49,11 @@ class OpcodeNameTest {
 
     /**
      * Provides test actual and expected arguments.
+     * PMD argues that this method is unused, but it is used by JUnit.
+     * So we just suppress this warning.
      * @return Stream of arguments.
      */
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static Stream<Arguments> opcodes() {
         return Stream.of(
             Arguments.of(Opcodes.INVOKESPECIAL, "INVOKESPECIAL"),

--- a/src/test/java/org/eolang/jeo/representation/directives/OpcodeNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/OpcodeNameTest.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.stream.Stream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Test case for {@link OpcodeName}.
+ * @since 0.1
+ */
+class OpcodeNameTest {
+
+    @ParameterizedTest(name = "{0} -> {1}")
+    @MethodSource("opcodes")
+    void checksOpcodeNames(final int actual, final String expected) {
+        MatcherAssert.assertThat(
+            "Opcode name is not as expected",
+            new OpcodeName(actual).asString(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    /**
+     * Provides test actual and expected arguments.
+     * @return Stream of arguments.
+     */
+    private static Stream<Arguments> opcodes() {
+        return Stream.of(
+            Arguments.of(Opcodes.INVOKESPECIAL, "INVOKESPECIAL"),
+            Arguments.of(Opcodes.INVOKEVIRTUAL, "INVOKEVIRTUAL"),
+            Arguments.of(Opcodes.INVOKESTATIC, "INVOKESTATIC"),
+            Arguments.of(Opcodes.INVOKEINTERFACE, "INVOKEINTERFACE"),
+            Arguments.of(Opcodes.INVOKEDYNAMIC, "INVOKEDYNAMIC"),
+            Arguments.of(Opcodes.DUP, "DUP")
+        );
+    }
+}


### PR DESCRIPTION
Add unit test for `OpcodeName`.

Closes: #92.
____
History:
- feat(#92): remove the puzzle for the 92 issue
- feat(#92): add unit test for OpcodeNames
- feat(#92): fix all qulice suggestions
