### PR TITLE
feat(#269): Print Logs During `bytecode-to-eo` Transformation

### DIFF
--- a/src/it/betecode-to-eo/verify.groovy
+++ b/src/it/betecode-to-eo/verify.groovy
@@ -23,6 +23,8 @@
  */
 //Check logs first.
 String log = new File(basedir, 'build.log').text;
+assert log.contains("Application.class translated into Application.xmir")
+assert log.contains("Foo.class translated into Foo.xmir")
 assert log.contains("BUILD SUCCESS")
 //Check that we have generated XMIR object file.
 assert new File(basedir, 'target/generated-sources/xmir/org/eolang/jeo/Application.xmir').exists()

--- a/src/main/java/org/eolang/jeo/Details.java
+++ b/src/main/java/org/eolang/jeo/Details.java
@@ -1,27 +1,86 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo;
 
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Details of representation.
+ * Additional info about representation.
+ * @since 0.1
+ */
 public class Details {
 
+    /**
+     * Name of the class or an object.
+     */
     private static final String NAME = "name";
+
+    /**
+     * Original source of the representation.
+     * Might be a file name or a URL:
+     * - Application.java
+     * - Application.xmir
+     */
     private static final String SOURCE = "source";
+
+    /**
+     * Storage with all the details.
+     */
     private final Map<String, String> storage;
 
-    public Details(final String name) {
-        this(name, "Unknown");
-    }
-
+    /**
+     * Constructor.
+     * @param name Name of the class or an object.
+     * @param source Original source of the representation.
+     */
     public Details(final String name, final String source) {
         this(Details.NAME, name, Details.SOURCE, source);
     }
 
-    public Details(final String... inits) {
+    /**
+     * Constructor.
+     * @param name Name of the class or an object.
+     */
+    Details(final String name) {
+        this(name, "Unknown");
+    }
+
+    /**
+     * Constructor.
+     * @param inits Initializations.
+     */
+    private Details(final String... inits) {
         this(Details.initial(inits));
     }
 
-    public Details(final Map<String, String> storage) {
+    /**
+     * Constructor.
+     * @param storage Storage with all the details.
+     */
+    private Details(final Map<String, String> storage) {
         this.storage = storage;
     }
 
@@ -42,6 +101,11 @@ public class Details {
         return this.storage.get(Details.SOURCE);
     }
 
+    /**
+     * Initializations.
+     * @param pairs Pairs of key-value.
+     * @return Map with all the details.
+     */
     private static Map<String, String> initial(String... pairs) {
         final int length = pairs.length;
         if (length % 2 == 1) {
@@ -53,6 +117,4 @@ public class Details {
         }
         return map;
     }
-
-
 }

--- a/src/main/java/org/eolang/jeo/Details.java
+++ b/src/main/java/org/eolang/jeo/Details.java
@@ -1,0 +1,58 @@
+package org.eolang.jeo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Details {
+
+    private static final String NAME = "name";
+    private static final String SOURCE = "source";
+    private final Map<String, String> storage;
+
+    public Details(final String name) {
+        this(name, "Unknown");
+    }
+
+    public Details(final String name, final String source) {
+        this(Details.NAME, name, Details.SOURCE, source);
+    }
+
+    public Details(final String... inits) {
+        this(Details.initial(inits));
+    }
+
+    public Details(final Map<String, String> storage) {
+        this.storage = storage;
+    }
+
+    /**
+     * Name of the class or an object.
+     * @return Name.
+     */
+    public String name() {
+        return this.storage.get(Details.NAME);
+    }
+
+    /**
+     * Original source of the representation.
+     * It could be a file name or a URL.
+     * @return Source.
+     */
+    public String source() {
+        return this.storage.get(Details.SOURCE);
+    }
+
+    private static Map<String, String> initial(String... pairs) {
+        final int length = pairs.length;
+        if (length % 2 == 1) {
+            throw new IllegalArgumentException("Must have an even number of arguments");
+        }
+        Map<String, String> map = new HashMap<>(pairs.length / 2);
+        for (int i = 0; i < length; i += 2) {
+            map.put(pairs[i], pairs[i + 1]);
+        }
+        return map;
+    }
+
+
+}

--- a/src/main/java/org/eolang/jeo/Details.java
+++ b/src/main/java/org/eolang/jeo/Details.java
@@ -36,7 +36,7 @@ public class Details {
     /**
      * Name of the class or an object.
      */
-    private static final String NAME = "name";
+    private static final String NAME_KEY = "name";
 
     /**
      * Original source of the representation.
@@ -44,7 +44,7 @@ public class Details {
      * - Application.java
      * - Application.xmir
      */
-    private static final String SOURCE = "source";
+    private static final String SOURCE_KEY = "source";
 
     /**
      * Storage with all the details.
@@ -57,7 +57,7 @@ public class Details {
      * @param source Original source of the representation.
      */
     public Details(final String name, final String source) {
-        this(Details.NAME, name, Details.SOURCE, source);
+        this(Details.NAME_KEY, name, Details.SOURCE_KEY, source);
     }
 
     /**
@@ -89,7 +89,7 @@ public class Details {
      * @return Name.
      */
     public String name() {
-        return this.storage.get(Details.NAME);
+        return this.storage.get(Details.NAME_KEY);
     }
 
     /**
@@ -98,7 +98,7 @@ public class Details {
      * @return Source.
      */
     public String source() {
-        return this.storage.get(Details.SOURCE);
+        return this.storage.get(Details.SOURCE_KEY);
     }
 
     /**
@@ -106,14 +106,14 @@ public class Details {
      * @param pairs Pairs of key-value.
      * @return Map with all the details.
      */
-    private static Map<String, String> initial(String... pairs) {
+    private static Map<String, String> initial(final String... pairs) {
         final int length = pairs.length;
         if (length % 2 == 1) {
             throw new IllegalArgumentException("Must have an even number of arguments");
         }
-        Map<String, String> map = new HashMap<>(pairs.length / 2);
-        for (int i = 0; i < length; i += 2) {
-            map.put(pairs[i], pairs[i + 1]);
+        final Map<String, String> map = new HashMap<>(pairs.length / 2);
+        for (int index = 0; index < length; index += 2) {
+            map.put(pairs[index], pairs[index + 1]);
         }
         return map;
     }

--- a/src/main/java/org/eolang/jeo/EoRepresentations.java
+++ b/src/main/java/org/eolang/jeo/EoRepresentations.java
@@ -23,8 +23,6 @@
  */
 package org.eolang.jeo;
 
-import com.jcabi.xml.XMLDocument;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -62,28 +60,11 @@ final class EoRepresentations {
         final Path path = this.objectspath.resolve(new XmirDefaultDirectory().toPath());
         try (Stream<Path> walk = Files.walk(path)) {
             return walk.filter(Files::isRegularFile)
-                .map(EoRepresentations::xml)
                 .map(EoRepresentation::new)
                 .collect(Collectors.toList());
         } catch (final IOException exception) {
             throw new IllegalStateException(
                 String.format("Can't read folder '%s'", path),
-                exception
-            );
-        }
-    }
-
-    /**
-     * Convert path to XML.
-     * @param path Path to XML file.
-     * @return XML.
-     */
-    private static XMLDocument xml(final Path path) {
-        try {
-            return new XMLDocument(path.toFile());
-        } catch (final FileNotFoundException exception) {
-            throw new IllegalStateException(
-                String.format("Can't find file '%s'", path),
                 exception
             );
         }

--- a/src/main/java/org/eolang/jeo/Representation.java
+++ b/src/main/java/org/eolang/jeo/Representation.java
@@ -34,8 +34,19 @@ import org.eolang.jeo.representation.bytecode.Bytecode;
 public interface Representation {
 
     /**
+     * Details of representation.
+     * Additional info about representation.
+     * @return Representation details instance.
+     */
+    Details details();
+
+    /**
      * Name of the class or an object.
      * @return Name.
+     * @todo #269:30min Replace `name` method with `details` method.
+     *  Currently we just use `Represenation#name()` method everywhere. We should use
+     *  `Representation#details().name()` method instead.
+     *  When it will be ready, just remove this method.
      */
     String name();
 
@@ -69,6 +80,11 @@ public interface Representation {
          */
         public Named(final String name) {
             this.name = name;
+        }
+
+        @Override
+        public Details details() {
+            return new Details(this.name);
         }
 
         @Override

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementXmirFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementXmirFootprint.java
@@ -67,6 +67,11 @@ public final class ImprovementXmirFootprint implements Improvement {
             .collect(Collectors.toList());
     }
 
+    /**
+     * Transform representations.
+     * @param representation Representation to transform.
+     * @return Transformed representation.
+     */
     private static Representation transform(final Representation representation) {
         return new EoRepresentation(
             representation.toEO(),

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementXmirFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementXmirFootprint.java
@@ -62,10 +62,16 @@ public final class ImprovementXmirFootprint implements Improvement {
         final Collection<? extends Representation> representations
     ) {
         return representations.stream()
-            .map(Representation::toEO)
-            .map(EoRepresentation::new)
+            .map(ImprovementXmirFootprint::transform)
             .peek(this::tryToSave)
             .collect(Collectors.toList());
+    }
+
+    private static Representation transform(final Representation representation) {
+        return new EoRepresentation(
+            representation.toEO(),
+            representation.details().source()
+        );
     }
 
     /**
@@ -88,7 +94,7 @@ public final class ImprovementXmirFootprint implements Improvement {
                 String.format(
                     "%s translated into %s (%d bytes)",
                     representation.details().source(),
-                    path,
+                    path.getFileName().toString(),
                     Files.size(path)
                 )
             );

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementXmirFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementXmirFootprint.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.improvement;
 
+import com.jcabi.log.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -81,6 +82,15 @@ public final class ImprovementXmirFootprint implements Improvement {
                 path,
                 representation.toEO().toString().getBytes(StandardCharsets.UTF_8),
                 StandardOpenOption.CREATE_NEW
+            );
+            Logger.info(
+                this,
+                String.format(
+                    "%s translated into %s (%d bytes)",
+                    representation.details().source(),
+                    path,
+                    Files.size(path)
+                )
             );
         } catch (final IOException exception) {
             throw new IllegalStateException(

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -57,6 +57,9 @@ public final class BytecodeRepresentation implements Representation {
      */
     private final byte[] input;
 
+    /**
+     * The source of the input.
+     */
     private final String source;
 
     /**
@@ -64,16 +67,11 @@ public final class BytecodeRepresentation implements Representation {
      * @param clazz Path to the class file
      */
     public BytecodeRepresentation(final Path clazz) {
-        this(new InputOf(clazz));
+        this(new InputOf(clazz), clazz.getFileName().toString());
     }
 
-    /**
-     * Constructor.
-     * @param input Input source.
-     */
-    public BytecodeRepresentation(final byte[] input) {
-        this.input = Arrays.copyOf(input, input.length);
-        this.source = "bytecode";
+    public BytecodeRepresentation(final Bytecode bytecode) {
+        this(bytecode.asBytes());
     }
 
     /**
@@ -82,6 +80,35 @@ public final class BytecodeRepresentation implements Representation {
      */
     BytecodeRepresentation(final Input input) {
         this(new UncheckedBytes(new BytesOf(input)).asBytes());
+    }
+
+    /**
+     * Constructor.
+     * @param input Input source
+     */
+    private BytecodeRepresentation(final Input input, final String source) {
+        this(new UncheckedBytes(new BytesOf(input)).asBytes(), source);
+    }
+
+    /**
+     * Constructor.
+     * @param input Input source.
+     */
+    private BytecodeRepresentation(final byte[] input) {
+        this(input, "bytecode");
+    }
+
+    /**
+     * Constructor.
+     * @param input Input.
+     * @param source The source of the input.
+     */
+    private BytecodeRepresentation(
+        final byte[] input,
+        final String source
+    ) {
+        this.input = input.clone();
+        this.source = source;
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -33,6 +33,7 @@ import org.cactoos.Input;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.bytes.UncheckedBytes;
 import org.cactoos.io.InputOf;
+import org.eolang.jeo.Details;
 import org.eolang.jeo.Representation;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.directives.DirectivesClass;
@@ -56,6 +57,8 @@ public final class BytecodeRepresentation implements Representation {
      */
     private final byte[] input;
 
+    private final String source;
+
     /**
      * Constructor.
      * @param clazz Path to the class file
@@ -70,6 +73,7 @@ public final class BytecodeRepresentation implements Representation {
      */
     public BytecodeRepresentation(final byte[] input) {
         this.input = Arrays.copyOf(input, input.length);
+        this.source = "bytecode";
     }
 
     /**
@@ -78,6 +82,11 @@ public final class BytecodeRepresentation implements Representation {
      */
     BytecodeRepresentation(final Input input) {
         this(new UncheckedBytes(new BytesOf(input)).asBytes());
+    }
+
+    @Override
+    public Details details() {
+        return new Details(this.name(), this.source);
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -70,6 +70,10 @@ public final class BytecodeRepresentation implements Representation {
         this(new InputOf(clazz), clazz.getFileName().toString());
     }
 
+    /**
+     * Constructor.
+     * @param bytecode Bytecode
+     */
     public BytecodeRepresentation(final Bytecode bytecode) {
         this(bytecode.asBytes());
     }
@@ -85,6 +89,7 @@ public final class BytecodeRepresentation implements Representation {
     /**
      * Constructor.
      * @param input Input source
+     * @param source The source of the input
      */
     private BytecodeRepresentation(final Input input, final String source) {
         this(new UncheckedBytes(new BytesOf(input)).asBytes(), source);

--- a/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
@@ -26,6 +26,7 @@ package org.eolang.jeo.representation;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
+import org.eolang.jeo.Details;
 import org.eolang.jeo.Representation;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.xmir.XmlBytecode;
@@ -43,6 +44,8 @@ public final class EoRepresentation implements Representation {
      */
     private final XML xml;
 
+    private final String source;
+
     /**
      * Constructor.
      * @param lines Xml document lines.
@@ -57,6 +60,12 @@ public final class EoRepresentation implements Representation {
      */
     public EoRepresentation(final XML xml) {
         this.xml = xml;
+        this.source = "XMIR";
+    }
+
+    @Override
+    public Details details() {
+        return new Details(this.name(), this.source);
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
@@ -25,7 +25,9 @@ package org.eolang.jeo.representation;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Path;
 import org.eolang.jeo.Details;
 import org.eolang.jeo.Representation;
 import org.eolang.jeo.representation.bytecode.Bytecode;
@@ -46,6 +48,10 @@ public final class EoRepresentation implements Representation {
 
     private final String source;
 
+    public EoRepresentation(final Path path) {
+        this(EoRepresentation.xml(path), path.getFileName().toString());
+    }
+
     /**
      * Constructor.
      * @param lines Xml document lines.
@@ -59,8 +65,20 @@ public final class EoRepresentation implements Representation {
      * @param xml XML.
      */
     public EoRepresentation(final XML xml) {
+        this(xml, "Unknown");
+    }
+
+    /**
+     * Constructor.
+     * @param xml XML.
+     * @param source Source of the XML.
+     */
+    public EoRepresentation(
+        final XML xml,
+        final String source
+    ) {
         this.xml = xml;
-        this.source = "XMIR";
+        this.source = source;
     }
 
     @Override
@@ -86,6 +104,22 @@ public final class EoRepresentation implements Representation {
         } catch (final IOException exception) {
             throw new IllegalStateException(
                 String.format("The XMIR is invalid: %s", this.xml),
+                exception
+            );
+        }
+    }
+
+    /**
+     * Convert path to XML.
+     * @param path Path to XML file.
+     * @return XML.
+     */
+    private static XML xml(final Path path) {
+        try {
+            return new XMLDocument(path.toFile());
+        } catch (final FileNotFoundException exception) {
+            throw new IllegalStateException(
+                String.format("Can't find file '%s'", path),
                 exception
             );
         }

--- a/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
@@ -46,10 +46,17 @@ public final class EoRepresentation implements Representation {
      */
     private final XML xml;
 
+    /**
+     * Source of the XML.
+     */
     private final String source;
 
+    /**
+     * Constructor.
+     * @param path Path to XML file.
+     */
     public EoRepresentation(final Path path) {
-        this(EoRepresentation.xml(path), path.getFileName().toString());
+        this(EoRepresentation.open(path), path.getFileName().toString());
     }
 
     /**
@@ -114,7 +121,7 @@ public final class EoRepresentation implements Representation {
      * @param path Path to XML file.
      * @return XML.
      */
-    private static XML xml(final Path path) {
+    private static XML open(final Path path) {
         try {
             return new XMLDocument(path.toFile());
         } catch (final FileNotFoundException exception) {

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -136,7 +136,7 @@ public final class BytecodeClass {
      * @return XML representation of bytecode.
      */
     public XML xml() {
-        return new BytecodeRepresentation(this.bytecode().asBytes()).toEO();
+        return new BytecodeRepresentation(this.bytecode()).toEO();
     }
 
     /**

--- a/src/test/java/it/JavaSourceClass.java
+++ b/src/test/java/it/JavaSourceClass.java
@@ -41,6 +41,7 @@ import org.cactoos.Input;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
+import org.eolang.jeo.representation.bytecode.Bytecode;
 
 /**
  * Java source class with ".java" extension.
@@ -81,7 +82,7 @@ final class JavaSourceClass {
      * Compile the Java class.
      * @return Bytecode of compiled class.
      */
-    byte[] compile() {
+    Bytecode compile() {
         final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         final BytecodeManager manager = new BytecodeManager(compiler);
         final boolean successful = compiler.getTask(
@@ -93,7 +94,7 @@ final class JavaSourceClass {
             Collections.singleton(new SourceCode(this.name, this.java))
         ).call();
         if (successful) {
-            return manager.bytecode();
+            return new Bytecode(manager.bytecode());
         } else {
             throw new IllegalStateException(
                 String.format("Compilation failed for class %s", this.name)
@@ -120,7 +121,7 @@ final class JavaSourceClass {
         /**
          * Bytecode.
          */
-        private final AtomicReference<Bytecode> output;
+        private final AtomicReference<BytecodeOutput> output;
 
         /**
          * Constructor.
@@ -152,7 +153,7 @@ final class JavaSourceClass {
             final JavaFileObject.Kind kind,
             final FileObject sibling
         ) {
-            this.output.set(new Bytecode(classname));
+            this.output.set(new BytecodeOutput(classname));
             return this.output.get();
         }
 
@@ -197,7 +198,7 @@ final class JavaSourceClass {
      * Bytecode of compiled class.
      * @since 0.1.0
      */
-    private static final class Bytecode extends SimpleJavaFileObject {
+    private static final class BytecodeOutput extends SimpleJavaFileObject {
 
         /**
          * Output stream.
@@ -208,7 +209,7 @@ final class JavaSourceClass {
          * Constructor.
          * @param name Name of Java class.
          */
-        Bytecode(final String name) {
+        BytecodeOutput(final String name) {
             super(URI.create(String.format("%s%s", name, Kind.CLASS.extension)), Kind.CLASS);
             this.output = new ByteArrayOutputStream();
         }

--- a/src/test/java/org/eolang/jeo/improvement/ImprovementDistilledObjectsTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/ImprovementDistilledObjectsTest.java
@@ -143,7 +143,6 @@ final class ImprovementDistilledObjectsTest {
                 .instruction(Opcodes.IRETURN)
                 .up()
                 .bytecode()
-                .asBytes()
         );
     }
 
@@ -191,7 +190,6 @@ final class ImprovementDistilledObjectsTest {
                 .instruction(Opcodes.IRETURN)
                 .up()
                 .bytecode()
-                .asBytes()
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/EoRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/EoRepresentationTest.java
@@ -85,7 +85,7 @@ class EoRepresentationTest {
             .withField("foo")
             .bytecode();
         final Bytecode actual = new EoRepresentation(
-            new BytecodeRepresentation(expected.asBytes()).toEO()
+            new BytecodeRepresentation(expected).toEO()
         ).toBytecode();
         MatcherAssert.assertThat(
             String.format(EoRepresentationTest.MESSAGE, expected, actual),
@@ -101,7 +101,7 @@ class EoRepresentationTest {
             .helloWorldMethod()
             .bytecode();
         final Bytecode actual = new EoRepresentation(
-            new BytecodeRepresentation(expected.asBytes()).toEO()
+            new BytecodeRepresentation(expected).toEO()
         ).toBytecode();
         MatcherAssert.assertThat(
             String.format(EoRepresentationTest.MESSAGE, expected, actual),


### PR DESCRIPTION
Print logs during `bytecode-to-eo` transformation.

Closes: #269.
____
History:
- feat(#269): add Details class
- feat(#269): print bytecode-to-eo log
- feat(#269): check logs in integration tests
- feat(#269): add javadocs for Details class
- feat(#269): fix all qulice suggestiosn


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the representation of bytecode in the code. 

### Detailed summary
- Replaced `this.bytecode().asBytes()` with `this.bytecode()` in `BytecodeClass.java` and `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentationTest.java`.
- Replaced `new BytecodeRepresentation(expected.asBytes()).toEO()` with `new BytecodeRepresentation(expected).toEO()` in `EoRepresentation

> The following files were skipped due to too many changes: `src/main/java/org/eolang/jeo/Details.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->