### PR TITLE
feat(#278): Update `eo-parser` Library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
-      <version>0.32.0</version>
+      <version>0.33.0</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import lombok.ToString;
@@ -146,14 +145,6 @@ public final class BytecodeRepresentation implements Representation {
                     directives
                 ),
                 exception
-            );
-        } catch (final IOException ioexception) {
-            throw new IllegalStateException(
-                String.format(
-                    "Can't build XML from %s, since the resulting XMIR is invalid",
-                    Arrays.toString(this.input)
-                ),
-                ioexception
             );
         }
     }

--- a/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
@@ -26,7 +26,6 @@ package org.eolang.jeo.representation;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.nio.file.Path;
 import org.eolang.jeo.Details;
 import org.eolang.jeo.Representation;
@@ -105,15 +104,8 @@ public final class EoRepresentation implements Representation {
 
     @Override
     public Bytecode toBytecode() {
-        try {
-            new Schema(this.xml).check();
-            return new XmlBytecode(this.xml).bytecode();
-        } catch (final IOException exception) {
-            throw new IllegalStateException(
-                String.format("The XMIR is invalid: %s", this.xml),
-                exception
-            );
-        }
+        new Schema(this.xml).check();
+        return new XmlBytecode(this.xml).bytecode();
     }
 
     /**


### PR DESCRIPTION
Update `eo-parser` library up to `0.33.0` version and remove enncessary `IOException` checks.
Closes: #278.


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Update the version of `eo-parser` dependency to `0.33.0` in `pom.xml`
- Remove unnecessary import statements in `BytecodeRepresentation.java` and `EoRepresentation.java`
- Remove exception handling code in `BytecodeRepresentation.java` and `EoRepresentation.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->