### PR TITLE
feat(#271): Save Class Name And Package Separately

### DIFF
--- a/src/it/betecode-to-eo/src/main/java/WithoutPackage.java
+++ b/src/it/betecode-to-eo/src/main/java/WithoutPackage.java
@@ -1,0 +1,2 @@
+public class WithoutPackage {
+}

--- a/src/it/betecode-to-eo/verify.groovy
+++ b/src/it/betecode-to-eo/verify.groovy
@@ -25,6 +25,7 @@
 String log = new File(basedir, 'build.log').text;
 assert log.contains("Application.class translated into Application.xmir")
 assert log.contains("Foo.class translated into Foo.xmir")
+assert log.contains("WithoutPackage.class translated into WithoutPackage.xmir")
 assert log.contains("BUILD SUCCESS")
 //Check that we have generated XMIR object file.
 assert new File(basedir, 'target/generated-sources/xmir/org/eolang/jeo/Application.xmir').exists()

--- a/src/it/eo-to-bytecode/target/generated-sources/xmir/org/eolang/jeo/Application.xmir
+++ b/src/it/eo-to-bytecode/target/generated-sources/xmir/org/eolang/jeo/Application.xmir
@@ -11,7 +11,13 @@
 
   <license/>
 
-  <metas/>
+  <metas>
+    <meta>
+      <head>package</head>
+      <tail/>
+      <part/>
+    </meta>
+  </metas>
 
   <objects>
 

--- a/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
@@ -27,10 +27,10 @@ import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
-import java.util.List;
 import org.eolang.jeo.Details;
 import org.eolang.jeo.Representation;
 import org.eolang.jeo.representation.bytecode.Bytecode;
+import org.eolang.jeo.representation.directives.ClassName;
 import org.eolang.jeo.representation.xmir.XmlBytecode;
 import org.eolang.parser.Schema;
 
@@ -95,18 +95,10 @@ public final class EoRepresentation implements Representation {
 
     @Override
     public String name() {
-        final String result;
-        final String pckg = this.xml.xpath("/program/metas/meta/tail/text()").stream()
-            .findFirst()
-            .orElse("")
-            .replace(".", "/");
-        final String name = this.xml.xpath("/program/@name").get(0);
-        if (pckg.isEmpty()) {
-            result = name;
-        } else {
-            result = String.format("%s/%s", pckg, name);
-        }
-        return result;
+        return new ClassName(
+            this.xml.xpath("/program/metas/meta/tail/text()").stream().findFirst().orElse(""),
+            this.xml.xpath("/program/@name").get(0)
+        ).full();
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
@@ -27,6 +27,7 @@ import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.FileNotFoundException;
 import java.nio.file.Path;
+import java.util.List;
 import org.eolang.jeo.Details;
 import org.eolang.jeo.Representation;
 import org.eolang.jeo.representation.bytecode.Bytecode;
@@ -94,7 +95,18 @@ public final class EoRepresentation implements Representation {
 
     @Override
     public String name() {
-        return this.xml.xpath("/program/@name").get(0);
+        final String result;
+        final String pckg = this.xml.xpath("/program/metas/meta/tail/text()").stream()
+            .findFirst()
+            .orElse("")
+            .replace(".", "/");
+        final String name = this.xml.xpath("/program/@name").get(0);
+        if (pckg.isEmpty()) {
+            result = name;
+        } else {
+            result = String.format("%s/%s", pckg, name);
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/directives/ClassName.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/ClassName.java
@@ -1,12 +1,26 @@
 package org.eolang.jeo.representation.directives;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 public class ClassName {
 
     private final static String DELIMETER = "/";
     private final String name;
 
+    public ClassName(final String pckg, final String name) {
+        this(Stream.of(pckg, name)
+            .filter(s -> !s.isEmpty())
+            .map(s -> s.replace(".", ClassName.DELIMETER))
+            .collect(Collectors.joining(ClassName.DELIMETER)));
+    }
+
     public ClassName(final String name) {
         this.name = name;
+    }
+
+    public String full() {
+        return this.name;
     }
 
     public String pckg() {

--- a/src/main/java/org/eolang/jeo/representation/directives/ClassName.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/ClassName.java
@@ -1,45 +1,112 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.directives;
 
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class ClassName {
+/**
+ * Class name.
+ * Understands class name and package. Could extract them from full class name.
+ * @since 0.1
+ * @todo #271:30min Rename ClassName Class.
+ *  Currently we have to classes with the same name:
+ *  {@link org.eolang.jeo.representation.directives.ClassName} and
+ *  {@link org.eolang.jeo.representation.ClassName}. It makes sense to rename
+ *  one of them to avoid confusion.
+ */
+public final class ClassName {
 
-    private final static String DELIMETER = "/";
+    /**
+     * Internal delimiter.
+     * This delimiter is used to split full class name to package and class name.
+     * The field {@code #name} uses this delimiter internally.
+     */
+    private final static String DELIMITER = "/";
+
+    /**
+     * Full class name.
+     * This field contains full class name including package.
+     * Example: {@code org/eolang/jeo/representation/directives/ClassName}.
+     */
     private final String name;
 
+    /**
+     * Constructor.
+     * @param pckg Package
+     * @param name Class name
+     */
     public ClassName(final String pckg, final String name) {
         this(Stream.of(pckg, name)
             .filter(s -> !s.isEmpty())
-            .map(s -> s.replace(".", ClassName.DELIMETER))
-            .collect(Collectors.joining(ClassName.DELIMETER)));
+            .map(s -> s.replace(".", ClassName.DELIMITER))
+            .collect(Collectors.joining(ClassName.DELIMITER)));
     }
 
+    /**
+     * Constructor.
+     * @param name
+     */
     public ClassName(final String name) {
         this.name = name;
     }
 
+    /**
+     * Full class name.
+     * @return Full class name as is.
+     */
     public String full() {
         return this.name;
     }
 
+    /**
+     * Package.
+     * @return Package name in the following format:
+     * {@code org.eolang.jeo.representation.directives}.
+     */
     public String pckg() {
         final String result;
-        final int index = this.name.lastIndexOf(ClassName.DELIMETER);
+        final int index = this.name.lastIndexOf(ClassName.DELIMITER);
         if (index == -1) {
             result = "";
         } else {
-            result = this.name.substring(0, index).replace(ClassName.DELIMETER, ".");
+            result = this.name.substring(0, index).replace(ClassName.DELIMITER, ".");
         }
         return result;
     }
 
+    /**
+     * Class name.
+     * @return Class name in the following format: {@code ClassName}.
+     */
     public String name() {
-        if (this.name.contains(ClassName.DELIMETER)) {
-            final String[] split = this.name.split(ClassName.DELIMETER);
+        if (this.name.contains(ClassName.DELIMITER)) {
+            final String[] split = this.name.split(ClassName.DELIMITER);
             return split[split.length - 1];
         } else {
             return this.name;
         }
     }
 }
+

--- a/src/main/java/org/eolang/jeo/representation/directives/ClassName.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/ClassName.java
@@ -43,14 +43,14 @@ public final class ClassName {
      * This delimiter is used to split full class name to package and class name.
      * The field {@code #name} uses this delimiter internally.
      */
-    private final static String DELIMITER = "/";
+    private static final String DELIMITER = "/";
 
     /**
      * Full class name.
      * This field contains full class name including package.
      * Example: {@code org/eolang/jeo/representation/directives/ClassName}.
      */
-    private final String name;
+    private final String fqn;
 
     /**
      * Constructor.
@@ -66,10 +66,10 @@ public final class ClassName {
 
     /**
      * Constructor.
-     * @param name
+     * @param name Full class name.
      */
     public ClassName(final String name) {
-        this.name = name;
+        this.fqn = name;
     }
 
     /**
@@ -77,21 +77,20 @@ public final class ClassName {
      * @return Full class name as is.
      */
     public String full() {
-        return this.name;
+        return this.fqn;
     }
 
     /**
      * Package.
-     * @return Package name in the following format:
-     * {@code org.eolang.jeo.representation.directives}.
+     * @return Package name in the following format: "org.eolang.jeo.representation.directives".
      */
     public String pckg() {
         final String result;
-        final int index = this.name.lastIndexOf(ClassName.DELIMITER);
+        final int index = this.fqn.lastIndexOf(ClassName.DELIMITER);
         if (index == -1) {
             result = "";
         } else {
-            result = this.name.substring(0, index).replace(ClassName.DELIMITER, ".");
+            result = this.fqn.substring(0, index).replace(ClassName.DELIMITER, ".");
         }
         return result;
     }
@@ -101,12 +100,14 @@ public final class ClassName {
      * @return Class name in the following format: {@code ClassName}.
      */
     public String name() {
-        if (this.name.contains(ClassName.DELIMITER)) {
-            final String[] split = this.name.split(ClassName.DELIMITER);
-            return split[split.length - 1];
+        final String result;
+        if (this.fqn.contains(ClassName.DELIMITER)) {
+            final String[] split = this.fqn.split(ClassName.DELIMITER);
+            result = split[split.length - 1];
         } else {
-            return this.name;
+            result = this.fqn;
         }
+        return result;
     }
 }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/ClassName.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/ClassName.java
@@ -10,12 +10,22 @@ public class ClassName {
     }
 
     public String pckg() {
-        return this.name.substring(0, this.name.lastIndexOf(ClassName.DELIMETER))
-            .replace(ClassName.DELIMETER, ".");
+        final String result;
+        final int index = this.name.lastIndexOf(ClassName.DELIMETER);
+        if (index == -1) {
+            result = "";
+        } else {
+            result = this.name.substring(0, index).replace(ClassName.DELIMETER, ".");
+        }
+        return result;
     }
 
     public String name() {
-        final String[] split = this.name.split(ClassName.DELIMETER);
-        return split[split.length - 1];
+        if (this.name.contains(ClassName.DELIMETER)) {
+            final String[] split = this.name.split(ClassName.DELIMETER);
+            return split[split.length - 1];
+        } else {
+            return this.name;
+        }
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/ClassName.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/ClassName.java
@@ -1,0 +1,21 @@
+package org.eolang.jeo.representation.directives;
+
+public class ClassName {
+
+    private final static String DELIMETER = "/";
+    private final String name;
+
+    public ClassName(final String name) {
+        this.name = name;
+    }
+
+    public String pckg() {
+        return this.name.substring(0, this.name.lastIndexOf(ClassName.DELIMETER))
+            .replace(ClassName.DELIMETER, ".");
+    }
+
+    public String name() {
+        final String[] split = this.name.split(ClassName.DELIMETER);
+        return split[split.length - 1];
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -48,6 +48,13 @@ import org.xembly.Directives;
  *  method argument names `arg__I__0` and `arg__Ljava/lang/String__1`. This is not a good way
  *  to do it. At least it leads to errors when argument type is an array or class.
  *  So we have to test this cases and maybe create a better strategy for arguments naming.
+ * @todo #271:90min Split DirectivesClass into two separate classes.
+ *  Currently {@link DirectivesClass} is responsible for two things:
+ *  - Scanning bytecode class/
+ *  - Building Xembly directives.
+ *  We have to split this class into two separate classes:
+ *  - DirectivesClassVisitor - responsible for scanning bytecode class.
+ *  - DirectivesClass - responsible for building Xembly directives according with scanned bytecode.
  */
 @SuppressWarnings({"PMD.UseObjectForClearerAPI", "PMD.AvoidDuplicateLiterals"})
 public final class DirectivesClass extends ClassVisitor implements Iterable<Directive> {

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -111,8 +111,9 @@ public final class DirectivesClass extends ClassVisitor implements Iterable<Dire
     ) {
         final String now = ZonedDateTime.now(ZoneOffset.UTC)
             .format(DateTimeFormatter.ISO_INSTANT);
+        final ClassName clazz = new ClassName(name);
         this.directives.add("program")
-            .attr("name", name)
+            .attr("name", clazz.name())
             .attr("version", "0.0.0")
             .attr("revision", "0.0.0")
             .attr("dob", now)
@@ -123,12 +124,18 @@ public final class DirectivesClass extends ClassVisitor implements Iterable<Dire
             .add("errors").up()
             .add("sheets").up()
             .add("license").up()
-            .add("metas").up()
+            .add("metas")
+            .add("meta")
+            .add("head").set("package").up()
+            .add("tail").set(clazz.pckg()).up()
+            .add("part").set(clazz.pckg()).up()
+            .up()
+            .up()
             .attr("ms", System.currentTimeMillis())
             .add("objects");
         this.directives.add("o")
             .attr("abstract", "")
-            .attr("name", name)
+            .attr("name", clazz.name())
             .append(new DirectivesClassProperties(access, signature, supername, interfaces));
         super.visit(version, access, name, signature, supername, interfaces);
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
@@ -27,6 +27,7 @@ import com.jcabi.xml.XML;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
+import org.eolang.jeo.representation.directives.ClassName;
 
 /**
  * XML to Java bytecode.
@@ -52,9 +53,10 @@ public final class XmlBytecode {
      * @return Bytecode.
      */
     public Bytecode bytecode() {
-        final XmlClass clazz = new XmlProgram(this.xml).top();
+        final XmlProgram program = new XmlProgram(this.xml);
+        final XmlClass clazz = program.top();
         final BytecodeClass bytecode = new BytecodeClass(
-            clazz.name(),
+            new ClassName(program.pckg(), clazz.name()).full(),
             clazz.properties().toBytecodeProperties()
         );
         for (final XmlField field : clazz.fields()) {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -100,6 +100,19 @@ public class XmlProgram {
     }
 
     /**
+     * Retrieve program package.
+     * @return Package.
+     */
+    public String pckg() {
+        return new XmlNode(this.root)
+            .child(XmlProgram.PROGRAM)
+            .child("metas")
+            .child("meta")
+            .child("tail")
+            .text();
+    }
+
+    /**
      * Convert to XMIR .
      * @return XMIR.
      */

--- a/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
@@ -49,7 +49,7 @@ final class BytecodeRepresentationTest {
             "The simplest class should contain the object with MethodByte name",
             new BytecodeRepresentation(new ResourceOf(BytecodeRepresentationTest.METHOD_BYTE))
                 .toEO().xpath("/program/@name").get(0),
-            Matchers.equalTo("org/eolang/jeo/MethodByte")
+            Matchers.equalTo("MethodByte")
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/EoRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/EoRepresentationTest.java
@@ -63,7 +63,7 @@ class EoRepresentationTest {
         MatcherAssert.assertThat(
             "The XML representation of the EO object is not correct",
             new EoRepresentation(new BytecodeClass("org/eolang/foo/Math").xml()).toEO(),
-            XhtmlMatchers.hasXPath("/program[@name='org/eolang/foo/Math']")
+            XhtmlMatchers.hasXPath("/program[@name='Math']")
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -81,7 +81,7 @@ class DirectivesClassTest {
         ).accept(directives, 0);
         final String xml = new Xembler(directives).xml();
         final String name = "ClassInPackage";
-        final String pckg = "some/package";
+        final String pckg = "some.package";
         MatcherAssert.assertThat(
             String.format(
                 "Can't parse '%s' class that placed under package '%s', result is: %n%s%n",

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -68,4 +68,5 @@ class DirectivesClassTest {
             new HasMethod("main").inside(clazz)
         );
     }
+
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -69,4 +69,29 @@ class DirectivesClassTest {
         );
     }
 
+    @Test
+    void parsesClassWithPackage() throws ImpossibleModificationException {
+        final DirectivesClass directives = new DirectivesClass();
+        final String clazz = "some/package/ClassInPackage";
+        new ClassReader(
+            new BytecodeClass(clazz)
+                .helloWorldMethod()
+                .bytecode()
+                .asBytes()
+        ).accept(directives, 0);
+        final String xml = new Xembler(directives).xml();
+        final String name = "ClassInPackage";
+        final String pckg = "some/package";
+        MatcherAssert.assertThat(
+            String.format(
+                "Can't parse '%s' class that placed under package '%s', result is: %n%s%n",
+                name,
+                pckg,
+                new XMLDocument(xml)
+            ),
+            xml,
+            new HasClass(name).inside(pckg)
+        );
+    }
+
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -93,5 +93,4 @@ class DirectivesClassTest {
             new HasClass(name).inside(pckg)
         );
     }
-
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/HasClass.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasClass.java
@@ -63,15 +63,15 @@ final class HasClass extends TypeSafeMatcher<String> {
      * Package example:
      * <p>
      * {@code
-     * <program>
-     *   <metas>
-     *     <meta line="1">
-     *        <head>package</head>
-     *        <tail>a.b.c</tail>
-     *        <part>a.b.c</part>
-     *     </meta>
-     *   </metas>
-     * </program>
+     * &lt;program&gt;
+     *   &lt;metas&gt;
+     *     &lt;meta line="1"&gt;
+     *        &lt;head&gt;package&lt;/head&gt;
+     *        &lt;tail&gt;a.b.c&lt;/tail&gt;
+     *        &lt;part&gt;a.b.c&lt;/part&gt;
+     *     &lt;/meta&gt;
+     *   &lt;/metas&gt;
+     * &lt;/program&gt;
      * }
      * </p>
      * @param pckg Package name.

--- a/src/test/java/org/eolang/jeo/representation/directives/HasClass.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasClass.java
@@ -24,6 +24,8 @@
 package org.eolang.jeo.representation.directives;
 
 import com.jcabi.xml.XMLDocument;
+import java.util.ArrayList;
+import java.util.List;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
@@ -40,18 +42,36 @@ final class HasClass extends TypeSafeMatcher<String> {
     private final String name;
 
     /**
+     * Additional checks.
+     * List of xpaths that should be checked.
+     */
+    private final List<String> checks;
+
+    /**
      * Constructor.
      * @param name Class name.
      */
     HasClass(final String name) {
         this.name = name;
+        this.checks = new ArrayList<>(0);
+    }
+
+    /**
+     * Add additional check for package.
+     * @param pckg Package name.
+     * @return This matcher.
+     */
+    public HasClass inside(final String pckg) {
+        checks.add(String.format("/program/metas/meta/"));
+        return this;
     }
 
     @Override
     public boolean matchesSafely(final String item) {
-        return !new XMLDocument(item).xpath(
+        final XMLDocument document = new XMLDocument(item);
+        return !document.xpath(
             String.format("/program/objects/o[@name='%s']/text()", this.name)
-        ).isEmpty();
+        ).isEmpty() && this.checks.stream().map(document::xpath).noneMatch(List::isEmpty);
     }
 
     @Override


### PR DESCRIPTION
Now we separate package from class name and save them in appropriate places.

```java
package foo.bar;
class Test {}
```
now will be transformed into:

```eo
+package foo.bar
[] > Test
  ...
```

Closes: #271.
____
History:
- feat(#271): add todo for the future refactoring
- feat(#271): Add unit test skeleton that fails
- feat(#271): finish with package check
- feat(#271): save classname as expected by test
- feat(#271): handle corner cases for classname and package
- feat(#271): fix all unit tests
- feat(#271): fix all integration tests
- feat(#271): simplify the code a bit
- feat(#271): add javadocs for ClassName
- feat(#271): fix all qulice suggestions.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the class name handling in the code. 

### Detailed summary
- Added a `ClassName` class to handle class names and packages.
- Updated relevant code to use the `ClassName` class for better organization and readability.
- Added additional checks for package names in the `HasClass` matcher.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->