### PR TITLE
feat(#285): split DirectivesClass to DirectivesClass and DirectivesClassVisitor

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -35,7 +35,7 @@ import org.cactoos.io.InputOf;
 import org.eolang.jeo.Details;
 import org.eolang.jeo.Representation;
 import org.eolang.jeo.representation.bytecode.Bytecode;
-import org.eolang.jeo.representation.directives.DirectivesClass;
+import org.eolang.jeo.representation.directives.DirectivesClassVisitor;
 import org.eolang.parser.Schema;
 import org.objectweb.asm.ClassReader;
 import org.xembly.ImpossibleModificationException;
@@ -129,7 +129,7 @@ public final class BytecodeRepresentation implements Representation {
 
     @Override
     public XML toEO() {
-        final DirectivesClass directives = new DirectivesClass(
+        final DirectivesClassVisitor directives = new DirectivesClassVisitor(
             new Base64Bytecode(this.input).asString()
         );
         try {

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -1,0 +1,61 @@
+package org.eolang.jeo.representation.directives;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.eolang.jeo.representation.ClassName;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+public class DirectivesClass implements Iterable<Directive> {
+
+    private final ClassName name;
+    private final DirectivesClassProperties properties;
+
+    private final List<DirectivesMethod> methods;
+
+    private final List<DirectivesField> fields;
+
+    public DirectivesClass(final ClassName name) {
+        this(name, new DirectivesClassProperties());
+    }
+
+    public DirectivesClass(final ClassName name, final DirectivesClassProperties properties) {
+        this(name, properties, new ArrayList<>(0), new ArrayList<>(0));
+    }
+
+    public DirectivesClass(
+        final ClassName name,
+        final DirectivesClassProperties properties,
+        final List<DirectivesMethodVisitor> methods,
+        final List<DirectivesField> fields
+    ) {
+        this.name = name;
+        this.properties = properties;
+        this.methods = methods;
+        this.fields = fields;
+    }
+
+    public DirectivesClass field(final DirectivesField field) {
+        this.fields.add(field);
+        return this;
+    }
+
+    public DirectivesClass method(final DirectivesMethod method) {
+        this.methods.add(method);
+        return this;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        Directives directives = new Directives();
+        directives.add("o")
+            .attr("abstract", "")
+            .attr("name", this.name.name())
+            .append(this.properties);
+        this.fields.forEach(directives::append);
+        this.methods.forEach(directives::append);
+        directives.up();
+        return directives.iterator();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -27,7 +27,7 @@ public class DirectivesClass implements Iterable<Directive> {
     public DirectivesClass(
         final ClassName name,
         final DirectivesClassProperties properties,
-        final List<DirectivesMethodVisitor> methods,
+        final List<DirectivesMethod> methods,
         final List<DirectivesField> fields
     ) {
         this.name = name;

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.directives;
 
 import java.util.ArrayList;
@@ -7,24 +30,58 @@ import org.eolang.jeo.representation.ClassName;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
-public class DirectivesClass implements Iterable<Directive> {
+/**
+ * Directives Class.
+ * @since 0.1
+ */
+public final class DirectivesClass implements Iterable<Directive> {
 
+    /**
+     * Class name.
+     */
     private final ClassName name;
+
+    /**
+     * Class properties.
+     */
     private final DirectivesClassProperties properties;
 
-    private final List<DirectivesMethod> methods;
-
+    /**
+     * Class fields.
+     */
     private final List<DirectivesField> fields;
 
-    public DirectivesClass(final ClassName name) {
+    /**
+     * Class methods.
+     */
+    private final List<DirectivesMethod> methods;
+
+    /**
+     * Constructor.
+     * @param name Class name
+     */
+    DirectivesClass(final ClassName name) {
         this(name, new DirectivesClassProperties());
     }
 
-    public DirectivesClass(final ClassName name, final DirectivesClassProperties properties) {
+    /**
+     * Constructor.
+     * @param name Class name
+     * @param properties Class properties
+     */
+    DirectivesClass(final ClassName name, final DirectivesClassProperties properties) {
         this(name, properties, new ArrayList<>(0), new ArrayList<>(0));
     }
 
-    public DirectivesClass(
+    /**
+     * Constructor.
+     * @param name Class name
+     * @param properties Class properties
+     * @param methods Class methods
+     * @param fields Class fields
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    private DirectivesClass(
         final ClassName name,
         final DirectivesClassProperties properties,
         final List<DirectivesMethod> methods,
@@ -36,11 +93,21 @@ public class DirectivesClass implements Iterable<Directive> {
         this.fields = fields;
     }
 
+    /**
+     * Add field to the directives.
+     * @param field Field
+     * @return The same instance of {@link DirectivesClass}.
+     */
     public DirectivesClass field(final DirectivesField field) {
         this.fields.add(field);
         return this;
     }
 
+    /**
+     * Add method to the directives.
+     * @param method Method
+     * @return The same instance of {@link DirectivesClass}.
+     */
     public DirectivesClass method(final DirectivesMethod method) {
         this.methods.add(method);
         return this;
@@ -48,14 +115,13 @@ public class DirectivesClass implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        Directives directives = new Directives();
+        final Directives directives = new Directives();
         directives.add("o")
             .attr("abstract", "")
             .attr("name", this.name.name())
             .append(this.properties);
         this.fields.forEach(directives::append);
         this.methods.forEach(directives::append);
-        directives.up();
-        return directives.iterator();
+        return directives.up().iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
@@ -54,6 +54,10 @@ final class DirectivesClassProperties implements Iterable<Directive> {
      */
     private final String[] interfaces;
 
+    DirectivesClassProperties(){
+        this(0, "", "", new String[0]);
+    }
+
     /**
      * Constructor.
      * @param access Access modifiers.

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
@@ -54,7 +54,10 @@ final class DirectivesClassProperties implements Iterable<Directive> {
      */
     private final String[] interfaces;
 
-    DirectivesClassProperties(){
+    /**
+     * Constructor.
+     */
+    DirectivesClassProperties() {
         this(0, "", "", new String[0]);
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -114,9 +114,9 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
     ) {
         final String now = ZonedDateTime.now(ZoneOffset.UTC)
             .format(DateTimeFormatter.ISO_INSTANT);
-        final ClassName clazz = new ClassName(name);
+        final ClassName classname = new ClassName(name);
         this.directives.add("program")
-            .attr("name", clazz.name())
+            .attr("name", classname.name())
             .attr("version", "0.0.0")
             .attr("revision", "0.0.0")
             .attr("dob", now)
@@ -130,8 +130,8 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
             .add("metas")
             .add("meta")
             .add("head").set("package").up()
-            .add("tail").set(clazz.pckg()).up()
-            .add("part").set(clazz.pckg()).up()
+            .add("tail").set(classname.pckg()).up()
+            .add("part").set(classname.pckg()).up()
             .up()
             .up()
             .attr("ms", System.currentTimeMillis())
@@ -142,7 +142,7 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
             supername,
             interfaces
         );
-        this.clazz.set(new DirectivesClass(clazz, props));
+        this.clazz.set(new DirectivesClass(classname, props));
         super.visit(version, access, name, signature, supername, interfaces);
     }
 
@@ -159,7 +159,8 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
             new DirectivesMethodProperties(access, descriptor, signature, exceptions)
         );
         this.clazz.get().method(method);
-        return new DirectivesMethodVisitor(method,
+        return new DirectivesMethodVisitor(
+            method,
             super.visitMethod(access, name, descriptor, signature, exceptions)
         );
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -144,10 +144,10 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
             supername,
             interfaces
         );
-        this.directives.add("o")
-            .attr("abstract", "")
-            .attr("name", clazz.name())
-            .append(props);
+//        this.directives.add("o")
+//            .attr("abstract", "")
+//            .attr("name", clazz.name())
+//            .append(props);
         this.clazz.set(new DirectivesClass(clazz, props));
         super.visit(version, access, name, signature, supername, interfaces);
     }
@@ -160,34 +160,39 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
         final String signature,
         final String[] exceptions
     ) {
-        final DirectivesMethodVisitor result;
-        if (name.equals("<init>")) {
-            this.directives.add("o")
-                .attr("abstract", "")
-                .attr("name", "new")
-                .append(new DirectivesMethodProperties(access, descriptor, signature, exceptions))
-                .add("o")
-                .attr("base", "seq")
-                .attr("name", "@");
-            result = new DirectivesMethodVisitor(
-                this.directives,
-                super.visitMethod(access, name, descriptor, signature, exceptions)
-            );
-        } else {
-            this.directives.add("o")
-                .attr("abstract", "")
-                .attr("name", name)
-                .append(new DirectivesMethodProperties(access, descriptor, signature, exceptions))
-                .add("o")
-                .attr("base", "seq")
-                .attr("name", "@");
-            result = new DirectivesMethodVisitor(
-                this.directives,
-                super.visitMethod(access, name, descriptor, signature, exceptions)
-            );
-        }
-        this.clazz.get().method(result);
-        return result;
+//        final DirectivesMethodVisitor result;
+//        if (name.equals("<init>")) {
+//            this.directives.add("o")
+//                .attr("abstract", "")
+//                .attr("name", "new")
+//                .append(new DirectivesMethodProperties(access, descriptor, signature, exceptions))
+//                .add("o")
+//                .attr("base", "seq")
+//                .attr("name", "@");
+//            result = new DirectivesMethodVisitor(
+//                this.directives,
+//                super.visitMethod(access, name, descriptor, signature, exceptions)
+//            );
+//        } else {
+//            this.directives.add("o")
+//                .attr("abstract", "")
+//                .attr("name", name)
+//                .append(new DirectivesMethodProperties(access, descriptor, signature, exceptions))
+//                .add("o")
+//                .attr("base", "seq")
+//                .attr("name", "@");
+//            result = new DirectivesMethodVisitor(
+//                this.directives,
+//                super.visitMethod(access, name, descriptor, signature, exceptions)
+//            );
+//        }
+        final DirectivesMethod method = new DirectivesMethod(name,
+            new DirectivesMethodProperties(access, descriptor, signature, exceptions)
+        );
+        this.clazz.get().method(method);
+        return new DirectivesMethodVisitor(method,
+            super.visitMethod(access, name, descriptor, signature, exceptions)
+        );
     }
 
     @Override
@@ -199,14 +204,14 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
         final Object value
     ) {
         this.clazz.get().field(new DirectivesField(access, name, descriptor, signature, value));
-        this.directives.append(new DirectivesField(access, name, descriptor, signature, value));
+//        this.directives.append(new DirectivesField(access, name, descriptor, signature, value));
         return super.visitField(access, name, descriptor, signature, value);
     }
 
     @Override
     public void visitEnd() {
 //        Here we should append the class to the directives.
-//        this.directives.append(this.clazz.get());
+        this.directives.append(this.clazz.get());
         this.directives.up();
         super.visitEnd();
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -50,7 +50,7 @@ import org.xembly.Directives;
  *  to do it. At least it leads to errors when argument type is an array or class.
  *  So we have to test this cases and maybe create a better strategy for arguments naming.
  * @todo #271:90min Split DirectivesClass into two separate classes.
- *  Currently {@link DirectivesClass} is responsible for two things:
+ *  Currently {@link DirectivesClassVisitor} is responsible for two things:
  *  - Scanning bytecode class/
  *  - Building Xembly directives.
  *  We have to split this class into two separate classes:
@@ -58,7 +58,7 @@ import org.xembly.Directives;
  *  - DirectivesClass - responsible for building Xembly directives according with scanned bytecode.
  */
 @SuppressWarnings({"PMD.UseObjectForClearerAPI", "PMD.AvoidDuplicateLiterals"})
-public final class DirectivesClass extends ClassVisitor implements Iterable<Directive> {
+public final class DirectivesClassVisitor extends ClassVisitor implements Iterable<Directive> {
 
     /**
      * Bytecode listing.
@@ -74,14 +74,14 @@ public final class DirectivesClass extends ClassVisitor implements Iterable<Dire
      * Constructor.
      * @param listing Bytecode listing.
      */
-    public DirectivesClass(final String listing) {
+    public DirectivesClassVisitor(final String listing) {
         this(new DefaultVersion().api(), new Directives(), listing);
     }
 
     /**
      * Constructor.
      */
-    DirectivesClass() {
+    DirectivesClassVisitor() {
         this("");
     }
 
@@ -91,7 +91,7 @@ public final class DirectivesClass extends ClassVisitor implements Iterable<Dire
      * @param directives Xembly directives.
      * @param listing Bytecode listing.
      */
-    private DirectivesClass(
+    private DirectivesClassVisitor(
         final int api,
         final Directives directives,
         final String listing

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -50,13 +50,6 @@ import org.xembly.Directives;
  *  method argument names `arg__I__0` and `arg__Ljava/lang/String__1`. This is not a good way
  *  to do it. At least it leads to errors when argument type is an array or class.
  *  So we have to test this cases and maybe create a better strategy for arguments naming.
- * @todo #271:90min Split DirectivesClass into two separate classes.
- *  Currently {@link DirectivesClassVisitor} is responsible for two things:
- *  - Scanning bytecode class/
- *  - Building Xembly directives.
- *  We have to split this class into two separate classes:
- *  - DirectivesClassVisitor - responsible for scanning bytecode class.
- *  - DirectivesClass - responsible for building Xembly directives according with scanned bytecode.
  */
 @SuppressWarnings({"PMD.UseObjectForClearerAPI", "PMD.AvoidDuplicateLiterals"})
 public final class DirectivesClassVisitor extends ClassVisitor implements Iterable<Directive> {
@@ -71,6 +64,11 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
      */
     private final Directives directives;
 
+    /**
+     * Class directives.
+     * This field uses atomic reference because the field can't be initialized in the constructor.
+     * It is ASM framework limitation.
+     */
     private final AtomicReference<DirectivesClass> clazz;
 
     /**
@@ -144,10 +142,6 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
             supername,
             interfaces
         );
-//        this.directives.add("o")
-//            .attr("abstract", "")
-//            .attr("name", clazz.name())
-//            .append(props);
         this.clazz.set(new DirectivesClass(clazz, props));
         super.visit(version, access, name, signature, supername, interfaces);
     }
@@ -160,33 +154,8 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
         final String signature,
         final String[] exceptions
     ) {
-//        final DirectivesMethodVisitor result;
-//        if (name.equals("<init>")) {
-//            this.directives.add("o")
-//                .attr("abstract", "")
-//                .attr("name", "new")
-//                .append(new DirectivesMethodProperties(access, descriptor, signature, exceptions))
-//                .add("o")
-//                .attr("base", "seq")
-//                .attr("name", "@");
-//            result = new DirectivesMethodVisitor(
-//                this.directives,
-//                super.visitMethod(access, name, descriptor, signature, exceptions)
-//            );
-//        } else {
-//            this.directives.add("o")
-//                .attr("abstract", "")
-//                .attr("name", name)
-//                .append(new DirectivesMethodProperties(access, descriptor, signature, exceptions))
-//                .add("o")
-//                .attr("base", "seq")
-//                .attr("name", "@");
-//            result = new DirectivesMethodVisitor(
-//                this.directives,
-//                super.visitMethod(access, name, descriptor, signature, exceptions)
-//            );
-//        }
-        final DirectivesMethod method = new DirectivesMethod(name,
+        final DirectivesMethod method = new DirectivesMethod(
+            name,
             new DirectivesMethodProperties(access, descriptor, signature, exceptions)
         );
         this.clazz.get().method(method);
@@ -204,13 +173,11 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
         final Object value
     ) {
         this.clazz.get().field(new DirectivesField(access, name, descriptor, signature, value));
-//        this.directives.append(new DirectivesField(access, name, descriptor, signature, value));
         return super.visitField(access, name, descriptor, signature, value);
     }
 
     @Override
     public void visitEnd() {
-//        Here we should append the class to the directives.
         this.directives.append(this.clazz.get());
         this.directives.up();
         super.visitEnd();

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
 import java.util.Optional;
+import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -79,8 +80,11 @@ final class DirectivesField implements Iterable<Directive> {
      */
     private final Object value;
 
-    public DirectivesField() {
-        this(0, "unknown", "I", "", "0");
+    /**
+     * Constructor.
+     */
+    DirectivesField() {
+        this(Opcodes.ACC_PUBLIC, "unknown", "I", "", "0");
     }
 
     /**
@@ -108,14 +112,14 @@ final class DirectivesField implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        final Directives directives = new Directives();
-        directives.add("o")
+        return new Directives().add("o")
             .attr("base", "field")
             .attr("name", this.name)
             .append(new DirectivesData(this.access))
             .append(new DirectivesData(this.descriptor))
             .append(new DirectivesData(this.signature))
-            .append(new DirectivesData(this.value));
-        return directives.up().iterator();
+            .append(new DirectivesData(this.value))
+            .up()
+            .iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
@@ -79,6 +79,10 @@ final class DirectivesField implements Iterable<Directive> {
      */
     private final Object value;
 
+    public DirectivesField() {
+        this(0, "unknown", "I", "", "0");
+    }
+
     /**
      * Constructor.
      * @param access Access

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.directives;
 
 import java.util.ArrayList;
@@ -6,25 +29,44 @@ import java.util.List;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
-public class DirectivesMethod implements Iterable<Directive> {
+/**
+ * Directives Method.
+ * @since 0.1
+ */
+public final class DirectivesMethod implements Iterable<Directive> {
 
+    /**
+     * Method name.
+     */
     private final String name;
+
+    /**
+     * Method properties.
+     */
     private final DirectivesMethodProperties properties;
 
+    /**
+     * Method instructions.
+     */
     private final List<Iterable<Directive>> instructions;
 
-    public DirectivesMethod(final String name) {
+    /**
+     * Constructor.
+     * @param name Method name
+     */
+    DirectivesMethod(final String name) {
         this(name, new DirectivesMethodProperties());
     }
 
-    public DirectivesMethod(final String name, final DirectivesMethodProperties properties) {
+    /**
+     * Constructor.
+     * @param name Method name
+     * @param properties Method properties
+     */
+    DirectivesMethod(final String name, final DirectivesMethodProperties properties) {
         this.name = name;
         this.properties = properties;
         this.instructions = new ArrayList<>(0);
-    }
-
-    public void operand(final DirectivesOperand directives) {
-        this.instructions.add(directives);
     }
 
     /**
@@ -38,16 +80,16 @@ public class DirectivesMethod implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        Directives directives = new Directives();
-        final String name;
+        final Directives directives = new Directives();
+        final String eoname;
         if (this.name.equals("<init>")) {
-            name = "new";
+            eoname = "new";
         } else {
-            name = this.name;
+            eoname = this.name;
         }
         directives.add("o")
             .attr("abstract", "")
-            .attr("name", name)
+            .attr("name", eoname)
             .append(this.properties)
             .add("o")
             .attr("base", "seq")
@@ -55,5 +97,13 @@ public class DirectivesMethod implements Iterable<Directive> {
         this.instructions.forEach(directives::append);
         directives.up().up();
         return directives.iterator();
+    }
+
+    /**
+     * Add operand to the directives.
+     * @param directives Operand directives.
+     */
+    void operand(final DirectivesOperand directives) {
+        this.instructions.add(directives);
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -11,12 +11,20 @@ public class DirectivesMethod implements Iterable<Directive> {
     private final String name;
     private final DirectivesMethodProperties properties;
 
-    private final List<DirectivesInstruction> instructions;
+    private final List<Iterable<Directive>> instructions;
+
+    public DirectivesMethod(final String name) {
+        this(name, new DirectivesMethodProperties());
+    }
 
     public DirectivesMethod(final String name, final DirectivesMethodProperties properties) {
         this.name = name;
         this.properties = properties;
         this.instructions = new ArrayList<>(0);
+    }
+
+    public void operand(final DirectivesOperand directives) {
+        this.instructions.add(directives);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
@@ -59,7 +59,10 @@ final class DirectivesMethodProperties implements Iterable<Directive> {
      */
     private final String[] exceptions;
 
-    public DirectivesMethodProperties() {
+    /**
+     * Constructor.
+     */
+    DirectivesMethodProperties() {
         this(Opcodes.ACC_PUBLIC, "()V", "", "", "");
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
 import java.util.Optional;
+import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -57,6 +58,10 @@ final class DirectivesMethodProperties implements Iterable<Directive> {
      * Method exceptions.
      */
     private final String[] exceptions;
+
+    public DirectivesMethodProperties() {
+        this(Opcodes.ACC_PUBLIC, "()V", "", "", "");
+    }
 
     /**
      * Constructor.

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitor.java
@@ -29,7 +29,6 @@ import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.xembly.Directive;
-import org.xembly.Directives;
 
 /**
  * Method printer.
@@ -40,23 +39,22 @@ import org.xembly.Directives;
 public final class DirectivesMethodVisitor extends MethodVisitor implements Iterable<Directive> {
 
     /**
-     * Xembly directives.
+     * Method directives.
      */
-    private final Directives directives;
-
     private final DirectivesMethod method;
+
 
     /**
      * Constructor.
-     * @param directives Xembly directives
+     * @param method Method
      * @param visitor Method visitor
      */
     DirectivesMethodVisitor(
-        final Directives directives,
+        final DirectivesMethod method,
         final MethodVisitor visitor
     ) {
         super(new DefaultVersion().api(), visitor);
-        this.directives = directives;
+        this.method = method;
     }
 
     @Override
@@ -120,19 +118,18 @@ public final class DirectivesMethodVisitor extends MethodVisitor implements Iter
 
     @Override
     public void visitLabel(final Label label) {
-        this.directives.append(new DirectivesOperand(label));
+        this.method.operand(new DirectivesOperand(label));
         super.visitLabel(label);
     }
 
     @Override
     public void visitEnd() {
-        this.directives.up().up();
         super.visitEnd();
     }
 
     @Override
     public Iterator<Directive> iterator() {
-        return this.directives.iterator();
+        return this.method.iterator();
     }
 
     /**
@@ -141,7 +138,7 @@ public final class DirectivesMethodVisitor extends MethodVisitor implements Iter
      * @param operands Operands
      */
     private void opcode(final int opcode, final Object... operands) {
-        this.directives.append(new DirectivesInstruction(opcode, operands));
+        this.method.opcode(opcode, operands);
     }
 
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitor.java
@@ -1,0 +1,147 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.Iterator;
+import org.eolang.jeo.representation.DefaultVersion;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+/**
+ * Method printer.
+ * ASM method visitor which scans the method and builds Xembly directives.
+ * @since 0.1
+ */
+@SuppressWarnings("PMD.TooManyMethods")
+public final class DirectivesMethodVisitor extends MethodVisitor implements Iterable<Directive> {
+
+    /**
+     * Xembly directives.
+     */
+    private final Directives directives;
+
+    private final DirectivesMethod method;
+
+    /**
+     * Constructor.
+     * @param directives Xembly directives
+     * @param visitor Method visitor
+     */
+    DirectivesMethodVisitor(
+        final Directives directives,
+        final MethodVisitor visitor
+    ) {
+        super(new DefaultVersion().api(), visitor);
+        this.directives = directives;
+    }
+
+    @Override
+    public void visitInsn(final int opcode) {
+        this.opcode(opcode);
+        super.visitInsn(opcode);
+    }
+
+    @Override
+    public void visitFieldInsn(
+        final int opcode,
+        final String owner,
+        final String name,
+        final String descriptor
+    ) {
+        this.opcode(opcode, owner, name, descriptor);
+        super.visitFieldInsn(opcode, owner, name, descriptor);
+    }
+
+    @Override
+    public void visitIntInsn(final int opcode, final int operand) {
+        this.opcode(opcode, operand);
+        super.visitIntInsn(opcode, operand);
+    }
+
+    @Override
+    public void visitJumpInsn(final int opcode, final Label label) {
+        this.opcode(opcode, label);
+        super.visitJumpInsn(opcode, label);
+    }
+
+    @Override
+    public void visitTypeInsn(final int opcode, final String type) {
+        this.opcode(opcode, type);
+        super.visitTypeInsn(opcode, type);
+    }
+
+    @Override
+    public void visitVarInsn(final int opcode, final int varindex) {
+        this.opcode(opcode, varindex);
+        super.visitVarInsn(opcode, varindex);
+    }
+
+    @Override
+    public void visitMethodInsn(
+        final int opcode,
+        final String owner,
+        final String name,
+        final String descriptor,
+        final boolean isinterface
+    ) {
+        this.opcode(opcode, owner, name, descriptor);
+        super.visitMethodInsn(opcode, owner, name, descriptor, false);
+    }
+
+    @Override
+    public void visitLdcInsn(final Object value) {
+        this.opcode(Opcodes.LDC, value);
+        super.visitLdcInsn(value);
+    }
+
+    @Override
+    public void visitLabel(final Label label) {
+        this.directives.append(new DirectivesOperand(label));
+        super.visitLabel(label);
+    }
+
+    @Override
+    public void visitEnd() {
+        this.directives.up().up();
+        super.visitEnd();
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        return this.directives.iterator();
+    }
+
+    /**
+     * Add opcode to the directives.
+     * @param opcode Opcode
+     * @param operands Operands
+     */
+    private void opcode(final int opcode, final Object... operands) {
+        this.directives.append(new DirectivesInstruction(opcode, operands));
+    }
+
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitor.java
@@ -43,7 +43,6 @@ public final class DirectivesMethodVisitor extends MethodVisitor implements Iter
      */
     private final DirectivesMethod method;
 
-
     /**
      * Constructor.
      * @param method Method
@@ -123,11 +122,6 @@ public final class DirectivesMethodVisitor extends MethodVisitor implements Iter
     }
 
     @Override
-    public void visitEnd() {
-        super.visitEnd();
-    }
-
-    @Override
     public Iterator<Directive> iterator() {
         return this.method.iterator();
     }
@@ -140,5 +134,4 @@ public final class DirectivesMethodVisitor extends MethodVisitor implements Iter
     private void opcode(final int opcode, final Object... operands) {
         this.method.opcode(opcode, operands);
     }
-
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -53,13 +53,13 @@ class DirectivesClassTest {
     @Test
     void appendsMethod() {
         final String xml = new Xembler(
-            new DirectivesClass(new ClassName("Neo")).method(new DirectivesMethod()),
+            new DirectivesClass(new ClassName("Neo")).method(new DirectivesMethod("method")),
             new Transformers.Node()
         ).xmlQuietly();
         MatcherAssert.assertThat(
             String.format("Can't append method, result is: '%s'", new XMLDocument(xml)),
             xml,
-            XhtmlMatchers.hasXPath("/o[@name='Neo']/o[@base='method']")
+            XhtmlMatchers.hasXPath("/o[@name='Neo']/o[@name='method']")
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -1,0 +1,66 @@
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XMLDocument;
+import org.eolang.jeo.representation.ClassName;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.Transformers;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link DirectivesClass}.
+ */
+class DirectivesClassTest {
+
+    @Test
+    void createsWithSimpleConstructor() {
+        MatcherAssert.assertThat(
+            new XMLDocument(new Xembler(
+                new DirectivesClass(new ClassName("Neo"), new DirectivesClassProperties()),
+                new Transformers.Node()
+            ).xmlQuietly()),
+            Matchers.equalTo(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<o abstract='' name='Neo'>",
+                        "<o base='int' data='bytes' name='access'>00 00 00 00 00 00 00 00</o>",
+                        "<o base='string' data='bytes' name='signature'/>",
+                        "<o base='string' data='bytes' name='supername'/>",
+                        "<o base='tuple' data='tuple' name='interfaces'/>",
+                        "</o>"
+                    )
+                )
+            )
+        );
+    }
+
+    @Test
+    void appendsField() {
+        final String xml = new Xembler(
+            new DirectivesClass(new ClassName("Neo")).field(new DirectivesField()),
+            new Transformers.Node()
+        ).xmlQuietly();
+        MatcherAssert.assertThat(
+            String.format("Can't append field, result is: '%s'", new XMLDocument(xml)),
+            xml,
+            XhtmlMatchers.hasXPath("/o[@name='Neo']/o[@base='field']")
+        );
+    }
+
+    @Test
+    void appendsMethod() {
+        final String xml = new Xembler(
+            new DirectivesClass(new ClassName("Neo")).method(new DirectivesMethod()),
+            new Transformers.Node()
+        ).xmlQuietly();
+        MatcherAssert.assertThat(
+            String.format("Can't append method, result is: '%s'", new XMLDocument(xml)),
+            xml,
+            XhtmlMatchers.hasXPath("/o[@name='Neo']/o[@base='method']")
+        );
+    }
+
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -41,6 +41,7 @@ class DirectivesClassTest {
     @Test
     void createsWithSimpleConstructor() {
         MatcherAssert.assertThat(
+            "Can't create class with simple constructor",
             new XMLDocument(
                 new Xembler(
                     new DirectivesClass(new ClassName("Neo"), new DirectivesClassProperties()),
@@ -70,7 +71,10 @@ class DirectivesClassTest {
             new Transformers.Node()
         ).xmlQuietly();
         MatcherAssert.assertThat(
-            String.format("Can't append field, result is: '%s'", new XMLDocument(xml)),
+            String.format(
+                "Can't append field to the class; result is: '%s'",
+                new XMLDocument(xml)
+            ),
             xml,
             XhtmlMatchers.hasXPath("/o[@name='Neo']/o[@base='field']")
         );
@@ -83,7 +87,10 @@ class DirectivesClassTest {
             new Transformers.Node()
         ).xmlQuietly();
         MatcherAssert.assertThat(
-            String.format("Can't append method, result is: '%s'", new XMLDocument(xml)),
+            String.format(
+                "Can't append method to the class, or the method is appended wrongly; result is: '%s'",
+                new XMLDocument(xml)
+            ),
             xml,
             XhtmlMatchers.hasXPath("/o[@name='Neo']/o[@name='method']")
         );

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.directives;
 
 import com.jcabi.matchers.XhtmlMatchers;
@@ -11,16 +34,19 @@ import org.xembly.Xembler;
 
 /**
  * Test case for {@link DirectivesClass}.
+ * @since 0.1
  */
 class DirectivesClassTest {
 
     @Test
     void createsWithSimpleConstructor() {
         MatcherAssert.assertThat(
-            new XMLDocument(new Xembler(
-                new DirectivesClass(new ClassName("Neo"), new DirectivesClassProperties()),
-                new Transformers.Node()
-            ).xmlQuietly()),
+            new XMLDocument(
+                new Xembler(
+                    new DirectivesClass(new ClassName("Neo"), new DirectivesClassProperties()),
+                    new Transformers.Node()
+                ).xmlQuietly()
+            ),
             Matchers.equalTo(
                 new XMLDocument(
                     String.join(

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassVisitorTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassVisitorTest.java
@@ -32,14 +32,14 @@ import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
 /**
- * Test case for {@link org.eolang.jeo.representation.directives.DirectivesClass}.
+ * Test case for {@link DirectivesClassVisitor}.
  * @since 0.1.0
  */
-class DirectivesClassTest {
+class DirectivesClassVisitorTest {
 
     @Test
     void parsesSimpleClassWithoutConstructor() throws ImpossibleModificationException {
-        final DirectivesClass directives = new DirectivesClass();
+        final DirectivesClassVisitor directives = new DirectivesClassVisitor();
         new ClassReader(new BytecodeClass().bytecode().asBytes()).accept(directives, 0);
         MatcherAssert.assertThat(
             "Can't parse simple class without constructor",
@@ -50,7 +50,7 @@ class DirectivesClassTest {
 
     @Test
     void parsesSimpleClassWithMethod() throws ImpossibleModificationException {
-        final DirectivesClass directives = new DirectivesClass();
+        final DirectivesClassVisitor directives = new DirectivesClassVisitor();
         final String clazz = "WithMethod";
         new ClassReader(
             new BytecodeClass(clazz)
@@ -71,7 +71,7 @@ class DirectivesClassTest {
 
     @Test
     void parsesClassWithPackage() throws ImpossibleModificationException {
-        final DirectivesClass directives = new DirectivesClass();
+        final DirectivesClassVisitor directives = new DirectivesClassVisitor();
         final String clazz = "some/package/ClassInPackage";
         new ClassReader(
             new BytecodeClass(clazz)

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -38,11 +38,11 @@ import org.xembly.Xembler;
 /**
  * Test case for {@link org.eolang.jeo.representation.directives.DirectivesMethod}.
  * We create {@link org.eolang.jeo.representation.directives.DirectivesMethod} only in the context
- * of using {@link org.eolang.jeo.representation.directives.DirectivesClass} in other words,
+ * of using {@link DirectivesClassVisitor} in other words,
  * {@link org.eolang.jeo.representation.directives.DirectivesMethod} can't be createad
- * without {@link org.eolang.jeo.representation.directives.DirectivesClass} and it is the main
+ * without {@link DirectivesClassVisitor} and it is the main
  * reason why in all the test we create
- * {@link org.eolang.jeo.representation.directives.DirectivesClass}.
+ * {@link DirectivesClassVisitor}.
  *
  * @since 0.1.0
  */
@@ -51,7 +51,7 @@ class DirectivesMethodTest {
 
     @Test
     void parsesMethodInstructions() throws ImpossibleModificationException {
-        final DirectivesClass visitor = new DirectivesClass();
+        final DirectivesClassVisitor visitor = new DirectivesClassVisitor();
         new ClassReader(
             new BytecodeClass()
                 .withMethod("main")

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
@@ -36,10 +36,10 @@ import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
 /**
- * Test case for {@link org.eolang.jeo.representation.directives.DirectivesMethod}.
- * We create {@link org.eolang.jeo.representation.directives.DirectivesMethod} only in the context
+ * Test case for {@link DirectivesMethodVisitor}.
+ * We create {@link DirectivesMethodVisitor} only in the context
  * of using {@link DirectivesClassVisitor} in other words,
- * {@link org.eolang.jeo.representation.directives.DirectivesMethod} can't be createad
+ * {@link DirectivesMethodVisitor} can't be createad
  * without {@link DirectivesClassVisitor} and it is the main
  * reason why in all the test we create
  * {@link DirectivesClassVisitor}.
@@ -47,7 +47,7 @@ import org.xembly.Xembler;
  * @since 0.1.0
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-class DirectivesMethodTest {
+class DirectivesMethodVisitorTest {
 
     @Test
     void parsesMethodInstructions() throws ImpossibleModificationException {


### PR DESCRIPTION
Refactor the code. Extract DirectivesClassVisitor from DirectivesClass. The DirictivesClass used to violate OCP, now it looks better.

Closes: #285.
____
History:
- feat(#285): rename DirectivesClass -> DirectivesClassVisitor
- feat(#285): add DirectivesClass and DirectivesMethod classes
- feat(#285): fix all unit tests
- feat(#285): remove the puzzle for 285 issue
- feat(#285): fix all qulice suggestions

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the DirectivesClass and DirectivesMethod classes in the codebase. 

### Detailed summary
- Added constructors to DirectivesClassProperties, DirectivesMethodProperties, and DirectivesField classes.
- Renamed DirectivesClass to DirectivesClassVisitor and updated its usage in BytecodeRepresentation.
- Renamed DirectivesMethodTest to DirectivesMethodVisitorTest and updated its imports.
- Added DirectivesClassVisitorTest to test the DirectivesClassVisitor class.
- Updated DirectivesClassTest to use the new DirectivesClass constructor and added new test cases.
- Added license headers to DirectivesClassVisitor and DirectivesMethodVisitor classes.

> The following files were skipped due to too many changes: `src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitor.java`, `src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java`, `src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java`, `src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->