### PR TITLE
feat(#273): Fix The Bug With Repeated Commands

### DIFF
--- a/src/it/betecode-to-eo/pom.xml
+++ b/src/it/betecode-to-eo/pom.xml
@@ -47,6 +47,20 @@ SOFTWARE.
               <goal>bytecode-to-eo</goal>
             </goals>
           </execution>
+          <!--
+            The second run was added in order to check that
+            we successfully overwrite the existing EO files.
+            For example, if a developer call
+            - "mvn test"
+            - "mvn test"
+           then the second run should not fail.
+          -->
+          <execution>
+            <id>bytecode-to-eo-second-time</id>
+            <goals>
+              <goal>bytecode-to-eo</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/src/it/eo-to-bytecode/pom.xml
+++ b/src/it/eo-to-bytecode/pom.xml
@@ -47,6 +47,20 @@ SOFTWARE.
               <goal>eo-to-bytecode</goal>
             </goals>
           </execution>
+          <!--
+            The second run was added in order to check that
+            we successfully overwrite the existing bytecode files.
+            For example, if a developer call
+            - "mvn test"
+            - "mvn test"
+           then the second run should not fail.
+          -->
+          <execution>
+            <id>eo-to-bytecode-second-time</id>
+            <goals>
+              <goal>eo-to-bytecode</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementXmirFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementXmirFootprint.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import org.eolang.jeo.Improvement;

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementXmirFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementXmirFootprint.java
@@ -81,8 +81,7 @@ public final class ImprovementXmirFootprint implements Improvement {
             final XML xmir = representation.toEO();
             Files.write(
                 path,
-                xmir.toString().getBytes(StandardCharsets.UTF_8),
-                StandardOpenOption.CREATE_NEW
+                xmir.toString().getBytes(StandardCharsets.UTF_8)
             );
             final String filename = path.getFileName().toString();
             Logger.info(

--- a/src/test/java/org/eolang/jeo/improvement/ImprovementXmirFootprintTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/ImprovementXmirFootprintTest.java
@@ -24,7 +24,12 @@
 package org.eolang.jeo.improvement;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Set;
+import org.antlr.v4.runtime.tree.xpath.XPathTokenElement;
+import org.eolang.jeo.Representation;
 import org.eolang.jeo.representation.EoRepresentation;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.hamcrest.MatcherAssert;
@@ -39,23 +44,44 @@ import org.junit.jupiter.api.io.TempDir;
  */
 final class ImprovementXmirFootprintTest {
 
+    /**
+     * Representations to test.
+     */
+    private final Collection<Representation> representations = Collections.singleton(
+        new EoRepresentation(
+            new BytecodeClass("org/eolang/jeo/Application").xml()
+        )
+    );
+
+    /**
+     * Where the XML file is expected to be saved.
+     */
+    private final Path expected = Paths.get("")
+        .resolve("xmir")
+        .resolve("org")
+        .resolve("eolang")
+        .resolve("jeo")
+        .resolve("Application.xmir");
+
     @Test
     void savesXml(@TempDir final Path temp) {
         final ImprovementXmirFootprint footprint = new ImprovementXmirFootprint(temp);
-        footprint.apply(
-            Collections.singleton(
-                new EoRepresentation(
-                    new BytecodeClass("org/eolang/jeo/Application").xml()
-                )
-            )
-        );
+        footprint.apply(this.representations);
         MatcherAssert.assertThat(
             "XML file was not saved",
-            temp.resolve("xmir")
-                .resolve("org")
-                .resolve("eolang")
-                .resolve("jeo")
-                .resolve("Application.xmir").toFile(),
+            temp.resolve(this.expected).toFile(),
+            FileMatchers.anExistingFile()
+        );
+    }
+
+    @Test
+    void overwritesXml(@TempDir final Path temp) {
+        final ImprovementXmirFootprint footprint = new ImprovementXmirFootprint(temp);
+        footprint.apply(this.representations);
+        footprint.apply(this.representations);
+        MatcherAssert.assertThat(
+            "XML file was not successfully overwritten",
+            temp.resolve(this.expected).toFile(),
             FileMatchers.anExistingFile()
         );
     }

--- a/src/test/java/org/eolang/jeo/improvement/ImprovementXmirFootprintTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/ImprovementXmirFootprintTest.java
@@ -27,8 +27,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Set;
-import org.antlr.v4.runtime.tree.xpath.XPathTokenElement;
 import org.eolang.jeo.Representation;
 import org.eolang.jeo.representation.EoRepresentation;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
@@ -47,7 +45,7 @@ final class ImprovementXmirFootprintTest {
     /**
      * Representations to test.
      */
-    private final Collection<Representation> representations = Collections.singleton(
+    private final Collection<Representation> objects = Collections.singleton(
         new EoRepresentation(
             new BytecodeClass("org/eolang/jeo/Application").xml()
         )
@@ -66,7 +64,7 @@ final class ImprovementXmirFootprintTest {
     @Test
     void savesXml(@TempDir final Path temp) {
         final ImprovementXmirFootprint footprint = new ImprovementXmirFootprint(temp);
-        footprint.apply(this.representations);
+        footprint.apply(this.objects);
         MatcherAssert.assertThat(
             "XML file was not saved",
             temp.resolve(this.expected).toFile(),
@@ -77,8 +75,8 @@ final class ImprovementXmirFootprintTest {
     @Test
     void overwritesXml(@TempDir final Path temp) {
         final ImprovementXmirFootprint footprint = new ImprovementXmirFootprint(temp);
-        footprint.apply(this.representations);
-        footprint.apply(this.representations);
+        footprint.apply(this.objects);
+        footprint.apply(this.objects);
         MatcherAssert.assertThat(
             "XML file was not successfully overwritten",
             temp.resolve(this.expected).toFile(),


### PR DESCRIPTION
We had a bug when called `mvn test` several times. The original problem was in saving files to a FS. 
By default the previous saving command didn't overwrite files. Now I fixed that. 

Closes: #273.
____
History:
- feat(#273): change integration tests a bit in order to emphasize the problem when we run mvn test several times
- feat(#273): write unit test that reveals the problem
- feat(#273): solve the problem
- feat(#273): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a second run to check if the existing EO and bytecode files are successfully overwritten. 

### Detailed summary
- Added a second run to check overwriting of EO files in `pom.xml`
- Added a second run to check overwriting of bytecode files in `pom.xml`
- Removed `StandardOpenOption.CREATE_NEW` in `ImprovementXmirFootprint.java`
- Added `savesXml` and `overwritesXml` tests in `ImprovementXmirFootprintTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->