### PR TITLE
feat(#274): add aliases for opcode and label objects

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/ClassName.java
+++ b/src/main/java/org/eolang/jeo/representation/ClassName.java
@@ -49,6 +49,13 @@ public final class ClassName {
 
     /**
      * Constructor.
+     */
+    public ClassName() {
+        this("HelloWorld");
+    }
+
+    /**
+     * Constructor.
      * @param pckg Package
      * @param name Class name
      */

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -127,13 +127,7 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
             .add("errors").up()
             .add("sheets").up()
             .add("license").up()
-            .add("metas")
-            .add("meta")
-            .add("head").set("package").up()
-            .add("tail").set(classname.pckg()).up()
-            .add("part").set(classname.pckg()).up()
-            .up()
-            .up()
+            .append(new DirectivesMetas(classname))
             .attr("ms", System.currentTimeMillis())
             .add("objects");
         final DirectivesClassProperties props = new DirectivesClassProperties(

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -32,14 +32,24 @@ import org.xembly.Directives;
  * Directives for meta information of a class.
  * @since 0.1
  */
-public class DirectivesMetas implements Iterable<Directive> {
+public final class DirectivesMetas implements Iterable<Directive> {
 
+    /**
+     * Class name.
+     */
     private final ClassName name;
 
+    /**
+     * Constructor.
+     */
     DirectivesMetas() {
         this(new ClassName());
     }
 
+    /**
+     * Constructor.
+     * @param classname Class name.
+     */
     DirectivesMetas(final ClassName classname) {
         this.name = classname;
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.Iterator;
+import org.eolang.jeo.representation.ClassName;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+/**
+ * Directives for meta information of a class.
+ * @since 0.1
+ */
+public class DirectivesMetas implements Iterable<Directive> {
+
+    private final ClassName name;
+
+    public DirectivesMetas(final ClassName classname) {
+        this.name = classname;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        final Directives directives = new Directives();
+        directives.add("metas")
+            .add("meta")
+            .add("head").set("package").up()
+            .add("tail").set(this.name.pckg()).up()
+            .add("part").set(this.name.pckg()).up()
+            .up()
+            .up();
+        return directives.iterator();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -36,20 +36,37 @@ public class DirectivesMetas implements Iterable<Directive> {
 
     private final ClassName name;
 
-    public DirectivesMetas(final ClassName classname) {
+    DirectivesMetas() {
+        this(new ClassName());
+    }
+
+    DirectivesMetas(final ClassName classname) {
         this.name = classname;
     }
 
     @Override
     public Iterator<Directive> iterator() {
-        final Directives directives = new Directives();
-        directives.add("metas")
+        final String opcode = "org.eolang.jeo.opcode";
+        final String label = "org.eolang.jeo.label";
+        final String alias = "alias";
+        return new Directives()
+            .add("metas")
             .add("meta")
             .add("head").set("package").up()
             .add("tail").set(this.name.pckg()).up()
             .add("part").set(this.name.pckg()).up()
             .up()
-            .up();
-        return directives.iterator();
+            .add("meta")
+            .add("head").set(alias).up()
+            .add("tail").set(opcode).up()
+            .add("part").set(opcode).up()
+            .up()
+            .add("meta")
+            .add("head").set(alias).up()
+            .add("tail").set(label).up()
+            .add("part").set(label).up()
+            .up()
+            .up()
+            .iterator();
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.eolang.jeo.representation.ClassName;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.Transformers;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link DirectivesMetas}.
+ * @since 0.1
+ */
+class DirectivesMetasTest {
+
+    @Test
+    void createsMetasWithPackage() {
+        MatcherAssert.assertThat(
+            "Can't create corresponding xembly directives for metas with package, head and tail for class package",
+            new Xembler(
+                new DirectivesMetas(new ClassName("path/to/SomeClass")),
+                new Transformers.Node()
+            ).xmlQuietly(),
+            Matchers.allOf(
+                XhtmlMatchers.hasXPath("/metas/meta/head[text()='package']"),
+                XhtmlMatchers.hasXPath("/metas/meta/tail[text()='path.to']"),
+                XhtmlMatchers.hasXPath("/metas/meta/part[text()='path.to']")
+            )
+        );
+    }
+
+
+    @Test
+    void addsInitialAliasesForOpcodes() {
+        MatcherAssert.assertThat(
+            "Can't create corresponding xembly directives for opcode alias",
+            new Xembler(
+                new DirectivesMetas(),
+                new Transformers.Node()
+            ).xmlQuietly(),
+            Matchers.allOf(
+                XhtmlMatchers.hasXPath("/metas/meta/head[text()='alias']"),
+                XhtmlMatchers.hasXPath("/metas/meta/tail[text()='org.eolang.jeo.opcode']"),
+                XhtmlMatchers.hasXPath("/metas/meta/part[text()='org.eolang.jeo.opcode']")
+            )
+        );
+    }
+
+    @Test
+    void addsInitalAliasesForLabels() {
+        MatcherAssert.assertThat(
+            "Can't create corresponding xembly directives for label alias",
+            new Xembler(
+                new DirectivesMetas(),
+                new Transformers.Node()
+            ).xmlQuietly(),
+            Matchers.allOf(
+                XhtmlMatchers.hasXPath("/metas/meta/tail[text()='org.eolang.jeo.label']"),
+                XhtmlMatchers.hasXPath("/metas/meta/part[text()='org.eolang.jeo.label']")
+            )
+        );
+    }
+
+
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
@@ -35,7 +35,7 @@ import org.xembly.Xembler;
  * Test case for {@link DirectivesMetas}.
  * @since 0.1
  */
-class DirectivesMetasTest {
+final class DirectivesMetasTest {
 
     @Test
     void createsMetasWithPackage() {
@@ -52,7 +52,6 @@ class DirectivesMetasTest {
             )
         );
     }
-
 
     @Test
     void addsInitialAliasesForOpcodes() {
@@ -84,6 +83,4 @@ class DirectivesMetasTest {
             )
         );
     }
-
-
 }


### PR DESCRIPTION
Add `+alias` for `opcode` and `label` eo objects.

Closes: #274.
____
History:
- feat(#274): add DirectivesMetas class
- feat(#274): add alias for opcode and label
- feat(#274): fix all qulice suggestions
