### PR TITLE
feat(#305): Enable Test That Transforms Random Java Program

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,11 @@ SOFTWARE.
       <version>0.0.2</version>
     </dependency>
     <dependency>
+      <groupId>com.yegor256</groupId>
+      <artifactId>jhome</artifactId>
+      <version>0.0.4</version>
+    </dependency>
+    <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-matchers</artifactId>
       <!-- version from the parent pom -->

--- a/src/test/java/it/JavaSourceCompilationIT.java
+++ b/src/test/java/it/JavaSourceCompilationIT.java
@@ -46,6 +46,8 @@ import org.junit.jupiter.api.io.TempDir;
  * - Transform bytecode into XMIR
  * - Transform XMIR back into bytecode
  * - Compare the original bytecode with the transformed one.
+ * In this class we compare bytecode as strings because the order of values in
+ * the bytecode constant pool might differ, however the bytecode is still the same.
  * @since 0.1
  * @todo #218:90min Add debug information to bytecode.
  *  Currently we do not add any debug information to the bytecode.
@@ -65,8 +67,8 @@ class JavaSourceCompilationIT {
             "Bytecode is not equal to the original one, check that transformation is correct and does not change the bytecode",
             new EoRepresentation(
                 new BytecodeRepresentation(expected).toEO()
-            ).toBytecode(),
-            Matchers.equalTo(expected)
+            ).toBytecode().toString(),
+            Matchers.equalTo(expected.toString())
         );
     }
 

--- a/src/test/java/it/JavaSourceCompilationIT.java
+++ b/src/test/java/it/JavaSourceCompilationIT.java
@@ -34,8 +34,8 @@ import org.eolang.jeo.representation.EoRepresentation;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -58,7 +58,7 @@ import org.junit.jupiter.api.io.TempDir;
 class JavaSourceCompilationIT {
 
     @Test
-    @Disabled
+    @EnabledIf(value = "hasJavaCompiler", disabledReason = "Java compiler is not available")
     void transformsRandomJavaSourceCodeIntoEoAndBack(@TempDir final Path temp) throws IOException {
         final Bytecode expected = JavaSourceCompilationIT.compile(temp, new RandomJavaClass());
         MatcherAssert.assertThat(
@@ -86,5 +86,13 @@ class JavaSourceCompilationIT {
         return new Bytecode(
             Files.readAllBytes(where.resolve(String.format("%s.class", clazz.name())))
         );
+    }
+
+    /**
+     * Check if java compiler is available.
+     * @return True if java compiler is available.
+     */
+    private static boolean hasJavaCompiler() {
+        return ToolProvider.getSystemJavaCompiler() != null;
     }
 }

--- a/src/test/java/it/JavaSourceCompilationIT.java
+++ b/src/test/java/it/JavaSourceCompilationIT.java
@@ -87,6 +87,8 @@ class JavaSourceCompilationIT {
             System.out,
             System.err,
             "-g:none",
+            "-source", "11",
+            "-target", "11",
             src.toString()
         );
         return new Bytecode(

--- a/src/test/java/it/JavaSourceCompilationIT.java
+++ b/src/test/java/it/JavaSourceCompilationIT.java
@@ -47,13 +47,13 @@ import org.junit.jupiter.api.io.TempDir;
  * - Transform XMIR back into bytecode
  * - Compare the original bytecode with the transformed one.
  * @since 0.1
- * @todo #218:90min Enable java compilation test.
- *  Currently, the test is disabled because it fails. The reason is that:
- *  1. We loose some additional information from original code during transformation and bytecode is
- *  not equal to the original one. It's not critical for runtime, but we need to fix it.
- *  2. Some machines might now have java compiler installed.
- *  We need to fix both of these issues and enable the test.
- *  The test is {@link #transformsRandomJavaSourceCodeIntoEoAndBack}.
+ * @todo #218:90min Add debug information to bytecode.
+ *  Currently we do not add any debug information to the bytecode.
+ *  We added -g:none flag to the compiler in order to avoid adding
+ *  any debug information.
+ *  See {@link #transformsRandomJavaSourceCodeIntoEoAndBack(java.nio.file.Path)} for more info.
+ *  We have to add debug information to the bytecode.
+ *  When it is done, we have to remove -g:none flag from the test.
  */
 class JavaSourceCompilationIT {
 
@@ -82,7 +82,13 @@ class JavaSourceCompilationIT {
     ) throws IOException {
         final Path src = where.resolve(String.format("%s.java", clazz.name()));
         Files.write(src, clazz.src().getBytes(StandardCharsets.UTF_8));
-        ToolProvider.getSystemJavaCompiler().run(System.in, System.out, System.err, src.toString());
+        ToolProvider.getSystemJavaCompiler().run(
+            System.in,
+            System.out,
+            System.err,
+            "-g:none",
+            src.toString()
+        );
         return new Bytecode(
             Files.readAllBytes(where.resolve(String.format("%s.class", clazz.name())))
         );

--- a/src/test/java/it/JavaSourceCompilationIT.java
+++ b/src/test/java/it/JavaSourceCompilationIT.java
@@ -100,8 +100,10 @@ class JavaSourceCompilationIT {
 
     /**
      * Check if java compiler is available.
+     * Don't care about PMD warning: this method is used in @EnabledIf annotation.
      * @return True if java compiler is available.
      */
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static boolean hasJavaCompiler() {
         return ToolProvider.getSystemJavaCompiler() != null;
     }


### PR DESCRIPTION
I enabled the integration test that:
1. Generates random java program
2. Compiles it into bytecode
3. Converts bytecode into EO
4. Converts EO back to bytecode.
5. Compares the bytecode (2) with received bytecode (4).

In order to do so I excluded debug information from bytecode and specified source and target java versions for `javac`.

Closes: #305.
____
- feat(#305): check if javac installed
- feat(#305): ignore debug information
- feat(#305): use source and target params for javac
- feat(#305): compare bytecode as strings
- feat(#305): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enabling a java compilation test in the `JavaSourceCompilationIT` class. 

### Detailed summary
- Added a new dependency in the `pom.xml` file.
- Enabled the `transformsRandomJavaSourceCodeIntoEoAndBack` test in the `JavaSourceCompilationIT` class.
- Added a check for the availability of the Java compiler in the test.
- Added debug information to the bytecode in the test.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->