### PR TITLE
feat(#298): Add Counter For Opcode Names

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/OpcodeName.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/OpcodeName.java
@@ -77,6 +77,14 @@ final class OpcodeName {
     }
 
     /**
+     * Get simplified opcode name without counter.
+     * @return Simplified opcode name.
+     */
+    String simplified() {
+        return OpcodeName.NAMES.getOrDefault(this.opcode, "UNKNOWN");
+    }
+
+    /**
      * Get string representation of a bytecode.
      * @return String representation of a bytecode.
      */

--- a/src/main/java/org/eolang/jeo/representation/directives/OpcodeName.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/OpcodeName.java
@@ -26,6 +26,7 @@ package org.eolang.jeo.representation.directives;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.objectweb.asm.Opcodes;
 
 /**
@@ -42,16 +43,37 @@ final class OpcodeName {
     private static final Map<Integer, String> NAMES = OpcodeName.init();
 
     /**
+     * Default counter.
+     */
+    private static final AtomicInteger DEFAULT = new AtomicInteger(0);
+
+
+    /**
      * Bytecode operation code.
      */
     private final int opcode;
+
+    /**
+     * Opcode counter.
+     */
+    private final AtomicInteger counter;
 
     /**
      * Constructor.
      * @param opcode Bytecode operation code.
      */
     OpcodeName(final int opcode) {
+        this(opcode, OpcodeName.DEFAULT);
+    }
+
+    /**
+     * Constructor.
+     * @param opcode Bytecode operation code.
+     * @param counter Opcode counter.
+     */
+    OpcodeName(final int opcode, final AtomicInteger counter) {
         this.opcode = opcode;
+        this.counter = counter;
     }
 
     /**
@@ -59,7 +81,8 @@ final class OpcodeName {
      * @return String representation of a bytecode.
      */
     String asString() {
-        return OpcodeName.NAMES.getOrDefault(this.opcode, "UNKNOWN");
+        final String opc = OpcodeName.NAMES.getOrDefault(this.opcode, "UNKNOWN");
+        return String.format("%s-%X", opc, this.counter.incrementAndGet());
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/directives/OpcodeName.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/OpcodeName.java
@@ -47,7 +47,6 @@ final class OpcodeName {
      */
     private static final AtomicInteger DEFAULT = new AtomicInteger(0);
 
-
     /**
      * Bytecode operation code.
      */

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -254,7 +254,12 @@ public final class XmlInstruction implements XmlBytecodeEntry {
     private static boolean areAttributesEqual(final Node first, final Node second) {
         final boolean result;
         if (first != null && second != null && first.getNodeName().equals(second.getNodeName())) {
-            result = first.getNodeValue().equals(second.getNodeValue());
+            if (first.getNodeName().equals("name")) {
+                result = first.getNodeValue().split("-")[0]
+                    .equals(second.getNodeValue().split("-")[0]);
+            } else {
+                result = first.getNodeValue().equals(second.getNodeValue());
+            }
         } else {
             result = false;
         }

--- a/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
@@ -263,9 +263,9 @@ public final class HasMethod extends TypeSafeMatcher<String> {
          */
         Stream<String> checks(final String root) {
             final String instruction = String.format(
-                "%s/o[@base='seq']/o[@base='opcode' and @name='%s']",
+                "%s/o[@base='seq']/o[@base='opcode' and contains(@name,'%s')]",
                 root,
-                new OpcodeName(this.opcode).asString()
+                new OpcodeName(this.opcode).simplified()
             );
             return Stream.concat(
                 Stream.of(

--- a/src/test/java/org/eolang/jeo/representation/directives/OpcodeNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/OpcodeNameTest.java
@@ -43,7 +43,6 @@ class OpcodeNameTest {
      */
     private static final AtomicInteger COUNTER = new AtomicInteger(0);
 
-
     @ParameterizedTest(name = "{0} -> {1}")
     @MethodSource("opcodes")
     void checksOpcodeNames(final int actual, final String expected) {

--- a/src/test/java/org/eolang/jeo/representation/directives/OpcodeNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/OpcodeNameTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.directives;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -37,12 +38,18 @@ import org.objectweb.asm.Opcodes;
  */
 class OpcodeNameTest {
 
+    /**
+     * Opcode counter.
+     */
+    private static final AtomicInteger COUNTER = new AtomicInteger(0);
+
+
     @ParameterizedTest(name = "{0} -> {1}")
     @MethodSource("opcodes")
     void checksOpcodeNames(final int actual, final String expected) {
         MatcherAssert.assertThat(
             "Opcode name is not as expected",
-            new OpcodeName(actual).asString(),
+            new OpcodeName(actual, OpcodeNameTest.COUNTER).asString(),
             Matchers.equalTo(expected)
         );
     }
@@ -56,12 +63,17 @@ class OpcodeNameTest {
     @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static Stream<Arguments> opcodes() {
         return Stream.of(
-            Arguments.of(Opcodes.INVOKESPECIAL, "INVOKESPECIAL"),
-            Arguments.of(Opcodes.INVOKEVIRTUAL, "INVOKEVIRTUAL"),
-            Arguments.of(Opcodes.INVOKESTATIC, "INVOKESTATIC"),
-            Arguments.of(Opcodes.INVOKEINTERFACE, "INVOKEINTERFACE"),
-            Arguments.of(Opcodes.INVOKEDYNAMIC, "INVOKEDYNAMIC"),
-            Arguments.of(Opcodes.DUP, "DUP")
+            Arguments.of(Opcodes.INVOKESPECIAL, "INVOKESPECIAL-1"),
+            Arguments.of(Opcodes.INVOKEVIRTUAL, "INVOKEVIRTUAL-2"),
+            Arguments.of(Opcodes.INVOKESTATIC, "INVOKESTATIC-3"),
+            Arguments.of(Opcodes.INVOKEINTERFACE, "INVOKEINTERFACE-4"),
+            Arguments.of(Opcodes.INVOKEDYNAMIC, "INVOKEDYNAMIC-5"),
+            Arguments.of(Opcodes.DUP, "DUP-6"),
+            Arguments.of(Opcodes.LDC, "LDC-7"),
+            Arguments.of(Opcodes.ALOAD, "ALOAD-8"),
+            Arguments.of(Opcodes.ASTORE, "ASTORE-9"),
+            Arguments.of(Opcodes.ILOAD, "ILOAD-A"),
+            Arguments.of(Opcodes.ISTORE, "ISTORE-B")
         );
     }
 }


### PR DESCRIPTION
Add opcode counter for each instruction, in order to uniquely identify each instruction in a method.
In other words, was:
```java
LDC
ALOAD
```
become:
```
LDC-0
ALOAD-1
```

The only problem I've faced during the implementation is EO representation of opcode numbers. Since I use `XMIR` object from `eo-parser`, I can not change logic in order to print opcode numbers in hex format.
(Well, I can, but it doesn't worth it, I belive.) 

Closes: #298.
____
History:
- feat(#298): add counter for opcode names
- feat(#298): compare opcode names accuratly
- feat(#298): fix all unit tests
- feat(#298): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on improving the opcode name representation in the code.

### Detailed summary:
- Modified the `HasMethod` class to use `contains` instead of exact match for opcode name.
- Updated the `XmlInstruction` class to handle a specific case for opcode name comparison.
- Added a new constructor to the `OpcodeName` class to accept an opcode counter.
- Updated the `OpcodeName` class to provide a simplified opcode name without the counter.
- Added a new test case in the `OpcodeNameTest` class to test the opcode name with counter.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->