### PR TITLE
feat(#196): Add Unit Test For XmlNode

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
@@ -48,13 +48,6 @@ public interface XmlBytecodeEntry {
     boolean hasOpcode(int opcode);
 
     /**
-     * Replace values of instruction arguments.
-     * @param old Old value.
-     * @param replacement Which value to set instead.
-     */
-    void replaceArguementsValues(String old, String replacement);
-
-    /**
      * Xml node.
      * @return Xml node.
      */

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -24,14 +24,12 @@
 package org.eolang.jeo.representation.xmir;
 
 import com.jcabi.xml.XMLDocument;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.directives.DirectivesClass;
 import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 import org.xembly.Transformers;
 import org.xembly.Xembler;
 
@@ -135,7 +133,7 @@ public final class XmlClass {
      */
     List<XmlMethod> methods() {
         return this.objects()
-            .filter(o -> o.getAttributes().getNamedItem("base") == null)
+            .filter(o -> o.attribute("base").isEmpty())
             .map(XmlMethod::new)
             .collect(Collectors.toList());
     }
@@ -146,8 +144,8 @@ public final class XmlClass {
      */
     List<XmlField> fields() {
         return this.objects()
-            .filter(o -> o.getAttributes().getNamedItem("base") != null)
-            .filter(o -> "field".equals(o.getAttributes().getNamedItem("base").getNodeValue()))
+            .filter(o -> o.attribute("base").isPresent())
+            .filter(o -> "field".equals(o.attribute("base").get()))
             .map(XmlField::new)
             .collect(Collectors.toList());
     }
@@ -164,7 +162,7 @@ public final class XmlClass {
      * Objects.
      * @return Stream of class objects.
      */
-    private Stream<Node> objects() {
-        return new XmlNode(this.node).children().map(XmlNode::node);
+    private Stream<XmlNode> objects() {
+        return new XmlNode(this.node).children();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -165,14 +165,6 @@ public final class XmlClass {
      * @return Stream of class objects.
      */
     private Stream<Node> objects() {
-        final NodeList children = this.node.getChildNodes();
-        final List<Node> res = new ArrayList<>(children.getLength());
-        for (int index = 0; index < children.getLength(); ++index) {
-            final Node child = children.item(index);
-            if (child.getNodeName().equals("o")) {
-                res.add(child);
-            }
-        }
-        return res.stream();
+        return new XmlNode(this.node).children().map(XmlNode::node);
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -43,6 +43,14 @@ public class XmlField {
      * Constructor.
      * @param node Field node.
      */
+    XmlField(final XmlNode node) {
+        this(node.node());
+    }
+
+    /**
+     * Constructor.
+     * @param node Field node.
+     */
     XmlField(final Node node) {
         this.node = node;
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.IntStream;
-import org.eolang.jeo.representation.HexData;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.eolang.jeo.representation.directives.DirectivesInstruction;
 import org.w3c.dom.NamedNodeMap;
@@ -98,19 +97,6 @@ public final class XmlInstruction implements XmlBytecodeEntry {
     @Override
     public boolean hasOpcode(final int opcode) {
         return this.code() == opcode;
-    }
-
-    @Override
-    public void replaceArguementsValues(final String old, final String replacement) {
-        final String oldname = new HexData(old).value();
-        new XmlNode(this.node).children().forEach(
-            child -> {
-                final String content = child.text();
-                if (oldname.equals(content)) {
-                    child.withText(new HexData(replacement).value());
-                }
-            }
-        );
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
@@ -63,11 +63,6 @@ public final class XmlLabel implements XmlBytecodeEntry {
     }
 
     @Override
-    public void replaceArguementsValues(final String old, final String replacement) {
-        // Nothing to replace
-    }
-
-    @Override
     public Node node() {
         return this.node.node();
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -103,6 +103,14 @@ public final class XmlMethod {
      * Constructor.
      * @param node Method node.
      */
+    XmlMethod(final XmlNode node) {
+        this(node.node());
+    }
+
+    /**
+     * Constructor.
+     * @param node Method node.
+     */
     XmlMethod(final Node node) {
         this.node = node;
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -51,7 +51,7 @@ final class XmlNode {
      * Constructor.
      * @param xml XML string.
      */
-    XmlNode(String xml) {
+    XmlNode(final String xml) {
         this(new XMLDocument(xml).node().getFirstChild());
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -36,9 +36,6 @@ import org.w3c.dom.NodeList;
  * XML smart element.
  * Utility class that simplifies work with XML.
  * @since 0.1
- * @todo #193:90min Add unit tests for XmlNode.
- *  Currently we don't have unit tests for XmlNode. So, it makes sense to add
- *  them to keep code safe and clear.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 final class XmlNode {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -26,6 +26,7 @@ package org.eolang.jeo.representation.xmir;
 import com.jcabi.xml.XMLDocument;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.w3c.dom.NamedNodeMap;
@@ -79,6 +80,11 @@ final class XmlNode {
             res = false;
         }
         return res;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.node);
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -48,6 +48,14 @@ final class XmlNode {
 
     /**
      * Constructor.
+     * @param xml XML string.
+     */
+    XmlNode(String xml) {
+        this(new XMLDocument(xml).node().getFirstChild());
+    }
+
+    /**
+     * Constructor.
      * @param parent Parent node.
      */
     XmlNode(final Node parent) {
@@ -60,6 +68,22 @@ final class XmlNode {
      */
     public Node node() {
         return this.node;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        final boolean res;
+        if (obj instanceof XmlNode) {
+            res = new XMLDocument(this.node).equals(new XMLDocument(((XmlNode) obj).node));
+        } else {
+            res = false;
+        }
+        return res;
+    }
+
+    @Override
+    public String toString() {
+        return new XMLDocument(this.node).toString();
     }
 
     /**
@@ -147,49 +171,6 @@ final class XmlNode {
      */
     String text() {
         return this.node.getTextContent();
-    }
-
-    /**
-     * Set node text content.
-     * @param text Text content.
-     */
-    void withText(final String text) {
-        this.node.setTextContent(text);
-    }
-
-    /**
-     * Set node attribute.
-     * @param name Attribute name.
-     * @param value Attribute value.
-     */
-    void withAttribute(final String name, final String value) {
-        final NamedNodeMap attributes = this.node.getAttributes();
-        if (null == attributes.getNamedItem(name)) {
-            attributes.setNamedItem(this.node.getOwnerDocument().createAttribute(name));
-        }
-        attributes.getNamedItem(name).setNodeValue(value);
-        this.node.getAttributes().getNamedItem(name).setNodeValue(value);
-    }
-
-    /**
-     * Clean all child nodes.
-     * @return The same node.
-     */
-    XmlNode clean() {
-        while (this.node.hasChildNodes()) {
-            this.node.removeChild(this.node.getFirstChild());
-        }
-        return this;
-    }
-
-    /**
-     * Append child node.
-     * @param child Node to append.
-     * @return The same node.
-     */
-    XmlNode append(final Node child) {
-        this.node.appendChild(this.node.getOwnerDocument().adoptNode(child.cloneNode(true)));
-        return this;
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 class XmlNodeTest {
 
     @Test
-    void retrieveTheFirstChild() {
+    void retrievesTheFirstChild() {
         MatcherAssert.assertThat(
             "Can't retrieve the first child, or the first child is not the expected one",
             new XmlNode("<o><o name='inner'/></o>").firstChild(),

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.xmir;
 
 import java.util.List;
@@ -12,7 +35,6 @@ import org.junit.jupiter.api.Test;
  * @since 0.1
  */
 class XmlNodeTest {
-
 
     @Test
     void retrieveTheFirstChild() {

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
@@ -1,8 +1,8 @@
 package org.eolang.jeo.representation.xmir;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -44,9 +44,15 @@ class XmlNodeTest {
 
     @Test
     void retrievesAttribute() {
+        final Optional<String> attribute = new XmlNode("<o name='some'/>").attribute("name");
         MatcherAssert.assertThat(
-            "Can't retrieve the attribute, or the attribute is not the expected one",
-            new XmlNode("<o name='some'/>").attribute("name"),
+            "Can't retrieve the attribute",
+            attribute.isPresent(),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            "he attribute is not the expected one",
+            attribute.get(),
             Matchers.equalTo("some")
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
@@ -1,9 +1,62 @@
 package org.eolang.jeo.representation.xmir;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
 /**
  * Test case for {@link XmlNode}.
  * @since 0.1
  */
 class XmlNodeTest {
 
+
+    @Test
+    void retrieveTheFirstChild() {
+        MatcherAssert.assertThat(
+            "Can't retrieve the first child, or the first child is not the expected one",
+            new XmlNode("<o><o name='inner'/></o>").firstChild(),
+            Matchers.equalTo(new XmlNode("<o name='inner'/>"))
+        );
+    }
+
+    @Test
+    void retrievesChildren() {
+        final List<XmlNode> children = new XmlNode("<o><o name='inner1'/><o name='inner2'/></o>")
+            .children().collect(Collectors.toList());
+        MatcherAssert.assertThat(
+            "Size of children is not as expected",
+            children,
+            Matchers.hasSize(2)
+        );
+        MatcherAssert.assertThat(
+            "Can't retrieve the children, or the children are not the expected ones",
+            children,
+            Matchers.contains(
+                new XmlNode("<o name='inner1'/>"),
+                new XmlNode("<o name='inner2'/>")
+            )
+        );
+    }
+
+    @Test
+    void retrievesAttribute() {
+        MatcherAssert.assertThat(
+            "Can't retrieve the attribute, or the attribute is not the expected one",
+            new XmlNode("<o name='some'/>").attribute("name"),
+            Matchers.equalTo("some")
+        );
+    }
+
+    @Test
+    void retrievesText() {
+        MatcherAssert.assertThat(
+            "Can't retrieve the text, or the text is not the expected one",
+            new XmlNode("<o>text</o>").text(),
+            Matchers.equalTo("text")
+        );
+    }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
@@ -1,0 +1,9 @@
+package org.eolang.jeo.representation.xmir;
+
+/**
+ * Test case for {@link XmlNode}.
+ * @since 0.1
+ */
+class XmlNodeTest {
+
+}


### PR DESCRIPTION
Add unit test for `XmlNode`. Also I refactored `XmlClass` a bit.

Closes: #196.
____
History:
- feat(#196): remove unused methods
- feat(#196): add more test methods
- feat(#196): try to use XmlNode in XmlClass
- feat(#196): fix all qulice suggestions
- feat(#196): fix all jtcop suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding constructors to several classes and making some changes to the XmlNode class. 

### Detailed summary
- Added constructors to XmlMethod, XmlField, and XmlMethod classes.
- Removed the replaceArguementsValues method from XmlLabel and XmlBytecodeEntry classes.
- Added equals, hashCode, and toString methods to XmlNode class.
- Added tests for XmlNode class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->