### PR TITLE
feat(#177): Hide `node` in `XmlClass`

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -70,19 +70,6 @@ public final class XmlClass {
     }
 
     /**
-     * Internal XML node.
-     * @return Internal XML node.
-     * @todo #161:30min Hide internal node representation in XmlClass.
-     *  This class should not expose internal node representation.
-     *  We have to consider to add methods or classes in order to avoid
-     *  exposing internal node representation.
-     */
-    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
-    public Node node() {
-        return this.node;
-    }
-
-    /**
      * Class name.
      * @return Name.
      */

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -91,7 +91,7 @@ public final class XmlClass {
      * @return Class properties.
      */
     XmlClassProperties properties() {
-        return new XmlClassProperties(this.node.node());
+        return new XmlClassProperties(this.node);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -37,7 +37,6 @@ import org.xembly.Xembler;
  * XML class.
  * @since 0.1
  */
-@SuppressWarnings("PMD.TooManyMethods")
 @ToString
 @EqualsAndHashCode
 public final class XmlClass {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -46,7 +46,6 @@ public final class XmlClass {
      * Class node from entire XML.
      */
     @ToString.Include
-    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     private final XmlNode node;
 
     /**
@@ -54,14 +53,7 @@ public final class XmlClass {
      * @param classname Class name.
      */
     XmlClass(final String classname) {
-        this(
-            new XMLDocument(
-                new Xembler(
-                    new DirectivesClass(classname),
-                    new Transformers.Node()
-                ).xmlQuietly()
-            ).node().getFirstChild()
-        );
+        this(XmlClass.empty(classname));
     }
 
     /**
@@ -69,7 +61,15 @@ public final class XmlClass {
      * @param xml Class node.
      */
     XmlClass(final Node xml) {
-        this.node = new XmlNode(xml);
+        this(new XmlNode(xml));
+    }
+
+    /**
+     * Constructor.
+     * @param node Class node.
+     */
+    private XmlClass(final XmlNode node) {
+        this.node = node;
     }
 
     /**
@@ -85,6 +85,14 @@ public final class XmlClass {
                 )
             )
         );
+    }
+
+    /**
+     * Class properties.
+     * @return Class properties.
+     */
+    XmlClassProperties properties() {
+        return new XmlClassProperties(this.node.node());
     }
 
     /**
@@ -122,11 +130,16 @@ public final class XmlClass {
     }
 
     /**
-     * Class properties.
-     * @return Class properties.
+     * Generate empty class node with given name.
+     * @param classname Class name.
+     * @return Class node.
      */
-    XmlClassProperties properties() {
-        return new XmlClassProperties(this.node.node());
+    private static Node empty(final String classname) {
+        return new XMLDocument(
+            new Xembler(
+                new DirectivesClass(classname),
+                new Transformers.Node()
+            ).xmlQuietly()
+        ).node().getFirstChild();
     }
-
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
@@ -26,7 +26,6 @@ package org.eolang.jeo.representation.xmir;
 import com.jcabi.xml.XMLDocument;
 import java.util.Optional;
 import org.eolang.jeo.representation.bytecode.BytecodeClassProperties;
-import org.w3c.dom.Node;
 
 /**
  * XML representation of a class.
@@ -58,8 +57,8 @@ final class XmlClassProperties {
      * Constructor.
      * @param clazz XMl representation of a class.
      */
-    XmlClassProperties(final Node clazz) {
-        this(new XMLDocument(clazz));
+    XmlClassProperties(final XmlNode clazz) {
+        this(clazz.asDocument());
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -196,6 +196,14 @@ final class XmlNode {
     }
 
     /**
+     * Convert to XML document.
+     * @return XML document.
+     */
+    XMLDocument asDocument() {
+        return new XMLDocument(this.node);
+    }
+
+    /**
      * Generate exception if element not found.
      * @param name Element name.
      * @return Exception.


### PR DESCRIPTION
Hide `XmlClas#node` field inside `XmlClass`. Incapsulation.

Closes: #177.
____
History:
- feat(#177): remove the 'node' method from XmlClass
- feat(#177): simplify XmlClass
- feat(#177): make XmlClass look better
- feat(#177): remove redundant suppressings
- feat(#177): remove Node class usage from XmlClassProperties


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR adds a new method `asDocument()` to the `XmlNode` class and updates the `XmlClassProperties` and `XmlClass` classes to use the new method.

### Detailed summary:
- Added a new method `asDocument()` to the `XmlNode` class.
- Updated the `XmlClassProperties` class to use the `asDocument()` method.
- Updated the `XmlClass` class to use the `asDocument()` method and made other code improvements.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->