### PR TITLE
feat(#295): use more precise xpaths in XmlClassProperties

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -74,10 +74,19 @@ public final class DirectivesClass implements Iterable<Directive> {
 
     /**
      * Constructor.
+     * @param classname Class name.
+     * @param properties Class properties.
+     */
+    public DirectivesClass(final String classname, final DirectivesClassProperties properties) {
+        this(new ClassName(classname), properties);
+    }
+
+    /**
+     * Constructor.
      * @param name Class name
      * @param properties Class properties
      */
-    DirectivesClass(final ClassName name, final DirectivesClassProperties properties) {
+    public DirectivesClass(final ClassName name, final DirectivesClassProperties properties) {
         this(name, properties, new ArrayList<>(0), new ArrayList<>(0));
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
@@ -32,7 +32,7 @@ import org.xembly.Directives;
  *
  * @since 0.1.0
  */
-final class DirectivesClassProperties implements Iterable<Directive> {
+public final class DirectivesClassProperties implements Iterable<Directive> {
 
     /**
      * Access modifiers.
@@ -58,7 +58,15 @@ final class DirectivesClassProperties implements Iterable<Directive> {
      * Constructor.
      */
     DirectivesClassProperties() {
-        this(0, "", "", new String[0]);
+        this(0);
+    }
+
+    /**
+     * Constructor.
+     * @param access Access modifiers.
+     */
+    public DirectivesClassProperties(final int access) {
+        this(access, "", "", new String[0]);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
@@ -66,7 +66,16 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
      * @param access Access modifiers.
      */
     public DirectivesClassProperties(final int access) {
-        this(access, "", "", new String[0]);
+        this(access, "");
+    }
+
+    /**
+     * Constructor.
+     * @param access Access modifiers.
+     * @param signature Class Signature.
+     */
+    public DirectivesClassProperties(final int access, final String signature) {
+        this(access, signature, "", new String[0]);
     }
 
     /**
@@ -77,7 +86,7 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
      * @param interfaces Class interfaces.
      * @checkstyle ParameterNumberCheck (5 lines)
      */
-    DirectivesClassProperties(
+    public DirectivesClassProperties(
         final int access,
         final String signature,
         final String supername,

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.directives.DirectivesClass;
+import org.eolang.jeo.representation.directives.DirectivesClassProperties;
 import org.w3c.dom.Node;
 import org.xembly.Transformers;
 import org.xembly.Xembler;
@@ -53,6 +54,10 @@ public final class XmlClass {
      */
     XmlClass(final String classname) {
         this(XmlClass.empty(classname));
+    }
+
+    XmlClass(final String classname, final int access) {
+        this(XmlClass.withProps(classname, access));
     }
 
     /**
@@ -134,9 +139,19 @@ public final class XmlClass {
      * @return Class node.
      */
     private static Node empty(final String classname) {
+        return XmlClass.withProps(classname, 0);
+    }
+
+    /**
+     * Generate class node with given name and access.
+     * @param classname Class name.
+     * @param access Access.
+     * @return Class node.
+     */
+    private static Node withProps(final String classname, final int access) {
         return new XMLDocument(
             new Xembler(
-                new DirectivesClass(classname),
+                new DirectivesClass(classname, new DirectivesClassProperties(access)),
                 new Transformers.Node()
             ).xmlQuietly()
         ).node().getFirstChild();

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -56,8 +56,21 @@ public final class XmlClass {
         this(XmlClass.empty(classname));
     }
 
-    XmlClass(final String classname, final int access) {
-        this(XmlClass.withProps(classname, access));
+    /**
+     * Constructor.
+     * @param properties Class properties.
+     */
+    public XmlClass(final DirectivesClassProperties properties) {
+        this("HelloWorld", properties);
+    }
+
+    /**
+     * Constructor.
+     * @param classname Class name.
+     * @param properties Class properties.
+     */
+    XmlClass(final String classname, final DirectivesClassProperties properties) {
+        this(XmlClass.withProps(classname, properties));
     }
 
     /**
@@ -139,19 +152,19 @@ public final class XmlClass {
      * @return Class node.
      */
     private static Node empty(final String classname) {
-        return XmlClass.withProps(classname, 0);
+        return XmlClass.withProps(classname, new DirectivesClassProperties(0));
     }
 
     /**
      * Generate class node with given name and access.
      * @param classname Class name.
-     * @param access Access.
+     * @param props Class properties.
      * @return Class node.
      */
-    private static Node withProps(final String classname, final int access) {
+    private static Node withProps(final String classname, final DirectivesClassProperties props) {
         return new XMLDocument(
             new Xembler(
-                new DirectivesClass(classname, new DirectivesClassProperties(access)),
+                new DirectivesClass(classname, props),
                 new Transformers.Node()
             ).xmlQuietly()
         ).node().getFirstChild();

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
@@ -47,14 +47,6 @@ final class XmlClassProperties {
 
     /**
      * Constructor.
-     * @param xml XML representation of a class.
-     */
-    XmlClassProperties(final String xml) {
-        this(new XMLDocument(xml));
-    }
-
-    /**
-     * Constructor.
      * @param clazz XMl representation of a class.
      */
     XmlClassProperties(final XmlNode clazz) {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
@@ -66,7 +66,7 @@ final class XmlClassProperties {
      * @return Access modifiers.
      */
     int access() {
-        return new HexString(this.clazz.xpath("//o[@name='access']/text()").get(0)).decodeAsInt();
+        return new HexString(this.clazz.xpath("./o[@name='access']/text()").get(0)).decodeAsInt();
     }
 
     /**
@@ -86,7 +86,7 @@ final class XmlClassProperties {
      * @return Supername.
      */
     String supername() {
-        return this.clazz.xpath("//o[@name='supername']/text()")
+        return this.clazz.xpath("./o[@name='supername']/text()")
             .stream()
             .map(HexString::new)
             .map(HexString::decode)
@@ -98,7 +98,7 @@ final class XmlClassProperties {
      * @return Interfaces.
      */
     String[] interfaces() {
-        return this.clazz.xpath("//o[@name='interfaces']/o/text()")
+        return this.clazz.xpath("./o[@name='interfaces']/o/text()")
             .stream()
             .map(HexString::new)
             .map(HexString::decode).toArray(String[]::new);

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
@@ -31,12 +31,6 @@ import org.eolang.jeo.representation.bytecode.BytecodeClassProperties;
  * XML representation of a class.
  *
  * @since 0.1.0
- * @todo #202:90min Make Xpaths in XmlClassProperties more precise.
- *  Currently, they are too broad and can lead to incorrect results.
- *  Actually, it already happened with the 'signature' property.
- *  In order to fix this, we need to make Xpaths more precise.
- *  But before doing this, we need to make sure that we have enough
- *  tests for this class.
  */
 final class XmlClassProperties {
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
@@ -70,23 +70,10 @@ final class XmlClassProperties {
     }
 
     /**
-     * Convert to bytecode properties.
-     * @return Bytecode properties.
-     */
-    BytecodeClassProperties toBytecodeProperties() {
-        return new BytecodeClassProperties(
-            this.access(),
-            this.signature().orElse(null),
-            this.supername(),
-            this.interfaces()
-        );
-    }
-
-    /**
      * Retrieve 'signature' of a class.
      * @return Signature.
      */
-    private Optional<String> signature() {
+    Optional<String> signature() {
         return this.clazz.xpath("./o[@name='signature']/text()")
             .stream()
             .map(HexString::new)
@@ -98,7 +85,7 @@ final class XmlClassProperties {
      * Retrieve 'supername' of a class.
      * @return Supername.
      */
-    private String supername() {
+    String supername() {
         return this.clazz.xpath("//o[@name='supername']/text()")
             .stream()
             .map(HexString::new)
@@ -110,11 +97,24 @@ final class XmlClassProperties {
      * Retrieve 'interfaces' of a class.
      * @return Interfaces.
      */
-    private String[] interfaces() {
+    String[] interfaces() {
         return this.clazz.xpath("//o[@name='interfaces']/o/text()")
             .stream()
             .map(HexString::new)
             .map(HexString::decode).toArray(String[]::new);
+    }
+
+    /**
+     * Convert to bytecode properties.
+     * @return Bytecode properties.
+     */
+    BytecodeClassProperties toBytecodeProperties() {
+        return new BytecodeClassProperties(
+            this.access(),
+            this.signature().orElse(null),
+            this.supername(),
+            this.interfaces()
+        );
     }
 }
 

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlClassPropertiesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlClassPropertiesTest.java
@@ -23,6 +23,8 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import org.eolang.jeo.representation.directives.DirectivesClass;
+import org.eolang.jeo.representation.directives.DirectivesClassProperties;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -36,18 +38,8 @@ class XmlClassPropertiesTest {
 
     @Test
     void retrievesAccessModifier() {
-        final String xml =
-            String.join(
-                "\n",
-                "<o abstract='' name='Language'>",
-                "  <o base='int' data='bytes' name='access'>00 00 00 00 00 00 04 21</o>",
-                "  <o base='string' data='bytes' name='supername'>",
-                "6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>",
-                "  <o base='tuple' data='tuple' name='interfaces'/>",
-                "</o>"
-            );
-        final int actual = new XmlClassProperties(xml).access();
         final int expected = Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT | Opcodes.ACC_SUPER;
+        final int actual = new XmlClass("Language", expected).properties().access();
         MatcherAssert.assertThat(
             String.format(
                 "Can't retrieve access modifier correctly, expected %d (public abstract class), got %d",

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlClassPropertiesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlClassPropertiesTest.java
@@ -23,6 +23,8 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import java.util.Arrays;
+import java.util.Optional;
 import org.eolang.jeo.representation.directives.DirectivesClass;
 import org.eolang.jeo.representation.directives.DirectivesClassProperties;
 import org.hamcrest.MatcherAssert;
@@ -39,7 +41,10 @@ class XmlClassPropertiesTest {
     @Test
     void retrievesAccessModifier() {
         final int expected = Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT | Opcodes.ACC_SUPER;
-        final int actual = new XmlClass("Language", expected).properties().access();
+        final int actual = new XmlClass(
+            "Language",
+            new DirectivesClassProperties(expected)
+        ).properties().access();
         MatcherAssert.assertThat(
             String.format(
                 "Can't retrieve access modifier correctly, expected %d (public abstract class), got %d",
@@ -48,6 +53,93 @@ class XmlClassPropertiesTest {
             ),
             actual,
             Matchers.is(expected)
+        );
+    }
+
+    @Test
+    void retrievesSignature() {
+        final String expected = "Ljava/util/List<Ljava/lang/String;>;";
+        final Optional<String> actual = new XmlClass(
+            new DirectivesClassProperties(0, expected)).properties().signature();
+        MatcherAssert.assertThat(
+            String.format("Signature is not present, expected %s", expected),
+            actual.isPresent(),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            String.format(
+                "Can't retrieve signature correctly, expected %s, got %s",
+                expected,
+                actual.get()
+            ),
+            actual.get(),
+            Matchers.is(expected)
+        );
+    }
+
+    @Test
+    void retrievesSupernameIfDefined() {
+        final String expected = "some/custom/Supername";
+        final String supername = new XmlClass(new DirectivesClassProperties(0, "", expected))
+            .properties()
+            .supername();
+        MatcherAssert.assertThat(
+            String.format(
+                "Can't retrieve supername correctly, expected %s, got %s",
+                expected,
+                supername
+            ),
+            supername,
+            Matchers.is(expected)
+        );
+    }
+
+    @Test
+    void retrievesSupernameIfItIsNotDefinedExplicitly() {
+        final String expected = "java/lang/Object";
+        final String supername = new XmlClass("DefaultClass")
+            .properties()
+            .supername();
+        MatcherAssert.assertThat(
+            String.format(
+                "Can't retrieve default supername correctly, expected %s, got %s",
+                expected,
+                supername
+            ),
+            supername,
+            Matchers.is(expected)
+        );
+    }
+
+    @Test
+    void retrievesInterfacesIfTheyAreDefined() {
+        final String[] expected = {"java/util/List", "java/util/Collection"};
+        final String[] interfaces = new XmlClass(new DirectivesClassProperties(0, "", "", expected))
+            .properties()
+            .interfaces();
+        MatcherAssert.assertThat(
+            String.format(
+                "Can't retrieve interfaces correctly, expected %s, got %s",
+                Arrays.toString(expected),
+                Arrays.toString(interfaces)
+            ),
+            interfaces,
+            Matchers.is(expected)
+        );
+    }
+
+    @Test
+    void retrievesInterfacesIfTheyAreNotDefinedExplicitly() {
+        final String[] interfaces = new XmlClass("WithoutIntefaces")
+            .properties()
+            .interfaces();
+        MatcherAssert.assertThat(
+            String.format(
+                "Can't retrieve default interfaces correctly, expected empty array, got %s",
+                Arrays.toString(interfaces)
+            ),
+            interfaces,
+            Matchers.emptyArray()
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlClassPropertiesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlClassPropertiesTest.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation.xmir;
 
 import java.util.Arrays;
 import java.util.Optional;
-import org.eolang.jeo.representation.directives.DirectivesClass;
 import org.eolang.jeo.representation.directives.DirectivesClassProperties;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -60,7 +59,8 @@ class XmlClassPropertiesTest {
     void retrievesSignature() {
         final String expected = "Ljava/util/List<Ljava/lang/String;>;";
         final Optional<String> actual = new XmlClass(
-            new DirectivesClassProperties(0, expected)).properties().signature();
+            new DirectivesClassProperties(0, expected)
+        ).properties().signature();
         MatcherAssert.assertThat(
             String.format("Signature is not present, expected %s", expected),
             actual.isPresent(),


### PR DESCRIPTION
Use more precise xpaths in XmlClassProperties.

Closes: #295.
____
- feat(#295): add useful constructors for directives
- feat(#295): finish with tests for XmlClassProperties
- feat(#295): make all the xpaths absolute
- feat(#295): remove the puzzle for 295 issue
- feat(#295): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on making changes to the DirectivesClass and DirectivesClassProperties classes in order to improve code readability and provide more flexibility. 

### Detailed summary
- Added a new constructor to DirectivesClass that accepts a classname and properties as parameters.
- Changed the access modifier of DirectivesClassProperties from "final" to "public".
- Added new constructors to DirectivesClassProperties that accept access and signature as parameters.
- Updated the XmlClass class to use the new constructors of DirectivesClass and DirectivesClassProperties.
- Updated the XmlClassProperties class to make Xpaths more precise and added new methods to retrieve access, signature, supername, and interfaces.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->