### PR TITLE
feat(#253): Remove Redundant Code From XmlMethod

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -63,7 +63,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
      * @param name Method name
      * @param properties Method properties
      */
-    DirectivesMethod(final String name, final DirectivesMethodProperties properties) {
+    public DirectivesMethod(final String name, final DirectivesMethodProperties properties) {
         this.name = name;
         this.properties = properties;
         this.instructions = new ArrayList<>(0);

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
@@ -37,7 +37,7 @@ import org.xembly.Directives;
  *  We need to move them to a separate package. It will make it possible to hide
  *  some classes and probably remove prefixes like Directives*.
  */
-final class DirectivesMethodProperties implements Iterable<Directive> {
+public final class DirectivesMethodProperties implements Iterable<Directive> {
 
     /**
      * Method access modifiers.
@@ -74,7 +74,7 @@ final class DirectivesMethodProperties implements Iterable<Directive> {
      * @param exceptions Method exceptions.
      * @checkstyle ParameterNumberCheck (5 lines)
      */
-    DirectivesMethodProperties(
+    public DirectivesMethodProperties(
         final int access,
         final String descriptor,
         final String signature,

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import java.util.Optional;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.w3c.dom.Node;
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import java.util.Optional;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.w3c.dom.Node;
 
@@ -39,13 +40,6 @@ public interface XmlBytecodeEntry {
      * @param method Bytecode Method where instruction should be written.
      */
     void writeTo(BytecodeMethod method);
-
-    /**
-     * Check if instruction has opcode.
-     * @param opcode Opcode comparing with.
-     * @return True if instruction has opcode.
-     */
-    boolean hasOpcode(int opcode);
 
     /**
      * Xml node.

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -94,11 +94,6 @@ public final class XmlInstruction implements XmlBytecodeEntry {
         method.instruction(this.code(), this.arguments());
     }
 
-    @Override
-    public boolean hasOpcode(final int opcode) {
-        return this.code() == opcode;
-    }
-
     /**
      * Instruction arguments.
      * @return Arguments.

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
@@ -58,11 +58,6 @@ public final class XmlLabel implements XmlBytecodeEntry {
     }
 
     @Override
-    public boolean hasOpcode(final int opcode) {
-        return false;
-    }
-
-    @Override
     public Node node() {
         return this.node.node();
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -24,19 +24,14 @@
 package org.eolang.jeo.representation.xmir;
 
 import com.jcabi.xml.XMLDocument;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import org.eolang.jeo.representation.HexData;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodProperties;
 import org.eolang.jeo.representation.directives.DirectivesMethod;
-import org.eolang.jeo.representation.directives.DirectivesMethodParams;
 import org.eolang.jeo.representation.directives.DirectivesMethodProperties;
-import org.objectweb.asm.Opcodes;
 import org.w3c.dom.Node;
-import org.xembly.Directives;
 import org.xembly.Transformers;
 import org.xembly.Xembler;
 
@@ -44,7 +39,6 @@ import org.xembly.Xembler;
  * XML method.
  * @since 0.1
  */
-@SuppressWarnings("PMD.TooManyMethods")
 public final class XmlMethod {
 
     /**
@@ -66,14 +60,6 @@ public final class XmlMethod {
         final String descriptor
     ) {
         this(XmlMethod.prestructor(name, access, descriptor));
-    }
-
-    /**
-     * Constructor.
-     * @param xml XML node as String.
-     */
-    XmlMethod(final String... xml) {
-        this(new XMLDocument(String.join("", xml)).node());
     }
 
     /**
@@ -192,72 +178,31 @@ public final class XmlMethod {
             .collect(Collectors.toList());
     }
 
-    /**
-     * Copy method node.
-     * @return Instructions.
-     */
-    public XmlMethod copy() {
-        return new XmlMethod(this.node.cloneNode(true));
-    }
-
     @Override
     public String toString() {
         return new XMLDocument(this.node).toString();
     }
 
-    private static XmlNode prestructor(final String name, final int access, final String descriptor
-    ) {
-        final String xmled = new Xembler(new DirectivesMethod(
-            name,
-            new DirectivesMethodProperties(access, descriptor, "", new String[0])
-        ), new Transformers.Node()).xmlQuietly();
-        return new XmlNode(xmled);
-//        return new XMLDocument(
-//            String.join(
-//                "",
-//                String.format("<o name='%s'>", name),
-//                String.format(
-//                    "<o base='int' data='bytes' name='access'>%s</o>",
-//                    new HexData(access).value()
-//                ),
-//                String.format(
-//                    "<o base='string' data='bytes' name='descriptor'>%s</o>",
-//                    new HexData(descriptor).value()
-//                ),
-//                "<o base='string' data='bytes' name='signature'/>",
-//                "<o base='tuple' data='tuple' name='exceptions'/>",
-//                XmlMethod.params(descriptor),
-//                "<o base='seq' name='@'>",
-//                Arrays.stream(entries)
-//                    .map(e -> new XMLDocument(e.node()).toString())
-//                    .collect(Collectors.joining()),
-//                "</o>",
-//                "</o>"
-//            )
-//        ).node().getFirstChild();
-    }
-
-
     /**
-     * Extracts method params from descriptor.
-     * @param descriptor Descriptor.
-     * @return Method params as XML.
-     * @todo #164:90min Refactor params method in XmlMethod.
-     *  Currently we are using a method that returns method params as XML.
-     *  Thic method is not very readable and it is hard to understand what it does.
-     *  It's better to use Xembler to create XML instead of concatenating strings.
+     * Create Method XmlNode by directives.
+     * @param name Method name.
+     * @param access Method access modifiers.
+     * @param descriptor Method descriptor.
+     * @return Method XmlNode.
      */
-    private static String params(final String descriptor) {
+    private static XmlNode prestructor(
+        final String name,
+        final int access,
+        final String descriptor
+    ) {
         return new XmlNode(
-            new XMLDocument(
-                new Xembler(
-                    new Directives().add("o")
-                        .append(new DirectivesMethodParams(descriptor))
-                ).xmlQuietly()
-            ).node().getLastChild()
-        ).children().map(XmlNode::node)
-            .map(XMLDocument::new)
-            .map(XMLDocument::toString)
-            .collect(Collectors.joining());
+            new Xembler(
+                new DirectivesMethod(
+                    name,
+                    new DirectivesMethodProperties(access, descriptor, "")
+                ),
+                new Transformers.Node()
+            ).xmlQuietly()
+        );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -37,6 +37,7 @@ import org.eolang.jeo.representation.directives.DirectivesMethodProperties;
 import org.objectweb.asm.Opcodes;
 import org.w3c.dom.Node;
 import org.xembly.Directives;
+import org.xembly.Transformers;
 import org.xembly.Xembler;
 
 /**
@@ -57,16 +58,14 @@ public final class XmlMethod {
      * @param name Method name.
      * @param access Access modifiers.
      * @param descriptor Method descriptor.
-     * @param entries Method instructions.
      * @checkstyle ParameterNumberCheck (5 lines)
      */
     public XmlMethod(
         final String name,
         final int access,
-        final String descriptor,
-        final XmlBytecodeEntry... entries
+        final String descriptor
     ) {
-        this(XmlMethod.prestructor(name, access, descriptor, entries));
+        this(XmlMethod.prestructor(name, access, descriptor));
     }
 
     /**
@@ -201,52 +200,18 @@ public final class XmlMethod {
         return new XmlMethod(this.node.cloneNode(true));
     }
 
-    /**
-     * Retrieves the list of all invocations of other object methods.
-     * Usually they are invoke virtual instructions which look like this:
-     * - GET FIELD: foo
-     * - LIST OF ARGUMENTS
-     * - INVOKEVIRTUAL: bar
-     * This list represents the following command:
-     * foo.bar(a, b);
-     * @return List of invocations.
-     */
-    public List<XmlInvokeVirtual> invokeVirtuals() {
-        final List<XmlBytecodeEntry> all = this.instructions();
-        final List<XmlInvokeVirtual> res = new ArrayList<>(0);
-        for (int index = 0; index < all.size(); ++index) {
-            final XmlBytecodeEntry top = all.get(index);
-            if (top.hasOpcode(Opcodes.GETFIELD)) {
-                for (int inner = index + 1; inner < all.size(); ++inner) {
-                    final XmlBytecodeEntry bottom = all.get(inner);
-                    if (bottom.hasOpcode(Opcodes.INVOKEVIRTUAL)) {
-                        res.add(new XmlInvokeVirtual(all.subList(index, inner + 1)));
-                    }
-                }
-            }
-        }
-        return res;
-    }
-
     @Override
     public String toString() {
         return new XMLDocument(this.node).toString();
     }
 
-    private static Node prestructor(final String name, final int access, final String descriptor,
-        final XmlBytecodeEntry[] entries
+    private static XmlNode prestructor(final String name, final int access, final String descriptor
     ) {
-        final DirectivesMethod method = new DirectivesMethod(
+        final String xmled = new Xembler(new DirectivesMethod(
             name,
             new DirectivesMethodProperties(access, descriptor, "", new String[0])
-        );
-
-        for (final XmlBytecodeEntry entry : entries) {
-            method.opcode(entry.);
-        }
-
-        return method;
-
+        ), new Transformers.Node()).xmlQuietly();
+        return new XmlNode(xmled);
 //        return new XMLDocument(
 //            String.join(
 //                "",

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -31,7 +31,9 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.eolang.jeo.representation.HexData;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodProperties;
+import org.eolang.jeo.representation.directives.DirectivesMethod;
 import org.eolang.jeo.representation.directives.DirectivesMethodParams;
+import org.eolang.jeo.representation.directives.DirectivesMethodProperties;
 import org.objectweb.asm.Opcodes;
 import org.w3c.dom.Node;
 import org.xembly.Directives;
@@ -64,31 +66,7 @@ public final class XmlMethod {
         final String descriptor,
         final XmlBytecodeEntry... entries
     ) {
-        this(
-            new XMLDocument(
-                String.join(
-                    "",
-                    String.format("<o name='%s'>", name),
-                    String.format(
-                        "<o base='int' data='bytes' name='access'>%s</o>",
-                        new HexData(access).value()
-                    ),
-                    String.format(
-                        "<o base='string' data='bytes' name='descriptor'>%s</o>",
-                        new HexData(descriptor).value()
-                    ),
-                    "<o base='string' data='bytes' name='signature'/>",
-                    "<o base='tuple' data='tuple' name='exceptions'/>",
-                    XmlMethod.params(descriptor),
-                    "<o base='seq' name='@'>",
-                    Arrays.stream(entries)
-                        .map(e -> new XMLDocument(e.node()).toString())
-                        .collect(Collectors.joining()),
-                    "</o>",
-                    "</o>"
-                )
-            ).node().getFirstChild()
-        );
+        this(XmlMethod.prestructor(name, access, descriptor, entries));
     }
 
     /**
@@ -254,6 +232,46 @@ public final class XmlMethod {
     public String toString() {
         return new XMLDocument(this.node).toString();
     }
+
+    private static Node prestructor(final String name, final int access, final String descriptor,
+        final XmlBytecodeEntry[] entries
+    ) {
+        final DirectivesMethod method = new DirectivesMethod(
+            name,
+            new DirectivesMethodProperties(access, descriptor, "", new String[0])
+        );
+
+        for (final XmlBytecodeEntry entry : entries) {
+            method.opcode(entry.);
+        }
+
+        return method;
+
+//        return new XMLDocument(
+//            String.join(
+//                "",
+//                String.format("<o name='%s'>", name),
+//                String.format(
+//                    "<o base='int' data='bytes' name='access'>%s</o>",
+//                    new HexData(access).value()
+//                ),
+//                String.format(
+//                    "<o base='string' data='bytes' name='descriptor'>%s</o>",
+//                    new HexData(descriptor).value()
+//                ),
+//                "<o base='string' data='bytes' name='signature'/>",
+//                "<o base='tuple' data='tuple' name='exceptions'/>",
+//                XmlMethod.params(descriptor),
+//                "<o base='seq' name='@'>",
+//                Arrays.stream(entries)
+//                    .map(e -> new XMLDocument(e.node()).toString())
+//                    .collect(Collectors.joining()),
+//                "</o>",
+//                "</o>"
+//            )
+//        ).node().getFirstChild();
+    }
+
 
     /**
      * Extracts method params from descriptor.

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import java.util.List;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -34,74 +33,6 @@ import org.objectweb.asm.Opcodes;
  * @since 0.1
  */
 class XmlMethodTest {
-
-    @Test
-    void retrievesSimpleInvokeVirtualCalls() {
-        MatcherAssert.assertThat(
-            "Exactly one invoke virtual call is expected",
-            new XmlMethod(
-                "<o base='seq'>",
-                "<o base='opcode' name='GETFIELD'>",
-                "  <o base='int' data='bytes'>00 00 00 00 00 00 00 B4</o>",
-                "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 42</o>\n",
-                "  <o base='string' data='bytes'>61</o>\n",
-                "  <o base='string' data='bytes'>4C 6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41 3B</o>\n",
-                "</o>\n",
-                "<o base='opcode' name='INVOKEVIRTUAL'>\n",
-                "  <o base='int' data='bytes'>00 00 00 00 00 00 00 B6</o>",
-                "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41</o>\n",
-                "  <o base='string' data='bytes'>66 6F 6F</o>\n",
-                "  <o base='string' data='bytes'>28 29 49</o>\n",
-                "</o></o>"
-            ).invokeVirtuals(),
-            Matchers.hasSize(1)
-        );
-    }
-
-    @Test
-    void retrievesInvokeVirtualCallsWithArguments() {
-        final List<XmlInvokeVirtual> all = new XmlMethod(
-            "<o base='seq'>",
-            "<o base='opcode' name='GETFIELD'>",
-            "  <o base='int' data='bytes'>00 00 00 00 00 00 00 B4</o>",
-            "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 42</o>",
-            "  <o base='string' data='bytes'>61</o>",
-            "  <o base='string' data='bytes'>4C 6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41 3B</o>",
-            "</o>",
-            "<o base='opcode' name='ICONST_1'>",
-            "  <o base='int' data='bytes'>00 00 00 00 00 00 00 04</o>",
-            "</o>",
-            "<o base='opcode' name='INVOKEVIRTUAL'>",
-            "  <o base='int' data='bytes'>00 00 00 00 00 00 00 B6</o>",
-            "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41</o>",
-            "  <o base='string' data='bytes'>66 6F 6F</o>",
-            "  <o base='string' data='bytes'>28 29 49</o>",
-            "</o></o>"
-        ).invokeVirtuals();
-        final XmlInvokeVirtual call = all.get(0);
-        MatcherAssert.assertThat(
-            "Exactly one invoke argument is expected",
-            call.arguments(),
-            Matchers.hasSize(1)
-        );
-    }
-
-    @Test
-    void retrievesEmptyListOfInvokeVirtualCalls() {
-        MatcherAssert.assertThat(
-            "No invoke virtual calls are expected",
-            new XmlMethod(
-                "<o base='seq'>",
-                "<o base='opcode' name='GETFIELD'>",
-                "  <o base='int' data='bytes'>00 00 00 00 00 00 00 B4</o>",
-                "  <o base='string' data='bytes'>6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 42</o>",
-                "  <o base='string' data='bytes'>61</o>",
-                "  <o base='string' data='bytes'>4C 6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 41 3B</o>",
-                "</o></o>"
-            ).invokeVirtuals(),
-            Matchers.empty()
-        );
-    }
 
     @Test
     void createsMethodByValues() {


### PR DESCRIPTION
Remove redundant code from `XmlMethod`.

Closes: #253.
____
History:
- feat(#253): remove redundant tests
- feat(#253): simplify code in XmlMethod
- feat(#253): remove more redundant code
- feat(#253): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring and improving the code in the `XmlMethod` class. 

### Detailed summary
- Removed unused imports.
- Changed the constructor of `DirectivesMethod` to public.
- Changed the class `DirectivesMethodProperties` to public.
- Removed the `hasOpcode` method from `XmlLabel` and `XmlInstruction`.
- Removed the `hasOpcode` method from `XmlBytecodeEntry`.
- Added a public constructor to `DirectivesMethodProperties`.
- Removed the `invokeVirtuals` method from `XmlMethod`.
- Refactored the `params` method in `XmlMethod` to use `Xembler` for creating XML.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->