### PR TITLE
feat(#296): Repair XmlBytecodeTest

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -54,7 +54,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
      * Constructor.
      * @param name Method name
      */
-    DirectivesMethod(final String name) {
+    public DirectivesMethod(final String name) {
         this(name, new DirectivesMethodProperties());
     }
 
@@ -73,9 +73,11 @@ public final class DirectivesMethod implements Iterable<Directive> {
      * Add opcode to the directives.
      * @param opcode Opcode
      * @param operands Operands
+     * @return This object
      */
-    public void opcode(final int opcode, final Object... operands) {
+    public DirectivesMethod opcode(final int opcode, final Object... operands) {
         this.instructions.add(new DirectivesInstruction(opcode, operands));
+        return this;
     }
 
     @Override

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlBytecodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlBytecodeTest.java
@@ -73,7 +73,8 @@ class XmlBytecodeTest {
                 .withClass(
                     name,
                     new DirectivesClass(name).method(
-                        new DirectivesMethod("printElement",
+                        new DirectivesMethod(
+                            "printElement",
                             new DirectivesMethodProperties(
                                 Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
                                 "(Ljava/lang/Object;)V",

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlBytecodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlBytecodeTest.java
@@ -23,9 +23,16 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import org.eolang.jeo.representation.ClassName;
+import org.eolang.jeo.representation.directives.DirectivesClass;
+import org.eolang.jeo.representation.directives.DirectivesMethod;
+import org.eolang.jeo.representation.directives.DirectivesMethodProperties;
+import org.eolang.jeo.representation.directives.DirectivesProgram;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.xembly.Xembler;
 
 /**
  * Test case for {@link XmlBytecode}.
@@ -39,6 +46,7 @@ class XmlBytecodeTest {
 
     @Test
     void convertsGenericsMethodIntoBytecode() {
+        final String xml = createXml();
         MatcherAssert.assertThat(
             "Can't convert generics method into bytecode",
             new XmlBytecode(
@@ -70,5 +78,32 @@ class XmlBytecodeTest {
             ).bytecode(),
             Matchers.notNullValue()
         );
+    }
+
+    private String createXml() {
+        final ClassName name = new ClassName("org.eolang.jeo.takes", "StrangeClass");
+        final DirectivesProgram directives = new DirectivesProgram().withClass(
+            name,
+            new DirectivesClass(name).method(
+                new DirectivesMethod("printElement",
+                    new DirectivesMethodProperties(
+                        Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
+                        "(Ljava/lang/Object;)V",
+                        "<T:Ljava/lang/Object;>(TT;)V"
+                    )
+                )
+                    .opcode(Opcodes.GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;")
+                    .opcode(Opcodes.ALOAD, 0)
+                    .opcode(Opcodes.INVOKEVIRTUAL,
+                        "java/io/PrintStream",
+                        "println",
+                        "(Ljava/lang/Object;)V"
+                    )
+                    .opcode(Opcodes.RETURN)
+            )
+        );
+        final String xml = new Xembler(directives).xmlQuietly();
+        System.out.println(xml);
+        return xml;
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlBytecodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlBytecodeTest.java
@@ -38,9 +38,6 @@ import org.xembly.Xembler;
  * Test case for {@link XmlBytecode}.
  *
  * @since 0.1
- * @todo #202:90min Fix {@link #convertsGenericsMethodIntoBytecode} test.
- *  It passes now, but it's not correct. First of all, it prints error message to the console.
- *  We should fix this error and find a way to create a valid XML for this test more easily.
  */
 class XmlBytecodeTest {
 


### PR DESCRIPTION
Generate correct XML class with generic method for `XmlBytecodeTest`.

Closes: #296.
____
History:
- feat(#296): generate xml program with class that contains generic method
- feat(#296): add javadoc for xml generator method
- feat(#296): remove the puzzle description
- feat(#296): fix all qulice suggestions
