### PR TITLE
feat(#330): remove 'node' method

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
@@ -24,7 +24,6 @@
 package org.eolang.jeo.representation.xmir;
 
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
-import org.w3c.dom.Node;
 
 /**
  * XML representation of bytecode instruction or a label.

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
@@ -39,13 +39,4 @@ public interface XmlBytecodeEntry {
      * @param method Bytecode Method where instruction should be written.
      */
     void writeTo(BytecodeMethod method);
-
-    /**
-     * Xml node.
-     * @return Xml node.
-     * @todo #325:30min Remove 'node' method from XmlBytecodeEntry interface.
-     *  This method isn't used anywhere. So it should be removed.
-     *  Don't forget to remove it from all implementations.
-     */
-    Node node();
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -129,12 +129,6 @@ public final class XmlInstruction implements XmlBytecodeEntry {
         return new XMLDocument(this.node).toString();
     }
 
-    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
-    @Override
-    public Node node() {
-        return this.node;
-    }
-
     /**
      * Extract argument value from XmlNode.
      * @param argument XmlNode with argument value.

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
@@ -24,7 +24,6 @@
 package org.eolang.jeo.representation.xmir;
 
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
-import org.w3c.dom.Node;
 
 /**
  * XML representation of bytecode label.
@@ -55,10 +54,5 @@ public final class XmlLabel implements XmlBytecodeEntry {
     @Override
     public void writeTo(final BytecodeMethod method) {
         method.label(this.labels.label(this.node.child("base", "string").text()));
-    }
-
-    @Override
-    public Node node() {
-        return this.node.node();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
@@ -26,7 +26,6 @@ package org.eolang.jeo.representation.xmir;
 import java.util.Optional;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.eolang.jeo.representation.bytecode.BytecodeTryCatchBlock;
-import org.w3c.dom.Node;
 
 /**
  * XML try-catch entry.
@@ -58,11 +57,6 @@ public final class XmlTryCatchEntry implements XmlBytecodeEntry {
                 this.type().map(HexString::new).map(HexString::decode).orElse(null)
             )
         );
-    }
-
-    @Override
-    public Node node() {
-        return this.xmlnode.node();
     }
 
     /**


### PR DESCRIPTION
Remove `XmlBytecodeEntry.node()` method from interface and all the implementations.

Closes: #330.
____
History:
- feat(#330): remove 'node' method
- feat(#330): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing unused `node()` method from `XmlInstruction`, `XmlLabel`, `XmlTryCatchEntry`, and `XmlBytecodeEntry` classes.

### Detailed summary
- Removed the `node()` method from `XmlInstruction` class.
- Removed the `node()` method from `XmlLabel` class.
- Removed the `node()` method from `XmlTryCatchEntry` class.
- Removed the `node()` method from `XmlBytecodeEntry` interface.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->