### PR TITLE
feat(#279): remove 'name' method

### DIFF
--- a/src/main/java/org/eolang/jeo/Representation.java
+++ b/src/main/java/org/eolang/jeo/Representation.java
@@ -41,16 +41,6 @@ public interface Representation {
     Details details();
 
     /**
-     * Name of the class or an object.
-     * @return Name.
-     * @todo #269:30min Replace `name` method with `details` method.
-     *  Currently we just use `Represenation#name()` method everywhere. We should use
-     *  `Representation#details().name()` method instead.
-     *  When it will be ready, just remove this method.
-     */
-    String name();
-
-    /**
      * Convert to EOlang XML representation (XMIR).
      * @return XML.
      */
@@ -85,11 +75,6 @@ public interface Representation {
         @Override
         public Details details() {
             return new Details(this.name);
-        }
-
-        @Override
-        public String name() {
-            return this.name;
         }
 
         @Override

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementEoFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementEoFootprint.java
@@ -70,8 +70,9 @@ public final class ImprovementEoFootprint implements Improvement {
      * @param representation EO representation as XMIR.
      */
     private void saveEo(final Representation representation) {
+        final String name = representation.details().name();
         final Path path = this.target.resolve("eo")
-            .resolve(String.format("%s.eo", representation.name()));
+            .resolve(String.format("%s.eo", name));
         try {
             Files.createDirectories(path.getParent());
             Files.write(
@@ -82,7 +83,7 @@ public final class ImprovementEoFootprint implements Improvement {
             throw new IllegalStateException(
                 String.format(
                     "Can't save %s representation into %s",
-                    representation.name(),
+                    name,
                     path
                 ),
                 exception

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementLogged.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementLogged.java
@@ -71,6 +71,8 @@ public final class ImprovementLogged implements Improvement {
      * @param representation Representation to log.
      */
     private void log(final Representation representation) {
-        this.logger.accept(String.format("Optimization candidate: %s", representation.name()));
+        this.logger.accept(
+            String.format("Optimization candidate: %s", representation.details().name())
+        );
     }
 }

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementXmirFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementXmirFootprint.java
@@ -72,7 +72,7 @@ public final class ImprovementXmirFootprint implements Improvement {
      * @return New representation with source attached to the saved file.
      */
     private Representation transform(final Representation representation) {
-        final String name = representation.name();
+        final String name = representation.details().name();
         final Path path = this.target.resolve(new XmirDefaultDirectory().toPath())
             .resolve(String.format("%s.xmir", name.replace('/', File.separatorChar)));
         try {

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -117,11 +117,21 @@ public final class BytecodeRepresentation implements Representation {
 
     @Override
     public Details details() {
-        return new Details(this.name(), this.source);
+        return new Details(this.className(), this.source);
     }
 
     @Override
     public String name() {
+        final ClassNameVisitor name = new ClassNameVisitor();
+        new ClassReader(this.input).accept(name, 0);
+        return name.asString();
+    }
+
+    /**
+     * Read class name from bytecode.
+     * @return Class name.
+     */
+    private String className() {
         final ClassNameVisitor name = new ClassNameVisitor();
         new ClassReader(this.input).accept(name, 0);
         return name.asString();

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -120,13 +120,6 @@ public final class BytecodeRepresentation implements Representation {
         return new Details(this.className(), this.source);
     }
 
-    @Override
-    public String name() {
-        final ClassNameVisitor name = new ClassNameVisitor();
-        new ClassReader(this.input).accept(name, 0);
-        return name.asString();
-    }
-
     /**
      * Read class name from bytecode.
      * @return Class name.

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -120,16 +120,6 @@ public final class BytecodeRepresentation implements Representation {
         return new Details(this.className(), this.source);
     }
 
-    /**
-     * Read class name from bytecode.
-     * @return Class name.
-     */
-    private String className() {
-        final ClassNameVisitor name = new ClassNameVisitor();
-        new ClassReader(this.input).accept(name, 0);
-        return name.asString();
-    }
-
     @Override
     public XML toEO() {
         final DirectivesClassVisitor directives = new DirectivesClassVisitor(
@@ -155,5 +145,15 @@ public final class BytecodeRepresentation implements Representation {
     @Override
     public Bytecode toBytecode() {
         return new Bytecode(new UncheckedBytes(new BytesOf(this.input)).asBytes());
+    }
+
+    /**
+     * Read class name from bytecode.
+     * @return Class name.
+     */
+    private String className() {
+        final ClassNameVisitor name = new ClassNameVisitor();
+        new ClassReader(this.input).accept(name, 0);
+        return name.asString();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
@@ -89,15 +89,12 @@ public final class EoRepresentation implements Representation {
 
     @Override
     public Details details() {
-        return new Details(this.name(), this.source);
+        return new Details(this.className(), this.source);
     }
 
     @Override
     public String name() {
-        return new ClassName(
-            this.xml.xpath("/program/metas/meta/tail/text()").stream().findFirst().orElse(""),
-            this.xml.xpath("/program/@name").get(0)
-        ).full();
+        return this.className();
     }
 
     @Override
@@ -109,6 +106,17 @@ public final class EoRepresentation implements Representation {
     public Bytecode toBytecode() {
         new Schema(this.xml).check();
         return new XmlBytecode(this.xml).bytecode();
+    }
+
+    /**
+     * Retrieves class name from XMIR.
+     * @return Class name.
+     */
+    private String className() {
+        return new ClassName(
+            this.xml.xpath("/program/metas/meta/tail/text()").stream().findFirst().orElse(""),
+            this.xml.xpath("/program/@name").get(0)
+        ).full();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/EoRepresentation.java
@@ -93,11 +93,6 @@ public final class EoRepresentation implements Representation {
     }
 
     @Override
-    public String name() {
-        return this.className();
-    }
-
-    @Override
     public XML toEO() {
         return this.xml;
     }

--- a/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
@@ -68,7 +68,7 @@ final class BytecodeRepresentationTest {
     @Test
     void retrievesName() {
         final ResourceOf input = new ResourceOf(BytecodeRepresentationTest.METHOD_BYTE);
-        final String actual = new BytecodeRepresentation(input).name();
+        final String actual = new BytecodeRepresentation(input).details().name();
         final String expected = "org/eolang/jeo/MethodByte";
         MatcherAssert.assertThat(
             String.format(

--- a/src/test/java/org/eolang/jeo/representation/EoRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/EoRepresentationTest.java
@@ -46,7 +46,9 @@ class EoRepresentationTest {
     @Test
     void retrievesName() {
         final String expected = "org/eolang/foo/Math";
-        final String actual = new EoRepresentation(new BytecodeClass(expected).xml()).name();
+        final String actual = new EoRepresentation(
+            new BytecodeClass(expected).xml()
+        ).details().name();
         MatcherAssert.assertThat(
             String.format(
                 "The name of the class is not retrieved correctly, we expected '%s', but got '%s'",


### PR DESCRIPTION
Remove `name()` method from `Representation`. Use `Representation.details().name()` instead.

Closes: #279.
____
History:
- feat(#279): remove all the usages of 'name' method
- feat(#279): remove the method itself
- feat(#279): remove all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on replacing the `name()` method with the `details()` method in the `Representation` class to provide more detailed information.

### Detailed summary:
- Replaced `name()` method with `details()` method in `Representation` class.
- Updated method calls in `ImprovementLogged`, `ImprovementXmirFootprint`, `BytecodeRepresentationTest`, `EoRepresentationTest`, `ImprovementEoFootprint`, `Representation`, `BytecodeRepresentation`, and `EoRepresentation` classes.
- Added `className()` method in `BytecodeRepresentation` and `EoRepresentation` classes to retrieve class name from bytecode and XMIR respectively.
- Updated method calls using `className()` method in `BytecodeRepresentation` and `EoRepresentation` classes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->