### PR TITLE
feat(#299): use tuple for method instructions

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -101,8 +101,11 @@ public final class DirectivesMethod implements Iterable<Directive> {
             .append(this.properties)
             .add("o")
             .attr("base", "seq")
-            .attr("name", "@");
+            .attr("name", "@")
+            .add("o")
+            .attr("base", "tuple");
         this.instructions.forEach(directives::append);
+        directives.up();
         directives.up();
         directives.add("o")
             .attr("base", "tuple")

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -188,6 +188,7 @@ public final class XmlMethod {
         final Predicate<XmlBytecodeEntry>... predicates
     ) {
         return new XmlNode(this.node).child("base", "seq")
+            .child("base", "tuple")
             .children()
             .filter(element -> element.attribute("base").isPresent())
             .map(XmlNode::toCommand)

--- a/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
@@ -292,7 +292,7 @@ public final class HasMethod extends TypeSafeMatcher<String> {
          */
         Stream<String> checks(final String root) {
             final String instruction = String.format(
-                "%s/o[@base='seq']/o[@base='opcode' and contains(@name,'%s')]",
+                "%s/o[@base='seq']/o[@base='tuple']/o[@base='opcode' and contains(@name,'%s')]",
                 root,
                 new OpcodeName(this.opcode).simplified()
             );
@@ -418,7 +418,7 @@ public final class HasMethod extends TypeSafeMatcher<String> {
         static Stream<String> checks(final String root) {
             return Stream.of(
                 String.format(
-                    "%s/o[@base='seq']/o[@base='label']/o[@base='string' and @data='bytes']/@data",
+                    "%s/o[@base='seq']/o[@base='tuple']/o[@base='label']/o[@base='string' and @data='bytes']/@data",
                     root
                 )
             );


### PR DESCRIPTION
Use tuple with opcode instructions as argument for `seq`.

Closes: #299.


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on making changes to the `XmlMethod`, `DirectivesMethod`, and `HasMethod` classes.

### Detailed summary:
- In `XmlMethod`:
  - Added a new child element with the tag name "tuple" and the attribute "base" set to "tuple".
  - Filtered the child elements based on the presence of the attribute "base".
  - Mapped the filtered elements to commands using the `toCommand` method of `XmlNode`.
- In `DirectivesMethod`:
  - Added a new child element with the tag name "tuple" and the attribute "base" set to "tuple".
  - Moved the `directives.up()` call after the `this.instructions.forEach(directives::append)` line.
  - Added a new child element with the tag name "tuple" and the attribute "base" set to "tuple" and "name" set to "trycatchblocks".
- In `HasMethod`:
  - Updated the instruction format in the `checks` method to include the "tuple" element with the attribute "base" set to "tuple".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->