### PR TITLE
feat(#169): remove outdated puzzle

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -39,10 +39,6 @@ import org.xembly.Xembler;
 /**
  * Bytecode instruction from XML.
  * @since 0.1
- * @todo #157:90min Hide internal node representation in XmlInstruction.
- *  This class should not expose internal node representation.
- *  We have to consider to add methods or classes in order to avoid
- *  exposing internal node representation.
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class XmlInstruction implements XmlBytecodeEntry {


### PR DESCRIPTION
Closes: #169.


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to hide the internal node representation in the `XmlInstruction` class.
- The class should not expose the internal node representation.
- Methods or classes may be added to avoid exposing the internal node representation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->