### PR TITLE
feat(#170): Hide Node getter in XmlMethod

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import lombok.ToString;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodProperties;
 import org.eolang.jeo.representation.directives.DirectivesMethod;
 import org.eolang.jeo.representation.directives.DirectivesMethodProperties;
@@ -40,13 +41,18 @@ import org.xembly.Xembler;
  * @since 0.1
  */
 @SuppressWarnings("PMD.TooManyMethods")
+@ToString
 public final class XmlMethod {
 
     /**
      * Method node.
      */
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
+    @ToString.Exclude
     private final Node node;
+
+    @ToString.Include
+    private final XmlNode xmlnode;
 
     /**
      * Constructor.
@@ -79,6 +85,7 @@ public final class XmlMethod {
      */
     XmlMethod(final Node node) {
         this.node = node;
+        this.xmlnode = new XmlNode(node);
     }
 
     /**
@@ -181,11 +188,6 @@ public final class XmlMethod {
             .map(XmlNode::toCommand)
             .filter(instr -> Arrays.stream(predicates).allMatch(predicate -> predicate.test(instr)))
             .collect(Collectors.toList());
-    }
-
-    @Override
-    public String toString() {
-        return new XMLDocument(this.node).toString();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -108,9 +108,10 @@ public final class XmlMethod {
      * @return Access modifiers.
      */
     public int access() {
-        return new HexString(
-            new XMLDocument(this.node).xpath("./o[@name='access']/text()").get(0)
-        ).decodeAsInt();
+        return new HexString(this.xmlnode.child("name", "access").text()).decodeAsInt();
+//        return new HexString(
+//            new XMLDocument(this.node).xpath("./o[@name='access']/text()").get(0)
+//        ).decodeAsInt();
     }
 
     /**
@@ -118,9 +119,10 @@ public final class XmlMethod {
      * @return Descriptor.
      */
     public String descriptor() {
-        return new HexString(
-            new XMLDocument(this.node).xpath("./o[@name='descriptor']/text()").get(0)
-        ).decode();
+        return new HexString(this.xmlnode.child("name", "descriptor").text()).decode();
+//        return new HexString(
+//            new XMLDocument(this.node).xpath("./o[@name='descriptor']/text()").get(0)
+//        ).decode();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -23,17 +23,14 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import com.jcabi.xml.XMLDocument;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.ToString;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodProperties;
 import org.eolang.jeo.representation.directives.DirectivesMethod;
 import org.eolang.jeo.representation.directives.DirectivesMethodProperties;
-import org.w3c.dom.Node;
 import org.xembly.Transformers;
 import org.xembly.Xembler;
 
@@ -48,12 +45,8 @@ public final class XmlMethod {
     /**
      * Method node.
      */
-    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
-    @ToString.Exclude
-    private final Node node;
-
     @ToString.Include
-    private final XmlNode xmlnode;
+    private final XmlNode node;
 
     /**
      * Constructor.
@@ -74,19 +67,10 @@ public final class XmlMethod {
 
     /**
      * Constructor.
-     * @param node Method node.
+     * @param xmlnode Method node.
      */
-    XmlMethod(final XmlNode node) {
-        this(node.node());
-    }
-
-    /**
-     * Constructor.
-     * @param node Method node.
-     */
-    XmlMethod(final Node node) {
-        this.node = node;
-        this.xmlnode = new XmlNode(node);
+    XmlMethod(final XmlNode xmlnode) {
+        this.node = xmlnode;
     }
 
     /**
@@ -95,8 +79,7 @@ public final class XmlMethod {
      */
     public String name() {
         final String result;
-//        final String original = String.valueOf(new XMLDocument(this.node).xpath("./@name").get(0));
-        final String original = this.xmlnode.attribute("name").orElseThrow();
+        final String original = this.node.attribute("name").orElseThrow();
         if ("new".equals(original)) {
             result = "<init>";
         } else {
@@ -110,10 +93,7 @@ public final class XmlMethod {
      * @return Access modifiers.
      */
     public int access() {
-        return new HexString(this.xmlnode.child("name", "access").text()).decodeAsInt();
-//        return new HexString(
-//            new XMLDocument(this.node).xpath("./o[@name='access']/text()").get(0)
-//        ).decodeAsInt();
+        return new HexString(this.node.child("name", "access").text()).decodeAsInt();
     }
 
     /**
@@ -121,10 +101,7 @@ public final class XmlMethod {
      * @return Descriptor.
      */
     public String descriptor() {
-        return new HexString(this.xmlnode.child("name", "descriptor").text()).decode();
-//        return new HexString(
-//            new XMLDocument(this.node).xpath("./o[@name='descriptor']/text()").get(0)
-//        ).decode();
+        return new HexString(this.node.child("name", "descriptor").text()).decode();
     }
 
     /**
@@ -132,19 +109,12 @@ public final class XmlMethod {
      * @return Signature.
      */
     public String signature() {
-        return this.xmlnode.optchild("name", "signature")
+        return this.node.optchild("name", "signature")
             .map(XmlNode::text)
             .filter(s -> !s.isBlank())
             .map(HexString::new)
             .map(HexString::decode)
             .orElse(null);
-//        return new XMLDocument(this.node).xpath("./o[@name='signature']/text()")
-//            .stream()
-//            .filter(s -> !s.isBlank())
-//            .findFirst()
-//            .map(HexString::new)
-//            .map(HexString::decode)
-//            .orElse(null);
     }
 
     /**
@@ -152,7 +122,7 @@ public final class XmlMethod {
      * @return Trycatch entries.
      */
     public List<XmlTryCatchEntry> trycatchEntries() {
-        return this.xmlnode.children()
+        return this.node.children()
             .filter(element -> element.hasAttribute("name", "trycatchblocks"))
             .flatMap(XmlNode::children)
             .map(XmlTryCatchEntry::new)
@@ -178,7 +148,7 @@ public final class XmlMethod {
      * @return True if method is a constructor.
      */
     public boolean isConstructor() {
-        return this.xmlnode.hasAttribute("name", "new");
+        return this.node.hasAttribute("name", "new");
     }
 
     /**
@@ -190,7 +160,7 @@ public final class XmlMethod {
     public final List<XmlBytecodeEntry> instructions(
         final Predicate<XmlBytecodeEntry>... predicates
     ) {
-        return this.xmlnode.child("base", "seq")
+        return this.node.child("base", "seq")
             .child("base", "tuple")
             .children()
             .filter(element -> element.attribute("base").isPresent())
@@ -204,18 +174,12 @@ public final class XmlMethod {
      * @return Exceptions.
      */
     private String[] exceptions() {
-        return this.xmlnode.child("name", "exceptions")
+        return this.node.child("name", "exceptions")
             .children()
             .map(XmlNode::text)
             .map(HexString::new)
             .map(HexString::decode)
             .toArray(String[]::new);
-//        return new XMLDocument(this.node)
-//            .xpath("./o[@name='exceptions']/o/text()")
-//            .stream()
-//            .map(HexString::new)
-//            .map(HexString::decode)
-//            .toArray(String[]::new);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -196,12 +196,18 @@ public final class XmlMethod {
      * @return Exceptions.
      */
     private String[] exceptions() {
-        return new XMLDocument(this.node)
-            .xpath("./o[@name='exceptions']/o/text()")
-            .stream()
+        return this.xmlnode.child("name", "exceptions")
+            .children()
+            .map(XmlNode::text)
             .map(HexString::new)
             .map(HexString::decode)
             .toArray(String[]::new);
+//        return new XMLDocument(this.node)
+//            .xpath("./o[@name='exceptions']/o/text()")
+//            .stream()
+//            .map(HexString::new)
+//            .map(HexString::decode)
+//            .toArray(String[]::new);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -38,7 +38,7 @@ import org.xembly.Xembler;
  * XML method.
  * @since 0.1
  */
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
 @ToString
 public final class XmlMethod {
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -158,19 +158,6 @@ public final class XmlMethod {
     }
 
     /**
-     * XML node.
-     * @return XML node.
-     * @todo #157:90min Hide internal node representation in XmlMethod.
-     *  This class should not expose internal node representation.
-     *  We have to consider to add methods or classes in order to avoid
-     *  exposing internal node representation.
-     */
-    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
-    public Node node() {
-        return this.node;
-    }
-
-    /**
      * Checks if method is a constructor.
      * @return True if method is a constructor.
      */

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -26,6 +26,7 @@ package org.eolang.jeo.representation.xmir;
 import com.jcabi.xml.XMLDocument;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.ToString;
@@ -94,7 +95,8 @@ public final class XmlMethod {
      */
     public String name() {
         final String result;
-        final String original = String.valueOf(new XMLDocument(this.node).xpath("./@name").get(0));
+//        final String original = String.valueOf(new XMLDocument(this.node).xpath("./@name").get(0));
+        final String original = this.xmlnode.attribute("name").orElseThrow();
         if ("new".equals(original)) {
             result = "<init>";
         } else {
@@ -130,13 +132,19 @@ public final class XmlMethod {
      * @return Signature.
      */
     public String signature() {
-        return new XMLDocument(this.node).xpath("./o[@name='signature']/text()")
-            .stream()
+        return this.xmlnode.optchild("name", "signature")
+            .map(XmlNode::text)
             .filter(s -> !s.isBlank())
-            .findFirst()
             .map(HexString::new)
             .map(HexString::decode)
             .orElse(null);
+//        return new XMLDocument(this.node).xpath("./o[@name='signature']/text()")
+//            .stream()
+//            .filter(s -> !s.isBlank())
+//            .findFirst()
+//            .map(HexString::new)
+//            .map(HexString::decode)
+//            .orElse(null);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -142,8 +142,7 @@ public final class XmlMethod {
      * @return Trycatch entries.
      */
     public List<XmlTryCatchEntry> trycatchEntries() {
-        final XmlNode xmlnode = new XmlNode(this.node);
-        return xmlnode.children()
+        return this.xmlnode.children()
             .filter(element -> element.hasAttribute("name", "trycatchblocks"))
             .flatMap(XmlNode::children)
             .map(XmlTryCatchEntry::new)
@@ -169,7 +168,7 @@ public final class XmlMethod {
      * @return True if method is a constructor.
      */
     public boolean isConstructor() {
-        return this.node.getAttributes().getNamedItem("name").getNodeValue().equals("new");
+        return this.xmlnode.hasAttribute("name", "new");
     }
 
     /**
@@ -181,7 +180,7 @@ public final class XmlMethod {
     public final List<XmlBytecodeEntry> instructions(
         final Predicate<XmlBytecodeEntry>... predicates
     ) {
-        return new XmlNode(this.node).child("base", "seq")
+        return this.xmlnode.child("base", "seq")
             .child("base", "tuple")
             .children()
             .filter(element -> element.attribute("base").isPresent())


### PR DESCRIPTION
Remove `XmlMethod.node()` method and `Node` usage from this class at all.

Closes: #170.
____
History:
- feat(#170): remove getter method
- feat(#170): add xmlnode to XmlMethod
- feat(#170): replace 'node' with 'xmlnode' usage in several places
- feat(#170): replace 'node' with 'xmlnode' usage in several places
- feat(#170): replace 'node' with 'xmlnode' usage in several places
- feat(#170): replace 'node' with 'xmlnode' usage in several places
- feat(#170): remove outedaed field
- feat(#170): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `XmlMethod` class in the `org.eolang.jeo.representation.xmir` package. 

### Detailed summary
- Added `@ToString` annotation to the `XmlMethod` class.
- Replaced the `node` field with a `XmlNode` field in the `XmlMethod` class.
- Updated the constructor parameter name from `node` to `xmlnode` in the `XmlMethod` class.
- Refactored the `name()` method in the `XmlMethod` class to use the `attribute()` method of `XmlNode`.
- Refactored the `access()` method in the `XmlMethod` class to use the `child()` and `text()` methods of `XmlNode`.
- Refactored the `descriptor()` method in the `XmlMethod` class to use the `child()` and `text()` methods of `XmlNode`.
- Refactored the `signature()` method in the `XmlMethod` class to use the `optchild()` and `map()` methods of `XmlNode`.
- Refactored the `trycatchEntries()` method in the `XmlMethod` class to use the `children()` and `flatMap()` methods of `XmlNode`.
- Refactored the `isConstructor()` method in the `XmlMethod` class to use the `hasAttribute()` method of `XmlNode`.
- Refactored the `instructions()` method in the `XmlMethod` class to use the `child()` and `filter()` methods of `XmlNode`.
- Removed the `node()` method from the `XmlMethod` class.
- Refactored the `toString()` method in the `XmlMethod` class to use the `toString()` method of `XmlNode`.
- Refactored the `exceptions()` method in the `XmlMethod` class to use the `child()` and `children()` methods of `XmlNode`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->