### PR TITLE
feat(#168): remove node from XmlField

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -63,7 +63,11 @@ public class XmlField {
      * @return Name.
      */
     public String name() {
-        return this.node.getAttributes().getNamedItem("name").getNodeValue();
+        return this.xmlnode.attribute("name").orElseThrow(
+            () -> new IllegalStateException(
+                String.format("Can't find field name in '%s'", this.xmlnode)
+            )
+        );
     }
 
     /**
@@ -104,7 +108,7 @@ public class XmlField {
      * @return Text.
      */
     private Optional<HexString> find(final Attribute attribute) {
-        final String text = new XmlNode(this.node).children()
+        final String text = this.xmlnode.children()
             .map(XmlNode::text)
             .collect(Collectors.toList())
             .get(attribute.ordinal());

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation.xmir;
 
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.w3c.dom.Node;
 
 /**
  * XML field.
@@ -36,26 +35,14 @@ public class XmlField {
     /**
      * Field node.
      */
-    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
-    private final Node node;
-
-    private final XmlNode xmlnode;
+    private final XmlNode node;
 
     /**
      * Constructor.
-     * @param node Field node.
+     * @param xmlnode Field node.
      */
-    XmlField(final XmlNode node) {
-        this(node.node());
-    }
-
-    /**
-     * Constructor.
-     * @param node Field node.
-     */
-    XmlField(final Node node) {
-        this.node = node;
-        this.xmlnode = new XmlNode(node);
+    XmlField(final XmlNode xmlnode) {
+        this.node = xmlnode;
     }
 
     /**
@@ -63,9 +50,9 @@ public class XmlField {
      * @return Name.
      */
     public String name() {
-        return this.xmlnode.attribute("name").orElseThrow(
+        return this.node.attribute("name").orElseThrow(
             () -> new IllegalStateException(
-                String.format("Can't find field name in '%s'", this.xmlnode)
+                String.format("Can't find field name in '%s'", this.node)
             )
         );
     }
@@ -108,7 +95,7 @@ public class XmlField {
      * @return Text.
      */
     private Optional<HexString> find(final Attribute attribute) {
-        final String text = this.xmlnode.children()
+        final String text = this.node.children()
             .map(XmlNode::text)
             .collect(Collectors.toList())
             .get(attribute.ordinal());

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -39,6 +39,8 @@ public class XmlField {
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     private final Node node;
 
+    private final XmlNode xmlnode;
+
     /**
      * Constructor.
      * @param node Field node.
@@ -53,6 +55,7 @@ public class XmlField {
      */
     XmlField(final Node node) {
         this.node = node;
+        this.xmlnode = new XmlNode(node);
     }
 
     /**
@@ -93,19 +96,6 @@ public class XmlField {
      */
     public Object value() {
         return this.find(Attribute.VALUE).map(HexString::decode).orElse(null);
-    }
-
-    /**
-     * XML node.
-     * @return Node node.
-     * @todo #157:90min Hide internal node representation in XmlField.
-     *  This class should not expose internal node representation.
-     *  We have to consider to add methods or classes in order to avoid
-     *  exposing internal node representation.
-     */
-    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
-    public Node node() {
-        return this.node;
     }
 
     /**


### PR DESCRIPTION
Replace `Node` field with `XmlNode` in `XmlField`.

Closes: #168.
____
History:
- feat(#168): add xmlnode
- feat(#168): replace all node usages with xmlnode usages
- feat(#168): remove old node usage


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `XmlField` class by replacing the `Node` dependency with a custom `XmlNode` class. 

### Detailed summary
- Replaced `Node` dependency with `XmlNode` in the `XmlField` class.
- Renamed the constructor parameter from `node` to `xmlnode`.
- Updated the `name()` method to use the `attribute()` method of `XmlNode` to retrieve the field name.
- Updated the `value()` method to use the `find()` method of `XmlNode` to retrieve the field value.
- Removed the `node()` method from `XmlField`.
- Updated the `find()` method to use the `children()` method of `XmlNode` instead of creating a new `XmlNode` instance.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->