### PR TITLE
feat(#276): add j prefix for java names

### DIFF
--- a/src/main/java/org/eolang/jeo/improvement/ImprovementBytecodeFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementBytecodeFootprint.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import org.eolang.jeo.Details;
 import org.eolang.jeo.Improvement;
 import org.eolang.jeo.Representation;
+import org.eolang.jeo.representation.JavaName;
 
 /**
  * Footprint of the representations as bytecode classes.
@@ -68,7 +69,7 @@ public final class ImprovementBytecodeFootprint implements Improvement {
      */
     private void recompile(final Representation representation) {
         final Details details = representation.details();
-        final String name = details.name();
+        final String name = new JavaName(details.name()).decode();
         try {
             final byte[] bytecode = representation.toBytecode().asBytes();
             final String[] subpath = name.split("\\.");

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementEoFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementEoFootprint.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.util.Collection;
 import org.eolang.jeo.Improvement;
 import org.eolang.jeo.Representation;
+import org.eolang.jeo.representation.JavaName;
 import org.eolang.parser.XMIR;
 
 /**
@@ -70,7 +71,7 @@ public final class ImprovementEoFootprint implements Improvement {
      * @param representation EO representation as XMIR.
      */
     private void saveEo(final Representation representation) {
-        final String name = representation.details().name();
+        final String name = new JavaName(representation.details().name()).decode();
         final Path path = this.target.resolve("eo")
             .resolve(String.format("%s.eo", name));
         try {

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementXmirFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementXmirFootprint.java
@@ -36,6 +36,7 @@ import org.eolang.jeo.Improvement;
 import org.eolang.jeo.Representation;
 import org.eolang.jeo.XmirDefaultDirectory;
 import org.eolang.jeo.representation.EoRepresentation;
+import org.eolang.jeo.representation.JavaName;
 
 /**
  * Footprint of the EO's.
@@ -72,7 +73,7 @@ public final class ImprovementXmirFootprint implements Improvement {
      * @return New representation with source attached to the saved file.
      */
     private Representation transform(final Representation representation) {
-        final String name = representation.details().name();
+        final String name = new JavaName(representation.details().name()).decode();
         final Path path = this.target.resolve(new XmirDefaultDirectory().toPath())
             .resolve(String.format("%s.xmir", name.replace('/', File.separatorChar)));
         try {

--- a/src/main/java/org/eolang/jeo/representation/JavaName.java
+++ b/src/main/java/org/eolang/jeo/representation/JavaName.java
@@ -36,7 +36,17 @@ import lombok.ToString;
  * @since 0.1
  */
 @ToString
-public class JavaName {
+public final class JavaName {
+
+    /**
+     * Prefix.
+     */
+    private static final String PREFIX = "j$";
+
+    /**
+     * Blank name error message.
+     */
+    private static final String BLANK = "Name can't be blank";
 
     /**
      * Original name.
@@ -57,7 +67,10 @@ public class JavaName {
      * @return Encoded name.
      */
     public String encode() {
-        return this.origin;
+        if (this.origin.isBlank()) {
+            throw new IllegalArgumentException(JavaName.BLANK);
+        }
+        return String.format("%s%s", JavaName.PREFIX, this.origin);
     }
 
     /**
@@ -65,6 +78,14 @@ public class JavaName {
      * @return Decoded name.
      */
     public String decode() {
-        return this.origin;
+        final String res;
+        if (this.origin.isBlank()) {
+            throw new IllegalArgumentException(JavaName.BLANK);
+        } else if (this.origin.startsWith(JavaName.PREFIX)) {
+            res = this.origin.substring(JavaName.PREFIX.length());
+        } else {
+            res = this.origin;
+        }
+        return res;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/JavaName.java
+++ b/src/main/java/org/eolang/jeo/representation/JavaName.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation;
+
+import lombok.ToString;
+
+/**
+ * Java name.
+ * This class is used to represent any java class or method name and to avoid
+ * naming conflicts with EO reserved words.
+ * You can read more about the problem
+ * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/276">here</a>
+ * In the first implementation of this class it just added a 'j' prefix to any name.
+ *
+ * @since 0.1
+ */
+@ToString
+public class JavaName {
+
+    /**
+     * Original name.
+     * Might be with 'j' prefix or without it, depending on the context.
+     */
+    private final String origin;
+
+    /**
+     * Constructor.
+     * @param origin Original name.
+     */
+    public JavaName(final String origin) {
+        this.origin = origin;
+    }
+
+    /**
+     * Encode name.
+     * @return Encoded name.
+     */
+    public String encode() {
+        return this.origin;
+    }
+
+    /**
+     * Decode name.
+     * @return Decoded name.
+     */
+    public String decode() {
+        return this.origin;
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/JavaName.java
+++ b/src/main/java/org/eolang/jeo/representation/JavaName.java
@@ -79,6 +79,8 @@ public final class JavaName {
             final String[] split = this.origin.split(JavaName.DELIMITER);
             split[split.length - 1] = new JavaName(split[split.length - 1]).encode();
             res = String.join(JavaName.DELIMITER, split);
+        } else if ("<init>".equals(this.origin) || "new".equals(this.origin)) {
+            res = this.origin;
         } else {
             res = String.format("%s%s", JavaName.PREFIX, this.origin);
         }
@@ -99,6 +101,8 @@ public final class JavaName {
             final String[] split = this.origin.split(JavaName.DELIMITER);
             split[split.length - 1] = new JavaName(split[split.length - 1]).decode();
             res = String.join(JavaName.DELIMITER, split);
+        } else if ("<init>".equals(this.origin) || "new".equals(this.origin)) {
+            res = this.origin;
         } else {
             res = this.origin;
         }

--- a/src/main/java/org/eolang/jeo/representation/JavaName.java
+++ b/src/main/java/org/eolang/jeo/representation/JavaName.java
@@ -49,6 +49,11 @@ public final class JavaName {
     private static final String BLANK = "Name can't be blank";
 
     /**
+     * Delimiter.
+     */
+    private static final String DELIMITER = "/";
+
+    /**
      * Original name.
      * Might be with 'j' prefix or without it, depending on the context.
      */
@@ -67,10 +72,17 @@ public final class JavaName {
      * @return Encoded name.
      */
     public String encode() {
+        final String res;
         if (this.origin.isBlank()) {
             throw new IllegalArgumentException(JavaName.BLANK);
+        } else if (this.origin.contains(JavaName.DELIMITER)) {
+            final String[] split = this.origin.split(JavaName.DELIMITER);
+            split[split.length - 1] = new JavaName(split[split.length - 1]).encode();
+            res = String.join(JavaName.DELIMITER, split);
+        } else {
+            res = String.format("%s%s", JavaName.PREFIX, this.origin);
         }
-        return String.format("%s%s", JavaName.PREFIX, this.origin);
+        return res;
     }
 
     /**
@@ -83,6 +95,10 @@ public final class JavaName {
             throw new IllegalArgumentException(JavaName.BLANK);
         } else if (this.origin.startsWith(JavaName.PREFIX)) {
             res = this.origin.substring(JavaName.PREFIX.length());
+        } else if (this.origin.contains(JavaName.DELIMITER)) {
+            final String[] split = this.origin.split(JavaName.DELIMITER);
+            split[split.length - 1] = new JavaName(split[split.length - 1]).decode();
+            res = String.join(JavaName.DELIMITER, split);
         } else {
             res = this.origin;
         }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -206,7 +206,7 @@ public final class BytecodeClass {
         final int... modifiers
     ) {
         final BytecodeMethod method = new BytecodeMethod(
-            BytecodeClass.methodName(mname),
+            mname,
             this.writer,
             this,
             descriptor,
@@ -284,21 +284,5 @@ public final class BytecodeClass {
             )
             .opcode(Opcodes.RETURN)
             .up();
-    }
-
-    /**
-     * Get method name.
-     * Returns "init" for a constructor.
-     * @param raw Raw method name.
-     * @return Method name.
-     */
-    private static String methodName(final String raw) {
-        final String result;
-        if ("new".equals(raw)) {
-            result = "<init>";
-        } else {
-            result = raw;
-        }
-        return result;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
@@ -27,6 +27,7 @@ import com.jcabi.log.Logger;
 import java.util.stream.IntStream;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eolang.jeo.representation.JavaName;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 
@@ -130,7 +131,7 @@ public class BytecodeMethodProperties {
         );
         return writer.visitMethod(
             this.access,
-            this.name,
+            new JavaName(this.name).decode(),
             this.descriptor,
             this.signature,
             this.exceptions

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -26,6 +26,7 @@ package org.eolang.jeo.representation.directives;
 import java.util.Iterator;
 import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.DefaultVersion;
+import org.eolang.jeo.representation.JavaName;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
@@ -91,7 +92,7 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
         final String supername,
         final String[] interfaces
     ) {
-        final ClassName classname = new ClassName(name);
+        final ClassName classname = new ClassName(new JavaName(name).encode());
         this.program.withClass(
             classname,
             new DirectivesClass(
@@ -115,14 +116,15 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
         final String signature,
         final String[] exceptions
     ) {
+        String ename = new JavaName(name).encode();
         final DirectivesMethod method = new DirectivesMethod(
-            name,
+            ename,
             new DirectivesMethodProperties(access, descriptor, signature, exceptions)
         );
         this.program.top().method(method);
         return new DirectivesMethodVisitor(
             method,
-            super.visitMethod(access, name, descriptor, signature, exceptions)
+            super.visitMethod(access, ename, descriptor, signature, exceptions)
         );
     }
 
@@ -134,8 +136,9 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
         final String signature,
         final Object value
     ) {
-        this.program.top().field(new DirectivesField(access, name, descriptor, signature, value));
-        return super.visitField(access, name, descriptor, signature, value);
+        String ename = new JavaName(name).encode();
+        this.program.top().field(new DirectivesField(access, ename, descriptor, signature, value));
+        return super.visitField(access, ename, descriptor, signature, value);
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -116,7 +116,7 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
         final String signature,
         final String[] exceptions
     ) {
-        String ename = new JavaName(name).encode();
+        final String ename = new JavaName(name).encode();
         final DirectivesMethod method = new DirectivesMethod(
             ename,
             new DirectivesMethodProperties(access, descriptor, signature, exceptions)
@@ -136,7 +136,7 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
         final String signature,
         final Object value
     ) {
-        String ename = new JavaName(name).encode();
+        final String ename = new JavaName(name).encode();
         this.program.top().field(new DirectivesField(access, ename, descriptor, signature, value));
         return super.visitField(access, ename, descriptor, signature, value);
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
@@ -26,6 +26,7 @@ package org.eolang.jeo.representation.xmir;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.ClassName;
+import org.eolang.jeo.representation.JavaName;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
@@ -65,12 +66,13 @@ public final class XmlBytecode {
         final XmlProgram program = new XmlProgram(this.xml);
         final XmlClass clazz = program.top();
         final BytecodeClass bytecode = new BytecodeClass(
-            new ClassName(program.pckg(), clazz.name()).full(),
+            new ClassName(program.pckg(), new JavaName(clazz.name()).decode()).full(),
             clazz.properties().toBytecodeProperties()
         );
         for (final XmlField field : clazz.fields()) {
+            String dfname = new JavaName(field.name()).decode();
             bytecode.withField(
-                field.name(),
+                dfname,
                 field.descriptor(),
                 field.signature(),
                 field.value(),

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
@@ -70,9 +70,8 @@ public final class XmlBytecode {
             clazz.properties().toBytecodeProperties()
         );
         for (final XmlField field : clazz.fields()) {
-            String dfname = new JavaName(field.name()).decode();
             bytecode.withField(
-                dfname,
+                new JavaName(field.name()).decode(),
                 field.descriptor(),
                 field.signature(),
                 field.value(),

--- a/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
@@ -49,7 +49,7 @@ final class BytecodeRepresentationTest {
             "The simplest class should contain the object with MethodByte name",
             new BytecodeRepresentation(new ResourceOf(BytecodeRepresentationTest.METHOD_BYTE))
                 .toEO().xpath("/program/@name").get(0),
-            Matchers.equalTo("MethodByte")
+            Matchers.equalTo(new JavaName("MethodByte").encode())
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/EoRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/EoRepresentationTest.java
@@ -45,9 +45,10 @@ class EoRepresentationTest {
 
     @Test
     void retrievesName() {
-        final String expected = "org/eolang/foo/Math";
+        final String name = "org/eolang/foo/Math";
+        final String expected = new JavaName(name).encode();
         final String actual = new EoRepresentation(
-            new BytecodeClass(expected).xml()
+            new BytecodeClass(name).xml()
         ).details().name();
         MatcherAssert.assertThat(
             String.format(
@@ -65,7 +66,7 @@ class EoRepresentationTest {
         MatcherAssert.assertThat(
             "The XML representation of the EO object is not correct",
             new EoRepresentation(new BytecodeClass("org/eolang/foo/Math").xml()).toEO(),
-            XhtmlMatchers.hasXPath("/program[@name='Math']")
+            XhtmlMatchers.hasXPath("/program[@name='j$Math']")
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/JavaNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/JavaNameTest.java
@@ -43,6 +43,7 @@ class JavaNameTest {
         "someLongName, j$someLongName",
         "j$j, j$j$j",
         "jeo/xmir/Fake, jeo/xmir/j$Fake",
+        "<init>, <init>",
     })
     void encodesName(final String origin, final String encoded) {
         MatcherAssert.assertThat(
@@ -60,6 +61,7 @@ class JavaNameTest {
         "j$j$j, j$j",
         "someName, someName",
         "jeo/xmir/j$Fake, jeo/xmir/Fake",
+        "<init>, <init>",
     })
     void decodesName(final String encoded, final String origin) {
         MatcherAssert.assertThat(

--- a/src/test/java/org/eolang/jeo/representation/JavaNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/JavaNameTest.java
@@ -43,7 +43,7 @@ class JavaNameTest {
         "someLongName, j$someLongName",
         "j$j, j$j$j",
         "jeo/xmir/Fake, jeo/xmir/j$Fake",
-        "<init>, <init>",
+        "<init>, <init>"
     })
     void encodesName(final String origin, final String encoded) {
         MatcherAssert.assertThat(
@@ -61,7 +61,7 @@ class JavaNameTest {
         "j$j$j, j$j",
         "someName, someName",
         "jeo/xmir/j$Fake, jeo/xmir/Fake",
-        "<init>, <init>",
+        "<init>, <init>"
     })
     void decodesName(final String encoded, final String origin) {
         MatcherAssert.assertThat(

--- a/src/test/java/org/eolang/jeo/representation/JavaNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/JavaNameTest.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.jeo.representation;
 
-import lombok.ToString;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -58,6 +57,7 @@ class JavaNameTest {
         "j$ClassName, ClassName",
         "j$someLongName, someLongName",
         "j$j$j, j$j",
+        "someName, someName",
     })
     void decodesName(final String encoded, final String origin) {
         MatcherAssert.assertThat(
@@ -70,7 +70,7 @@ class JavaNameTest {
     @Test
     void throwsExceptionWhenEncodingInvalidName() {
         Assertions.assertThrows(
-            IllegalStateException.class,
+            IllegalArgumentException.class,
             () -> new JavaName(" ").encode(),
             "Can't throw exception when encoding invalid name"
         );
@@ -79,7 +79,7 @@ class JavaNameTest {
     @Test
     void throwsExceptionWhenDecodingInvalidName() {
         Assertions.assertThrows(
-            IllegalStateException.class,
+            IllegalArgumentException.class,
             () -> new JavaName(" ").decode(),
             "Can't throw exception when decoding invalid name"
         );

--- a/src/test/java/org/eolang/jeo/representation/JavaNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/JavaNameTest.java
@@ -42,6 +42,7 @@ class JavaNameTest {
         "ClassName, j$ClassName",
         "someLongName, j$someLongName",
         "j$j, j$j$j",
+        "jeo/xmir/Fake, jeo/xmir/j$Fake",
     })
     void encodesName(final String origin, final String encoded) {
         MatcherAssert.assertThat(
@@ -58,6 +59,7 @@ class JavaNameTest {
         "j$someLongName, someLongName",
         "j$j$j, j$j",
         "someName, someName",
+        "jeo/xmir/j$Fake, jeo/xmir/Fake",
     })
     void decodesName(final String encoded, final String origin) {
         MatcherAssert.assertThat(

--- a/src/test/java/org/eolang/jeo/representation/JavaNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/JavaNameTest.java
@@ -1,0 +1,87 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation;
+
+import lombok.ToString;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Test case for {@link JavaName}.
+ * @since 0.1
+ */
+class JavaNameTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "name, j$name",
+        "ClassName, j$ClassName",
+        "someLongName, j$someLongName",
+        "j$j, j$j$j",
+    })
+    void encodesName(final String origin, final String encoded) {
+        MatcherAssert.assertThat(
+            String.format("Can't encode '%s' to '%s'", origin, encoded),
+            new JavaName(origin).encode(),
+            Matchers.equalTo(encoded)
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "j$name, name",
+        "j$ClassName, ClassName",
+        "j$someLongName, someLongName",
+        "j$j$j, j$j",
+    })
+    void decodesName(final String encoded, final String origin) {
+        MatcherAssert.assertThat(
+            String.format("Can't decode '%s' to '%s'", encoded, origin),
+            new JavaName(encoded).decode(),
+            Matchers.equalTo(origin)
+        );
+    }
+
+    @Test
+    void throwsExceptionWhenEncodingInvalidName() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new JavaName(" ").encode(),
+            "Can't throw exception when encoding invalid name"
+        );
+    }
+
+    @Test
+    void throwsExceptionWhenDecodingInvalidName() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new JavaName(" ").decode(),
+            "Can't throw exception when decoding invalid name"
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/HasClass.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasClass.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.eolang.jeo.representation.JavaName;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 
@@ -54,7 +55,7 @@ final class HasClass extends TypeSafeMatcher<String> {
      * @param name Class name.
      */
     HasClass(final String name) {
-        this.name = name;
+        this.name = new JavaName(name).encode();
         this.additional = new ArrayList<>(0);
     }
 

--- a/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.HexData;
+import org.eolang.jeo.representation.JavaName;
 import org.eolang.jeo.representation.xmir.AllLabels;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
@@ -80,7 +81,7 @@ public final class HasMethod extends TypeSafeMatcher<String> {
      * @param method Method name.
      */
     public HasMethod(final String method) {
-        this("", method);
+        this("", new JavaName(method).encode());
     }
 
     /**
@@ -118,7 +119,7 @@ public final class HasMethod extends TypeSafeMatcher<String> {
      * @return New matcher that checks class.
      */
     public HasMethod inside(final String klass) {
-        return new HasMethod(klass, this.name);
+        return new HasMethod(new JavaName(klass).encode(), this.name);
     }
 
     /**


### PR DESCRIPTION
Add `j$` prefix for java name to avoid naming collisions with EO reserved words.

Closes: #276.
____
History:
- feat(#276): add JavaName and corresponding test for it
- feat(#276): finish with raw implementation of JavaName
- feat(#276): try to apply JavaName
- feat(#276): try to fix some tests
- feat(#276): handle constructors
- feat(#276): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on introducing a `JavaName` class to handle encoding and decoding of Java names. 

### Detailed summary
- Added `JavaName` class to handle encoding and decoding of Java names.
- Updated code references to use `JavaName` for encoding and decoding.

> The following files were skipped due to too many changes: `src/main/java/org/eolang/jeo/representation/JavaName.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->