### PR TITLE
feat(#292): Annotations Support. Enable Spring Application Inegration Test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@ SOFTWARE.
                         <limit>
                           <counter>CLASS</counter>
                           <value>MISSEDCOUNT</value>
-                          <maximum>4</maximum>
+                          <maximum>6</maximum>
                         </limit>
                       </limits>
                     </rule>

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -54,25 +54,25 @@ SOFTWARE.
   </dependencies>
   <build>
     <plugins>
-       <plugin>
-         <groupId>org.eolang</groupId>
-         <artifactId>jeo-maven-plugin</artifactId>
-         <version>@project.version@</version>
-         <executions>
-           <execution>
-             <id>bytecode-to-eo</id>
-             <goals>
-               <goal>bytecode-to-eo</goal>
-             </goals>
-           </execution>
-           <execution>
-             <id>eo-to-bytecode</id>
-             <goals>
-               <goal>eo-to-bytecode</goal>
-             </goals>
-           </execution>
-         </executions>
-       </plugin>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>jeo-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>bytecode-to-eo</id>
+            <goals>
+              <goal>bytecode-to-eo</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>eo-to-bytecode</id>
+            <goals>
+              <goal>eo-to-bytecode</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -54,6 +54,25 @@ SOFTWARE.
   </dependencies>
   <build>
     <plugins>
+       <plugin>
+         <groupId>org.eolang</groupId>
+         <artifactId>jeo-maven-plugin</artifactId>
+         <version>@project.version@</version>
+         <executions>
+           <execution>
+             <id>bytecode-to-eo</id>
+             <goals>
+               <goal>bytecode-to-eo</goal>
+             </goals>
+           </execution>
+           <execution>
+             <id>eo-to-bytecode</id>
+             <goals>
+               <goal>eo-to-bytecode</goal>
+             </goals>
+           </execution>
+         </executions>
+       </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>

--- a/src/it/spring/verify.groovy
+++ b/src/it/spring/verify.groovy
@@ -26,40 +26,6 @@ String log = new File(basedir, 'build.log').text;
 assert log.contains("BUILD SUCCESS")
 assert log.contains("Glad to see you, Spring...")
 //Check that we have generated EO object files.
-//assert new File(basedir, 'target/generated-sources/xmir/org/eolang/jeo/spring/Application.xmir').exists()
-//assert new File(basedir, 'target/generated-sources/xmir/org/eolang/jeo/spring/Receptionist.xmir').exists()
-/**
- * @todo #189:30min Enable Integration Test for Spring Framework.
- *  First of all, we have to implement all the features required for correct
- *  transformation. Then, we need to add JEO plugin into pom.xml of that test,
- *  the plugin setup you can find below. After that we need to add some
- *  assertions to this file. For example, we need to check that we have
- *  generated EO object files (see commented checks above).
- *
- * <p>
- * {@code
- * <plugin>
- *   <groupId>org.eolang</groupId>
- *   <artifactId>jeo-maven-plugin</artifactId>
- *   <version>@project.version@</version>
- *   <executions>
- *     <execution>
- *       <id>bytecode-to-eo</id>
- *       <goals>
- *         <goal>bytecode-to-eo</goal>
- *       </goals>
- *     </execution>
- *     <execution>
- *       <id>eo-to-bytecode</id>
- *       <goals>
- *         <goal>eo-to-bytecode</goal>
- *       </goals>
- *     </execution>
- *   </executions>
- * </plugin>
- *
- *}
- * </p>
- */
-
+assert new File(basedir, 'target/generated-sources/xmir/org/eolang/jeo/spring/Application.xmir').exists()
+assert new File(basedir, 'target/generated-sources/xmir/org/eolang/jeo/spring/Receptionist.xmir').exists()
 true

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -130,6 +130,15 @@ public final class BytecodeRepresentation implements Representation {
             final XMLDocument res = new XMLDocument(new Xembler(directives).xml());
             new Schema(res).check();
             return res;
+        } catch (final IllegalStateException exception) {
+            throw new IllegalStateException(
+                String.format(
+                    "Something went wrong during transformation %s into XML by using directives",
+                    this.className(),
+                    directives
+                ),
+                exception
+            );
         } catch (final ImpossibleModificationException exception) {
             throw new IllegalStateException(
                 String.format(

--- a/src/main/java/org/eolang/jeo/representation/HexData.java
+++ b/src/main/java/org/eolang/jeo/representation/HexData.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.StringJoiner;
 import org.objectweb.asm.Label;
+import org.objectweb.asm.Type;
 
 /**
  * Hexadecimal data.
@@ -75,9 +76,15 @@ public final class HexData {
             res = (byte[]) this.data;
         } else if (this.data instanceof Class<?>) {
             res = ((Class<?>) this.data).getName().getBytes(StandardCharsets.UTF_8);
+        } else if (this.data instanceof Type) {
+            res = ((Type) this.data).getClassName().getBytes(StandardCharsets.UTF_8);
         } else {
             throw new IllegalStateException(
-                String.format("Can't convert '%s' into hex string", this.data)
+                String.format(
+                    "Can't convert '%s' into hex string. The type is '%s'",
+                    this.data,
+                    this.data.getClass()
+                )
             );
         }
         return HexData.bytesToHex(res);
@@ -100,6 +107,8 @@ public final class HexData {
         } else if (this.data instanceof Label) {
             res = "label";
         } else if (this.data instanceof Class<?>) {
+            res = "reference";
+        } else if (this.data instanceof Type) {
             res = "reference";
         } else {
             res = "bytes";

--- a/src/main/java/org/eolang/jeo/representation/HexData.java
+++ b/src/main/java/org/eolang/jeo/representation/HexData.java
@@ -75,9 +75,11 @@ public final class HexData {
         } else if (this.data instanceof byte[]) {
             res = (byte[]) this.data;
         } else if (this.data instanceof Class<?>) {
-            res = ((Class<?>) this.data).getName().getBytes(StandardCharsets.UTF_8);
+            res = ((Class<?>) this.data).getName().replace('.', '/')
+                .getBytes(StandardCharsets.UTF_8);
         } else if (this.data instanceof Type) {
-            res = ((Type) this.data).getClassName().getBytes(StandardCharsets.UTF_8);
+            res = ((Type) this.data).getClassName().replace('.', '/')
+                .getBytes(StandardCharsets.UTF_8);
         } else {
             throw new IllegalStateException(
                 String.format(

--- a/src/main/java/org/eolang/jeo/representation/HexData.java
+++ b/src/main/java/org/eolang/jeo/representation/HexData.java
@@ -73,6 +73,8 @@ public final class HexData {
             }
         } else if (this.data instanceof byte[]) {
             res = (byte[]) this.data;
+        } else if (this.data instanceof Class<?>) {
+            res = ((Class<?>) this.data).getName().getBytes(StandardCharsets.UTF_8);
         } else {
             throw new IllegalStateException(
                 String.format("Can't convert '%s' into hex string", this.data)
@@ -97,6 +99,8 @@ public final class HexData {
             res = "bool";
         } else if (this.data instanceof Label) {
             res = "label";
+        } else if (this.data instanceof Class<?>) {
+            res = "reference";
         } else {
             res = "bytes";
         }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -28,6 +28,8 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.eolang.jeo.representation.BytecodeRepresentation;
+import org.eolang.jeo.representation.xmir.XmlAnnotation;
+import org.eolang.jeo.representation.xmir.XmlAnnotations;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
@@ -258,6 +260,21 @@ public final class BytecodeClass {
             descriptor,
             signature,
             value
+        );
+        return this;
+    }
+
+    /**
+     * Add annotations.
+     * @param annotations Annotations.
+     * @return This object.
+     */
+    public BytecodeClass withAnnotations(final XmlAnnotations annotations) {
+        annotations.all().forEach(
+            annotation -> this.writer.visitAnnotation(
+                annotation.descriptor(),
+                annotation.visible()
+            )
         );
         return this;
     }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -32,6 +32,7 @@ import org.eolang.jeo.representation.xmir.XmlAnnotation;
 import org.eolang.jeo.representation.xmir.XmlAnnotations;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.util.CheckClassAdapter;
 
@@ -224,13 +225,14 @@ public final class BytecodeClass {
      * @return This object.
      */
     public BytecodeClass withField(final String fname) {
-        return this.withField(
+        this.withField(
             fname,
             "Ljava/lang/String;",
             null,
             "bar",
             Opcodes.ACC_PUBLIC
         );
+        return this;
     }
 
     /**
@@ -243,7 +245,7 @@ public final class BytecodeClass {
      * @return This object.
      * @checkstyle ParameterNumberCheck (5 lines)
      */
-    public BytecodeClass withField(
+    public FieldVisitor withField(
         final String fname,
         final String descriptor,
         final String signature,
@@ -254,14 +256,13 @@ public final class BytecodeClass {
         for (final int modifier : modifiers) {
             access |= modifier;
         }
-        this.writer.visitField(
+        return this.writer.visitField(
             access,
             fname,
             descriptor,
             signature,
             value
         );
-        return this;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -28,7 +28,6 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.eolang.jeo.representation.BytecodeRepresentation;
-import org.eolang.jeo.representation.xmir.XmlAnnotation;
 import org.eolang.jeo.representation.xmir.XmlAnnotations;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
@@ -1,9 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
+/**
+ * Directives Annotation.
+ * @since 0.1
+ */
 public class DirectivesAnnotation implements Iterable<Directive> {
 
     private final String descriptor;

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
@@ -1,0 +1,28 @@
+package org.eolang.jeo.representation.directives;
+
+import java.util.Iterator;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+public class DirectivesAnnotation implements Iterable<Directive> {
+
+    private final String descriptor;
+
+    private final boolean visible;
+
+    public DirectivesAnnotation(
+        final String descriptor,
+        final boolean visible
+    ) {
+        this.descriptor = descriptor;
+        this.visible = visible;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        return new Directives().add("o")
+            .append(new DirectivesData("descriptor", this.descriptor))
+            .append(new DirectivesData("visible", this.visible))
+            .iterator();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
@@ -50,6 +50,7 @@ public class DirectivesAnnotation implements Iterable<Directive> {
         return new Directives().add("o")
             .append(new DirectivesData("descriptor", this.descriptor))
             .append(new DirectivesData("visible", this.visible))
+            .up()
             .iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
@@ -31,12 +31,23 @@ import org.xembly.Directives;
  * Directives Annotation.
  * @since 0.1
  */
-public class DirectivesAnnotation implements Iterable<Directive> {
+public final class DirectivesAnnotation implements Iterable<Directive> {
 
+    /**
+     * Annotation descriptor.
+     */
     private final String descriptor;
 
+    /**
+     * Annotation visible.
+     */
     private final boolean visible;
 
+    /**
+     * Constructor.
+     * @param descriptor Descriptor.
+     * @param visible Visible.
+     */
     public DirectivesAnnotation(
         final String descriptor,
         final boolean visible

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotations.java
@@ -33,7 +33,7 @@ import org.xembly.Directives;
  * Directives Annotation.
  * @since 0.1
  */
-public class DirectivesAnnotations implements Iterable<Directive> {
+public final class DirectivesAnnotations implements Iterable<Directive> {
 
     /**
      * All the annotations.

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotations.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+/**
+ * Directives Annotation.
+ * @since 0.1
+ */
+public class DirectivesAnnotations implements Iterable<Directive> {
+
+    /**
+     * All the annotations.
+     */
+    private final List<DirectivesAnnotation> annotations;
+
+    /**
+     * Constructor.
+     */
+    public DirectivesAnnotations() {
+        this(new ArrayList<>(0));
+    }
+
+    /**
+     * Constructor.
+     * @param annotations Annotations.
+     */
+    public DirectivesAnnotations(final List<DirectivesAnnotation> annotations) {
+        this.annotations = annotations;
+    }
+
+    /**
+     * Add annotation.
+     * @param annotation Annotation.
+     * @return This object.
+     */
+    public DirectivesAnnotations add(final DirectivesAnnotation annotation) {
+        this.annotations.add(annotation);
+        return this;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        final Directives directives = new Directives();
+        if (!this.annotations.isEmpty()) {
+            directives.add("o")
+                .attr("base", "tuple")
+                .attr("name", "annotations");
+            this.annotations.forEach(directives::append);
+            directives.up();
+        }
+        return directives.iterator();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -155,6 +155,7 @@ public final class DirectivesClass implements Iterable<Directive> {
             .append(this.properties);
         this.fields.forEach(directives::append);
         this.methods.forEach(directives::append);
+        directives.append(this.annotations);
         return directives.up().iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -57,6 +57,11 @@ public final class DirectivesClass implements Iterable<Directive> {
     private final List<DirectivesMethod> methods;
 
     /**
+     * Annotations.
+     */
+    private final DirectivesAnnotations annotations;
+
+    /**
      * Constructor.
      * @param classname Class name.
      */
@@ -108,6 +113,7 @@ public final class DirectivesClass implements Iterable<Directive> {
         this.properties = properties;
         this.methods = methods;
         this.fields = fields;
+        this.annotations = new DirectivesAnnotations();
     }
 
     /**
@@ -127,6 +133,16 @@ public final class DirectivesClass implements Iterable<Directive> {
      */
     public DirectivesClass method(final DirectivesMethod method) {
         this.methods.add(method);
+        return this;
+    }
+
+    /**
+     * Add annotation to the directives.
+     * @param annotation Annotation
+     * @return The same instance of {@link DirectivesClass}.
+     */
+    public DirectivesClass annotation(final DirectivesAnnotation annotation) {
+        this.annotations.add(annotation);
         return this;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -31,7 +31,6 @@ import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.TypePath;
 import org.xembly.Directive;
 
 /**

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -31,6 +31,7 @@ import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.TypePath;
 import org.xembly.Directive;
 
 /**
@@ -130,6 +131,12 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
     }
 
     @Override
+    public AnnotationVisitor visitAnnotation(final String descriptor, final boolean visible) {
+        this.program.top().annotation(new DirectivesAnnotation(descriptor, visible));
+        return super.visitAnnotation(descriptor, visible);
+    }
+
+    @Override
     public FieldVisitor visitField(
         final int access,
         final String name,
@@ -145,10 +152,5 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
     @Override
     public Iterator<Directive> iterator() {
         return this.program.iterator();
-    }
-
-    @Override
-    public AnnotationVisitor visitAnnotation(final String descriptor, final boolean visible) {
-        return super.visitAnnotation(descriptor, visible);
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -145,8 +145,18 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
         final Object value
     ) {
         final String ename = new JavaName(name).encode();
-        this.program.top().field(new DirectivesField(access, ename, descriptor, signature, value));
-        return super.visitField(access, ename, descriptor, signature, value);
+        final DirectivesField field = new DirectivesField(
+            access,
+            ename,
+            descriptor,
+            signature,
+            value
+        );
+        this.program.top().field(field);
+        return new DirectivesFieldVisitor(
+            super.visitField(access, ename, descriptor, signature, value),
+            field
+        );
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.DefaultVersion;
 import org.eolang.jeo.representation.JavaName;
+import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
@@ -144,5 +145,10 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
     @Override
     public Iterator<Directive> iterator() {
         return this.program.iterator();
+    }
+
+    @Override
+    public AnnotationVisitor visitAnnotation(final String descriptor, final boolean visible) {
+        return super.visitAnnotation(descriptor, visible);
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
@@ -81,6 +81,11 @@ final class DirectivesField implements Iterable<Directive> {
     private final Object value;
 
     /**
+     * Annotations.
+     */
+    private final DirectivesAnnotations annotations;
+
+    /**
      * Constructor.
      */
     DirectivesField() {
@@ -108,6 +113,17 @@ final class DirectivesField implements Iterable<Directive> {
         this.descriptor = Optional.ofNullable(descriptor).orElse("");
         this.signature = Optional.ofNullable(signature).orElse("");
         this.value = Optional.ofNullable(value).orElse("");
+        this.annotations = new DirectivesAnnotations();
+    }
+
+    /**
+     * Add annotation.
+     * @param annotation Annotation
+     * @return This object
+     */
+    public DirectivesField annotation(final DirectivesAnnotation annotation) {
+        this.annotations.add(annotation);
+        return this;
     }
 
     @Override
@@ -119,6 +135,7 @@ final class DirectivesField implements Iterable<Directive> {
             .append(new DirectivesData(this.descriptor))
             .append(new DirectivesData(this.signature))
             .append(new DirectivesData(this.value))
+            .append(this.annotations)
             .up()
             .iterator();
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesFieldVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesFieldVisitor.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.directives;
+
+import org.eolang.jeo.representation.DefaultVersion;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.FieldVisitor;
+
+/**
+ * Directives field visitor.
+ * @since 0.1
+ */
+public class DirectivesFieldVisitor extends FieldVisitor {
+
+    /**
+     * Field.
+     */
+    private final DirectivesField field;
+
+    /**
+     * Constructor.
+     * @param visitor Field visitor.
+     * @param field Field.
+     */
+    protected DirectivesFieldVisitor(
+        final FieldVisitor visitor,
+        final DirectivesField field
+    ) {
+        super(new DefaultVersion().api(), visitor);
+        this.field = field;
+    }
+
+    @Override
+    public AnnotationVisitor visitAnnotation(final String descriptor, final boolean visible) {
+        this.field.annotation(new DirectivesAnnotation(descriptor, visible));
+        return super.visitAnnotation(descriptor, visible);
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesFieldVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesFieldVisitor.java
@@ -31,7 +31,7 @@ import org.objectweb.asm.FieldVisitor;
  * Directives field visitor.
  * @since 0.1
  */
-public class DirectivesFieldVisitor extends FieldVisitor {
+public final class DirectivesFieldVisitor extends FieldVisitor {
 
     /**
      * Field.

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.directives;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import org.xembly.Directive;
 import org.xembly.Directives;
@@ -72,8 +73,8 @@ public final class DirectivesInstruction implements Iterable<Directive> {
             throw new IllegalStateException(
                 String.format(
                     "Failed to convert instruction %s with arguments %s to xembly directives",
-                    this.opcode,
-                    this.arguments
+                    new OpcodeName(this.opcode).simplified(),
+                    Arrays.toString(this.arguments)
                 ),
                 exception
             );

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
@@ -57,15 +57,26 @@ public final class DirectivesInstruction implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        final Directives directives = new Directives();
-        directives.add("o")
-            .attr("name", new OpcodeName(this.opcode).asString())
-            .attr("base", "opcode");
-        directives.append(new DirectivesOperand(this.opcode));
-        for (final Object operand : this.arguments) {
-            directives.append(new DirectivesOperand(operand));
+        try {
+            final Directives directives = new Directives();
+            directives.add("o")
+                .attr("name", new OpcodeName(this.opcode).asString())
+                .attr("base", "opcode");
+            directives.append(new DirectivesOperand(this.opcode));
+            for (final Object operand : this.arguments) {
+                directives.append(new DirectivesOperand(operand));
+            }
+            directives.up();
+            return directives.iterator();
+        } catch (final IllegalStateException exception) {
+            throw new IllegalStateException(
+                String.format(
+                    "Failed to convert instruction %s with arguments %s to xembly directives",
+                    this.opcode,
+                    this.arguments
+                ),
+                exception
+            );
         }
-        directives.up();
-        return directives.iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitor.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
 import org.eolang.jeo.representation.DefaultVersion;
+import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
@@ -152,6 +153,11 @@ public final class DirectivesMethodVisitor extends MethodVisitor implements Iter
     ) {
         this.method.exception(new DirectivesTryCatch(start, end, handler, type));
         super.visitTryCatchBlock(start, end, handler, type);
+    }
+
+    @Override
+    public AnnotationVisitor visitAnnotation(final String descriptor, final boolean visible) {
+        return super.visitAnnotation(descriptor, visible);
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/xmir/HexString.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/HexString.java
@@ -85,4 +85,21 @@ final class HexString {
     int decodeAsInt() {
         return Integer.parseInt(this.hex.trim().replace(" ", ""), HexString.RADIX);
     }
+
+    /**
+     * Convert hex string to boolean.
+     * @return Boolean.
+     */
+    boolean decodeAsBoolean() {
+        final String value = this.hex.trim();
+        if (value.length() != 2) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Invalid hex boolean string: %s, the expected size is 2: 01 or 00",
+                    this.hex
+                )
+            );
+        }
+        return value.equals("01");
+    }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
@@ -23,20 +23,39 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+/**
+ * Xmir representation of an annotation.
+ * @since 0.1
+ */
 public class XmlAnnotation {
 
+    /**
+     * Xmir node.
+     */
     private final XmlNode node;
 
+    /**
+     * Constructor.
+     * @param xmlnode XML node.
+     */
     public XmlAnnotation(final XmlNode xmlnode) {
         this.node = xmlnode;
     }
 
+    /**
+     * Annotation descriptor.
+     * @return Descriptor.
+     */
     public String descriptor() {
         return new HexString(this.node.child("name", "descriptor").text()).decode();
     }
 
+    /**
+     * Annotation visible.
+     * Is it runtime-visible?
+     * @return True if visible at runtime, false otherwise.
+     */
     public boolean visible() {
         return new HexString(this.node.child("name", "visible").text()).decode().equals("true");
     }
-
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.xmir;
+
+public class XmlAnnotation {
+
+    public String descriptor() {
+        return null;
+    }
+
+    public boolean visible() {
+        return true;
+    }
+
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
@@ -23,8 +23,6 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import org.eolang.jeo.representation.HexData;
-
 /**
  * Xmir representation of an annotation.
  * @since 0.1

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
@@ -23,6 +23,8 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import org.eolang.jeo.representation.HexData;
+
 /**
  * Xmir representation of an annotation.
  * @since 0.1
@@ -56,6 +58,6 @@ public class XmlAnnotation {
      * @return True if visible at runtime, false otherwise.
      */
     public boolean visible() {
-        return new HexString(this.node.child("name", "visible").text()).decode().equals("true");
+        return new HexString(this.node.child("name", "visible").text()).decodeAsBoolean();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
@@ -25,12 +25,18 @@ package org.eolang.jeo.representation.xmir;
 
 public class XmlAnnotation {
 
+    private final XmlNode node;
+
+    public XmlAnnotation(final XmlNode xmlnode) {
+        this.node = xmlnode;
+    }
+
     public String descriptor() {
-        return null;
+        return new HexString(this.node.child("name", "descriptor").text()).decode();
     }
 
     public boolean visible() {
-        return true;
+        return new HexString(this.node.child("name", "visible").text()).decode().equals("true");
     }
 
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotations.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.xmir;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Xmir annotations.
+ * @since 0.1
+ * @todo #292:90min Add unit test for XmlAnnotations class.
+ *  XmlAnnotations class is not covered by unit tests.
+ *  Add unit tests for XmlAnnotations class.
+ *  Don't forget to remove the current puzzle.
+ */
+public class XmlAnnotations {
+
+    /**
+     * XML node representing annotations.
+     */
+    private final XmlNode node;
+
+    /**
+     * Constructor.
+     * @param xmlnode XML node.
+     */
+    public XmlAnnotations(final XmlNode xmlnode) {
+        this.node = xmlnode;
+    }
+
+    /**
+     * All annotations.
+     * @return Annotations.
+     */
+    public List<XmlAnnotation> all() {
+        return Arrays.asList();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotations.java
@@ -23,8 +23,8 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Xmir annotations.
@@ -54,6 +54,8 @@ public class XmlAnnotations {
      * @return Annotations.
      */
     public List<XmlAnnotation> all() {
-        return Arrays.asList();
+        return this.node.children()
+            .map(XmlAnnotation::new)
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
@@ -69,6 +69,7 @@ public final class XmlBytecode {
             new ClassName(program.pckg(), new JavaName(clazz.name()).decode()).full(),
             clazz.properties().toBytecodeProperties()
         );
+        clazz.annotations().ifPresent(bytecode::withAnnotations);
         for (final XmlField field : clazz.fields()) {
             bytecode.withField(
                 new JavaName(field.name()).decode(),

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
@@ -72,9 +72,7 @@ public final class XmlBytecode {
             clazz.properties().toBytecodeProperties()
         );
         clazz.annotations().ifPresent(bytecode::withAnnotations);
-        final List<XmlField> fields = clazz.fields();
-        System.out.println("\nfields size: \n" + fields.size() + "\n");
-        for (final XmlField field : fields) {
+        for (final XmlField field : clazz.fields()) {
             final FieldVisitor visitor = bytecode.withField(
                 new JavaName(field.name()).decode(),
                 field.descriptor(),
@@ -91,9 +89,7 @@ public final class XmlBytecode {
                 )
             );
         }
-        final List<XmlMethod> methods = clazz.methods();
-        System.out.println("\nmethods size: \n" + methods.size() + "\n");
-        for (final XmlMethod xmlmethod : methods) {
+        for (final XmlMethod xmlmethod : clazz.methods()) {
             final BytecodeMethod method = bytecode.withMethod(xmlmethod.properties());
             xmlmethod.instructions().forEach(inst -> inst.writeTo(method));
             xmlmethod.trycatchEntries().forEach(exc -> exc.writeTo(method));

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation.xmir;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
-import java.util.List;
 import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.JavaName;
 import org.eolang.jeo.representation.bytecode.Bytecode;
@@ -80,13 +79,14 @@ public final class XmlBytecode {
                 field.value(),
                 field.access()
             );
-            field.annotations().ifPresent(annotations -> annotations.all()
-                .forEach(
-                    annotation -> visitor.visitAnnotation(
-                        annotation.descriptor(),
-                        annotation.visible()
+            field.annotations().ifPresent(
+                annotations -> annotations.all()
+                    .forEach(
+                        annotation -> visitor.visitAnnotation(
+                            annotation.descriptor(),
+                            annotation.visible()
+                        )
                     )
-                )
             );
         }
         for (final XmlMethod xmlmethod : clazz.methods()) {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.xmir;
 
 import com.jcabi.xml.XMLDocument;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -144,6 +145,18 @@ public final class XmlClass {
             .filter(o -> "field".equals(o.attribute("base").get()))
             .map(XmlField::new)
             .collect(Collectors.toList());
+    }
+
+    /**
+     * Annotations.
+     * @return Annotations node.
+     */
+    public Optional<XmlAnnotations> annotations() {
+        return this.node.children()
+            .filter(o -> o.hasAttribute("name", "annotations"))
+            .filter(o -> o.hasAttribute("base", "tuple"))
+            .findFirst()
+            .map(XmlAnnotations::new);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -106,6 +106,18 @@ public final class XmlClass {
     }
 
     /**
+     * Annotations.
+     * @return Annotations node.
+     */
+    public Optional<XmlAnnotations> annotations() {
+        return this.node.children()
+            .filter(o -> o.hasAttribute("name", "annotations"))
+            .filter(o -> o.hasAttribute("base", "tuple"))
+            .findFirst()
+            .map(XmlAnnotations::new);
+    }
+
+    /**
      * Class properties.
      * @return Class properties.
      */
@@ -145,18 +157,6 @@ public final class XmlClass {
             .filter(o -> "field".equals(o.attribute("base").get()))
             .map(XmlField::new)
             .collect(Collectors.toList());
-    }
-
-    /**
-     * Annotations.
-     * @return Annotations node.
-     */
-    public Optional<XmlAnnotations> annotations() {
-        return this.node.children()
-            .filter(o -> o.hasAttribute("name", "annotations"))
-            .filter(o -> o.hasAttribute("base", "tuple"))
-            .findFirst()
-            .map(XmlAnnotations::new);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -90,6 +90,14 @@ public class XmlField {
     }
 
     /**
+     * Field annotations.
+     * @return Annotations.
+     */
+    public Optional<XmlAnnotations> annotations() {
+        return this.node.optchild("name", "annotations").map(XmlAnnotations::new);
+    }
+
+    /**
      * Find node text by attribute.
      * @param attribute Attribute.
      * @return Text.

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.stream.IntStream;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.eolang.jeo.representation.directives.DirectivesInstruction;
+import org.objectweb.asm.Type;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -145,6 +146,8 @@ public final class XmlInstruction implements XmlBytecodeEntry {
             result = new HexString(argument.text()).decodeAsInt();
         } else if (attr.equals("label")) {
             result = this.labels.label(argument.text());
+        } else if (attr.equals("reference")) {
+            result = Type.getType(String.format("L%s;", new HexString(argument.text()).decode()));
         } else {
             result = new HexString(argument.text()).decode();
         }

--- a/src/test/java/org/eolang/jeo/representation/HexDataTest.java
+++ b/src/test/java/org/eolang/jeo/representation/HexDataTest.java
@@ -76,12 +76,14 @@ class HexDataTest {
             Arguments.of("Hello!", "string"),
             Arguments.of(new byte[]{1, 2, 3}, "bytes"),
             Arguments.of(true, "bool"),
-            Arguments.of(0.1d, "float")
+            Arguments.of(0.1d, "float"),
+            Arguments.of(HexDataTest.class, "reference")
         );
     }
 
     /**
      * Arguments for {@link HexDataTest#convertsRawDataIntoHexString(Object, String)}.
+     * Example for reference - {@link HexDataTest} is "org.eolang.jeo.representation.HexDataTest"
      * @return Stream of arguments.
      */
     static Stream<Arguments> values() {
@@ -91,7 +93,11 @@ class HexDataTest {
             Arguments.of(new byte[]{1, 2, 3}, "01 02 03"),
             Arguments.of(true, "01"),
             Arguments.of(false, "00"),
-            Arguments.of(0.1d, "3F B9 99 99 99 99 99 9A")
+            Arguments.of(0.1d, "3F B9 99 99 99 99 99 9A"),
+            Arguments.of(
+                HexDataTest.class,
+                "6F 72 67 2E 65 6F 6C 61 6E 67 2E 6A 65 6F 2E 72 65 70 72 65 73 65 6E 74 61 74 69 6F 6E 2E 48 65 78 44 61 74 61 54 65 73 74"
+            )
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/HexDataTest.java
+++ b/src/test/java/org/eolang/jeo/representation/HexDataTest.java
@@ -96,7 +96,7 @@ class HexDataTest {
             Arguments.of(0.1d, "3F B9 99 99 99 99 99 9A"),
             Arguments.of(
                 HexDataTest.class,
-                "6F 72 67 2E 65 6F 6C 61 6E 67 2E 6A 65 6F 2E 72 65 70 72 65 73 65 6E 74 61 74 69 6F 6E 2E 48 65 78 44 61 74 61 54 65 73 74"
+                "6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 72 65 70 72 65 73 65 6E 74 61 74 69 6F 6E 2F 48 65 78 44 61 74 61 54 65 73 74"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.directives;
 
 import com.jcabi.matchers.XhtmlMatchers;
@@ -55,5 +78,4 @@ class DirectivesAnnotationsTest {
             )
         );
     }
-
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java
@@ -1,0 +1,59 @@
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.eolang.jeo.representation.HexData;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link DirectivesAnnotation}.
+ * @since 0.1
+ */
+class DirectivesAnnotationsTest {
+
+    @Test
+    void returnsEmptyDirectviesIfNoAnnotations() {
+        MatcherAssert.assertThat(
+            "Must return empty directives if no annotations",
+            new DirectivesAnnotations().iterator().hasNext(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void returnsSingleAnnotation() throws ImpossibleModificationException {
+        final String annotation = "Ljava/lang/Override;";
+        final String xml = new Xembler(
+            new DirectivesAnnotations()
+                .add(new DirectivesAnnotation(annotation, true))
+        ).xml();
+        MatcherAssert.assertThat(
+            String.format(
+                "Must return single annotation with correct descriptor and visibility, but was: %n%s",
+                xml
+            ),
+            xml,
+            Matchers.allOf(
+                XhtmlMatchers.hasXPath(
+                    "/o[@base='tuple' and @name='annotations']/o"
+                ),
+                XhtmlMatchers.hasXPath(
+                    String.format(
+                        "/o[@base='tuple' and @name='annotations']/o/o[@base='string' and @name='descriptor' and text()='%s']",
+                        new HexData(annotation).value()
+                    )
+                ),
+                XhtmlMatchers.hasXPath(
+                    String.format(
+                        "/o[@base='tuple' and @name='annotations']/o/o[@base='bool' and @name='visible' and text()='%s']",
+                        new HexData(true).value()
+                    )
+                )
+            )
+        );
+    }
+
+}


### PR DESCRIPTION
In this large PR I've added support of annotations for classes and fields.
This annotation processing was required to enable Spring Application Integration test.

Closes: #292.
_____
History:
- feat(#292): enable spring test - fails
- feat(#292): remove the 292 puzzle description
- feat(#292): add context to IllegalStateException
- feat(#292): add context to IllegalStateException
- feat(#292): convert reference into XMIR
- feat(#292): correct reference transformation into eo and back
- feat(#292): replace . with slash for class types
- feat(#292): add DirectivesAnnotations and DirectiveAnnotation classes
- feat(#292): try to visit class annotation
- feat(#292): add XmlAnnotations and XmlAnnotation classes
- feat(#292): finish with class-level annotations
- feat(#292): add several javadocs
- feat(#292): add field annotations
- feat(#292): correctly save annotation directive
- feat(#292): spring application doesn't work by some reason
- feat(#292): integration test is working
- feat(#292): fix all the unit tests
- feat(#292): fix all xcop suggestions
- feat(#292): fix all qulice suggestions
- feat(#292): up jacoco limits a bit


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Update XML and Java code representations in the project.

### Detailed summary:
- Updated the `pom.xml` file to change the value of the `maximum` element from 4 to 6.
- Added a new method `annotations()` in the `XmlField` class to retrieve field annotations.
- Modified the `BytecodeRepresentation` class to handle exceptions during transformation.
- Added a new method `decodeAsBoolean()` in the `HexString` class to convert a hex string to a boolean.
- Updated the `pom.xml` file in the `spring` module to include the `jeo-maven-plugin` plugin.
- Added a new method `annotations()` in the `XmlClass` class to retrieve class annotations.
- Modified the `DirectivesMethodVisitor` class to override the `visitAnnotation()` method.
- Updated the `XmlInstruction` class to handle the `reference` attribute in the `argument()` method.
- Added a new test case in the `HexDataTest` class to test the conversion of a class reference to a hex string.
- Added a new method `annotation()` in the `DirectivesField` class to add annotations to the field directives.
- Updated the `XmlBytecode` class to handle field annotations and method properties.
- Updated the `HexData` class to handle class references and type information.
- Added a new method `annotation()` in the `DirectivesClass` class to add annotations to the class directives.
- Modified the `DirectivesClassVisitor` class to override the `visitAnnotation()` method.
- Updated the `DirectivesInstruction` class to handle instructions with arguments and convert them to xembly directives.

> The following files were skipped due to too many changes: `src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java`, `src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java`, `src/it/spring/verify.groovy`, `src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java`, `src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotations.java`, `src/main/java/org/eolang/jeo/representation/directives/DirectivesFieldVisitor.java`, `src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java`, `src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotations.java`, `src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->