### PR TITLE
feat(#347): Open Directives* and Xml* Classes for Programmers

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -103,7 +103,7 @@ public final class DirectivesClass implements Iterable<Directive> {
      * @param fields Class fields
      * @checkstyle ParameterNumberCheck (5 lines)
      */
-    private DirectivesClass(
+    public DirectivesClass(
         final ClassName name,
         final DirectivesClassProperties properties,
         final List<DirectivesMethod> methods,

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
@@ -57,7 +57,7 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
     /**
      * Constructor.
      */
-    DirectivesClassProperties() {
+    public DirectivesClassProperties() {
         this(0);
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesData.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesData.java
@@ -33,7 +33,7 @@ import org.xembly.Directives;
  *
  * @since 0.1.0
  */
-final class DirectivesData implements Iterable<Directive> {
+public final class DirectivesData implements Iterable<Directive> {
 
     /**
      * Data.
@@ -49,7 +49,7 @@ final class DirectivesData implements Iterable<Directive> {
      * Constructor.
      * @param data Data.
      */
-    DirectivesData(final Object data) {
+    public DirectivesData(final Object data) {
         this("", data);
     }
 
@@ -58,7 +58,7 @@ final class DirectivesData implements Iterable<Directive> {
      * @param name Name.
      * @param data Data.
      */
-    DirectivesData(final String name, final Object data) {
+    public DirectivesData(final String name, final Object data) {
         this.data = data;
         this.name = name;
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
@@ -53,7 +53,7 @@ import org.xembly.Directives;
  *
  * @since 0.1
  */
-final class DirectivesField implements Iterable<Directive> {
+public final class DirectivesField implements Iterable<Directive> {
 
     /**
      * Access.
@@ -88,7 +88,7 @@ final class DirectivesField implements Iterable<Directive> {
     /**
      * Constructor.
      */
-    DirectivesField() {
+    public DirectivesField() {
         this(Opcodes.ACC_PUBLIC, "unknown", "I", "", "0");
     }
 
@@ -101,7 +101,7 @@ final class DirectivesField implements Iterable<Directive> {
      * @param value Initial value
      * @checkstyle ParameterNumberCheck (5 lines)
      */
-    DirectivesField(
+    public DirectivesField(
         final int access,
         final String name,
         final String descriptor,

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesLabel.java
@@ -54,7 +54,7 @@ public final class DirectivesLabel implements Iterable<Directive> {
      * Constructor.
      * @param label Bytecode label.
      */
-    DirectivesLabel(final Label label) {
+    public DirectivesLabel(final Label label) {
         this(label, new AllLabels());
     }
 
@@ -63,7 +63,7 @@ public final class DirectivesLabel implements Iterable<Directive> {
      * @param label Bytecode label.
      * @param all All labels.
      */
-    private DirectivesLabel(final Label label, final AllLabels all) {
+    public DirectivesLabel(final Label label, final AllLabels all) {
         this(label, "", all);
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -42,7 +42,7 @@ public final class DirectivesMetas implements Iterable<Directive> {
     /**
      * Constructor.
      */
-    DirectivesMetas() {
+    public DirectivesMetas() {
         this(new ClassName());
     }
 
@@ -50,7 +50,7 @@ public final class DirectivesMetas implements Iterable<Directive> {
      * Constructor.
      * @param classname Class name.
      */
-    DirectivesMetas(final ClassName classname) {
+    public DirectivesMetas(final ClassName classname) {
         this.name = classname;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
@@ -62,7 +62,7 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
     /**
      * Constructor.
      */
-    DirectivesMethodProperties() {
+    public DirectivesMethodProperties() {
         this(Opcodes.ACC_PUBLIC, "()V", "", "", "");
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesOperand.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesOperand.java
@@ -32,7 +32,7 @@ import org.xembly.Directive;
  * Operand XML directives.
  * @since 0.1
  */
-final class DirectivesOperand implements Iterable<Directive> {
+public final class DirectivesOperand implements Iterable<Directive> {
 
     /**
      * Raw operand.
@@ -43,7 +43,7 @@ final class DirectivesOperand implements Iterable<Directive> {
      * Constructor.
      * @param operand Raw operand.
      */
-    DirectivesOperand(final Object operand) {
+    public DirectivesOperand(final Object operand) {
         this.raw = operand;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesProgram.java
@@ -69,7 +69,7 @@ public final class DirectivesProgram implements Iterable<Directive> {
      * Constructor.
      * @param code Program listing.
      */
-    DirectivesProgram(final String code) {
+    public DirectivesProgram(final String code) {
         this(code, new AtomicReference<>(), new AtomicReference<>());
     }
 
@@ -79,7 +79,7 @@ public final class DirectivesProgram implements Iterable<Directive> {
      * @param clazz Class.
      * @param name Classname.
      */
-    private DirectivesProgram(
+    public DirectivesProgram(
         final String code,
         final AtomicReference<DirectivesClass> clazz,
         final AtomicReference<ClassName> name
@@ -130,7 +130,7 @@ public final class DirectivesProgram implements Iterable<Directive> {
      * Retrieve top-level class.
      * @return Top-level class.
      */
-    DirectivesClass top() {
+    public DirectivesClass top() {
         if (Objects.isNull(this.klass.get())) {
             throw new IllegalStateException(
                 String.format("Class is not initialized here %s", this)

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesTuple.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesTuple.java
@@ -32,7 +32,7 @@ import org.xembly.Directives;
  *
  * @since 0.1.0
  */
-final class DirectivesTuple implements Iterable<Directive> {
+public final class DirectivesTuple implements Iterable<Directive> {
 
     /**
      * Tuple name.
@@ -49,7 +49,7 @@ final class DirectivesTuple implements Iterable<Directive> {
      * @param name Tuple name.
      * @param values Tuple values.
      */
-    DirectivesTuple(
+    public DirectivesTuple(
         final String name,
         final String... values
     ) {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
@@ -55,7 +55,7 @@ public final class XmlBytecode {
      * Constructor.
      * @param lines Xml document lines.
      */
-    XmlBytecode(final String... lines) {
+    public XmlBytecode(final String... lines) {
         this(new XMLDocument(String.join("\n", lines)));
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -53,7 +53,7 @@ public final class XmlClass {
      * Constructor.
      * @param classname Class name.
      */
-    XmlClass(final String classname) {
+    public XmlClass(final String classname) {
         this(XmlClass.empty(classname));
     }
 
@@ -70,7 +70,7 @@ public final class XmlClass {
      * @param classname Class name.
      * @param properties Class properties.
      */
-    XmlClass(final String classname, final DirectivesClassProperties properties) {
+    public XmlClass(final String classname, final DirectivesClassProperties properties) {
         this(XmlClass.withProps(classname, properties));
     }
 
@@ -78,7 +78,7 @@ public final class XmlClass {
      * Constructor.
      * @param xml Class node.
      */
-    XmlClass(final Node xml) {
+    public XmlClass(final Node xml) {
         this(new XmlNode(xml));
     }
 
@@ -86,7 +86,7 @@ public final class XmlClass {
      * Constructor.
      * @param node Class node.
      */
-    private XmlClass(final XmlNode node) {
+    public XmlClass(final XmlNode node) {
         this.node = node;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
@@ -32,7 +32,7 @@ import org.eolang.jeo.representation.bytecode.BytecodeClassProperties;
  *
  * @since 0.1.0
  */
-final class XmlClassProperties {
+public final class XmlClassProperties {
 
     /**
      * XML representation of a class.
@@ -43,7 +43,7 @@ final class XmlClassProperties {
      * Constructor.
      * @param clazz XMl representation of a class.
      */
-    XmlClassProperties(final XmlNode clazz) {
+    public XmlClassProperties(final XmlNode clazz) {
         this(clazz.asDocument());
     }
 
@@ -51,7 +51,7 @@ final class XmlClassProperties {
      * Constructor.
      * @param clazz XML representation of a class.
      */
-    private XmlClassProperties(final XMLDocument clazz) {
+    public XmlClassProperties(final XMLDocument clazz) {
         this.clazz = clazz;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -41,7 +41,7 @@ public class XmlField {
      * Constructor.
      * @param xmlnode Field node.
      */
-    XmlField(final XmlNode xmlnode) {
+    public XmlField(final XmlNode xmlnode) {
         this.node = xmlnode;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -81,7 +81,7 @@ public final class XmlInstruction implements XmlBytecodeEntry {
      * Constructor.
      * @param node Instruction node.
      */
-    XmlInstruction(final Node node) {
+    public XmlInstruction(final Node node) {
         this.node = node;
         this.labels = new AllLabels();
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -69,7 +69,7 @@ public final class XmlMethod {
      * Constructor.
      * @param xmlnode Method node.
      */
-    XmlMethod(final XmlNode xmlnode) {
+    public XmlMethod(final XmlNode xmlnode) {
         this.node = xmlnode;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -39,7 +39,7 @@ import org.w3c.dom.NodeList;
  * @since 0.1
  */
 @SuppressWarnings("PMD.TooManyMethods")
-final class XmlNode {
+public final class XmlNode {
 
     /**
      * Parent node.
@@ -51,7 +51,7 @@ final class XmlNode {
      * Constructor.
      * @param xml XML string.
      */
-    XmlNode(final String xml) {
+    public XmlNode(final String xml) {
         this(new XMLDocument(xml).node().getFirstChild());
     }
 
@@ -59,7 +59,7 @@ final class XmlNode {
      * Constructor.
      * @param parent Parent node.
      */
-    XmlNode(final Node parent) {
+    public XmlNode(final Node parent) {
         this.node = parent;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -35,7 +35,7 @@ import org.xembly.Xembler;
  * XMIR Program.
  * @since 0.1
  */
-final class XmlProgram {
+public final class XmlProgram {
 
     /**
      * Program node name.
@@ -51,7 +51,7 @@ final class XmlProgram {
      * Constructor.
      * @param name Class name.
      */
-    XmlProgram(final ClassName name) {
+    public XmlProgram(final ClassName name) {
         this(
             new XMLDocument(
                 new Xembler(
@@ -65,7 +65,7 @@ final class XmlProgram {
      * Constructor.
      * @param xml Raw XMIR.
      */
-    XmlProgram(final XML xml) {
+    public XmlProgram(final XML xml) {
         this(xml.node());
     }
 
@@ -73,7 +73,7 @@ final class XmlProgram {
      * Constructor.
      * @param root Root node.
      */
-    private XmlProgram(final Node root) {
+    public XmlProgram(final Node root) {
         this.root = root;
     }
 


### PR DESCRIPTION
Open `Directives*` and `Xml*` classes for usage in other projects.

Closes: #347.
____
History:
- feat(#347): open Directives* classes
- feat(#347): opem Xml* classes


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The constructors of several classes have been changed from private to public.
- Some classes have been changed from `final` to `public final`.
- The visibility of some methods has been changed from private to public.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->