### PR TITLE
feat(#350): allow XmlMethod instructions mutation

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -86,6 +86,14 @@ public final class DirectivesMethod implements Iterable<Directive> {
         return this;
     }
 
+    /**
+     * Add operand to the directives.
+     * @param directives Operand directives.
+     */
+    public void operand(final Iterable<Directive> directives) {
+        this.instructions.add(directives);
+    }
+
     @Override
     public Iterator<Directive> iterator() {
         final Directives directives = new Directives();
@@ -114,14 +122,6 @@ public final class DirectivesMethod implements Iterable<Directive> {
         directives.up();
         directives.up();
         return directives.iterator();
-    }
-
-    /**
-     * Add operand to the directives.
-     * @param directives Operand directives.
-     */
-    void operand(final Iterable<Directive> directives) {
-        this.instructions.add(directives);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -121,7 +121,7 @@ public final class XmlClass {
      * Class properties.
      * @return Class properties.
      */
-    XmlClassProperties properties() {
+    public XmlClassProperties properties() {
         return new XmlClassProperties(this.node);
     }
 
@@ -129,7 +129,7 @@ public final class XmlClass {
      * Retrieve all constructors from XMIR.
      * @return List of constructors.
      */
-    List<XmlMethod> constructors() {
+    public List<XmlMethod> constructors() {
         return this.methods()
             .stream()
             .filter(XmlMethod::isConstructor)
@@ -140,7 +140,7 @@ public final class XmlClass {
      * Methods.
      * @return Class methods.
      */
-    List<XmlMethod> methods() {
+    public List<XmlMethod> methods() {
         return this.node.children()
             .filter(o -> o.attribute("base").isEmpty())
             .map(XmlMethod::new)
@@ -151,7 +151,7 @@ public final class XmlClass {
      * Fields.
      * @return Class fields.
      */
-    List<XmlField> fields() {
+    public List<XmlField> fields() {
         return this.node.children()
             .filter(o -> o.attribute("base").isPresent())
             .filter(o -> "field".equals(o.attribute("base").get()))

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -111,6 +111,14 @@ public final class XmlInstruction implements XmlBytecodeEntry {
             .toArray();
     }
 
+    /**
+     * Get XML node.
+     * @return XML node.
+     */
+    public XmlNode toNode() {
+        return new XmlNode(this.node);
+    }
+
     @Override
     public boolean equals(final Object other) {
         final boolean result;

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -88,14 +88,22 @@ public final class XmlInstruction implements XmlBytecodeEntry {
 
     @Override
     public void writeTo(final BytecodeMethod method) {
-        method.opcode(this.code(), this.arguments());
+        method.opcode(this.opcode(), this.operands());
+    }
+
+    /**
+     * Instruction code.
+     * @return Code.
+     */
+    public int opcode() {
+        return new HexString(new XmlNode(this.node).firstChild().text()).decodeAsInt();
     }
 
     /**
      * Instruction arguments.
      * @return Arguments.
      */
-    public Object[] arguments() {
+    public Object[] operands() {
         return new XmlNode(this.node)
             .children()
             .skip(1)
@@ -152,14 +160,6 @@ public final class XmlInstruction implements XmlBytecodeEntry {
             result = new HexString(argument.text()).decode();
         }
         return result;
-    }
-
-    /**
-     * Instruction code.
-     * @return Code.
-     */
-    private int code() {
-        return new HexString(new XmlNode(this.node).firstChild().text()).decodeAsInt();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -224,7 +224,7 @@ public final class XmlMethod {
         final String name,
         final int access,
         final String descriptor,
-        final String[] exceptions
+        final String... exceptions
     ) {
         return new XmlNode(
             new Xembler(

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -31,6 +31,7 @@ import lombok.ToString;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodProperties;
 import org.eolang.jeo.representation.directives.DirectivesMethod;
 import org.eolang.jeo.representation.directives.DirectivesMethodProperties;
+import org.objectweb.asm.Opcodes;
 import org.xembly.Transformers;
 import org.xembly.Xembler;
 
@@ -47,6 +48,13 @@ public final class XmlMethod {
      */
     @ToString.Include
     private final XmlNode node;
+
+    /**
+     * Constructor.
+     */
+    public XmlMethod() {
+        this("foo", Opcodes.ACC_PUBLIC, "()V");
+    }
 
     /**
      * Constructor.
@@ -170,6 +178,27 @@ public final class XmlMethod {
     }
 
     /**
+     * Replace instructions.
+     * @param entries Instructions to replace.
+     * @todo #350 Remove mutable method from XmlMethod.
+     *  Here we just remove all instructions and add new ones, this makes XmlMethod class
+     *  mutable, which is a significant architecture flaw. It's much better to
+     *  implement copying of this class with creation of a new XmlMethod, but in order to
+     *  implement this we will have to implement copying all the top level classes like
+     *  XmlProgram, XmlClass and so on, which requires lots of work.
+     */
+    public void replaceInstructions(final XmlNode... entries) {
+        final XmlNode seq = this.node.child("base", "seq")
+            .child("base", "tuple");
+        seq.children()
+            .filter(element -> element.attribute("base").isPresent())
+            .forEach(XmlNode::erase);
+        for (final XmlNode entry : entries) {
+            seq.append(entry);
+        }
+    }
+
+    /**
      * Method exceptions.
      * @return Exceptions.
      */
@@ -195,7 +224,7 @@ public final class XmlMethod {
         final String name,
         final int access,
         final String descriptor,
-        final String... exceptions
+        final String[] exceptions
     ) {
         return new XmlNode(
             new Xembler(

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -97,7 +97,7 @@ public final class XmlNode {
      * @param name Child node name.
      * @return Child node.
      */
-    XmlNode child(final String name) {
+    public XmlNode child(final String name) {
         return this.optchild(name).orElseThrow(() -> this.notFound(name));
     }
 
@@ -106,7 +106,7 @@ public final class XmlNode {
      * @param name Child node name.
      * @return Child node.
      */
-    Optional<XmlNode> optchild(final String name) {
+    public Optional<XmlNode> optchild(final String name) {
         Optional<XmlNode> result = Optional.empty();
         final NodeList children = this.node.getChildNodes();
         for (int index = 0; index < children.getLength(); ++index) {
@@ -125,7 +125,7 @@ public final class XmlNode {
      * @param value Attribute value.
      * @return Child node.
      */
-    XmlNode child(final String attribute, final String value) {
+    public XmlNode child(final String attribute, final String value) {
         return this.children()
             .filter(xmlnode -> xmlnode.hasAttribute(attribute, value))
             .findFirst()
@@ -142,7 +142,7 @@ public final class XmlNode {
      * @param value Attribute value.
      * @return Child node.
      */
-    Optional<XmlNode> optchild(final String attribute, final String value) {
+    public Optional<XmlNode> optchild(final String attribute, final String value) {
         return this.children()
             .filter(xmlnode -> xmlnode.hasAttribute(attribute, value))
             .findFirst();
@@ -152,7 +152,7 @@ public final class XmlNode {
      * Get first child.
      * @return First child node.
      */
-    XmlNode firstChild() {
+    public XmlNode firstChild() {
         return this.children().findFirst()
             .orElseThrow(
                 () -> new IllegalStateException(
@@ -168,8 +168,60 @@ public final class XmlNode {
      * Get all child nodes.
      * @return Child nodes.
      */
-    Stream<XmlNode> children() {
+    public Stream<XmlNode> children() {
         return this.objects().map(XmlNode::new);
+    }
+
+    /**
+     * Retrieve node text content.
+     * @return Text content.
+     */
+    public String text() {
+        return this.node.getTextContent();
+    }
+
+    /**
+     * Get attribute.
+     * @param name Attribute name.
+     * @return Attribute.
+     */
+    public Optional<String> attribute(final String name) {
+        final Optional<String> result;
+        final NamedNodeMap attrs = this.node.getAttributes();
+        if (attrs == null) {
+            result = Optional.empty();
+        } else {
+            result = Optional.ofNullable(attrs.getNamedItem(name)).map(Node::getTextContent);
+        }
+        return result;
+    }
+
+    /**
+     * Check if attribute exists.
+     * @param name Attribute name.
+     * @param value Attribute value.
+     * @return True if attribute with specified value exists.
+     */
+    public boolean hasAttribute(final String name, final String value) {
+        return this.attribute(name)
+            .map(String::valueOf)
+            .map(val -> val.equals(value))
+            .orElse(false);
+    }
+
+    /**
+     * Append entry to the end of the node.
+     * @param entry Entry.
+     */
+    public void append(final XmlNode entry) {
+        this.node.appendChild(this.node.getOwnerDocument().adoptNode(entry.node.cloneNode(true)));
+    }
+
+    /**
+     * Remove this node from parent.
+     */
+    public void erase() {
+        this.node.getParentNode().removeChild(this.node);
     }
 
     /**
@@ -195,48 +247,11 @@ public final class XmlNode {
     }
 
     /**
-     * Retrieve node text content.
-     * @return Text content.
-     */
-    String text() {
-        return this.node.getTextContent();
-    }
-
-    /**
-     * Get attribute.
-     * @param name Attribute name.
-     * @return Attribute.
-     */
-    Optional<String> attribute(final String name) {
-        final Optional<String> result;
-        final NamedNodeMap attrs = this.node.getAttributes();
-        if (attrs == null) {
-            result = Optional.empty();
-        } else {
-            result = Optional.ofNullable(attrs.getNamedItem(name)).map(Node::getTextContent);
-        }
-        return result;
-    }
-
-    /**
      * Convert to XML document.
      * @return XML document.
      */
     XMLDocument asDocument() {
         return new XMLDocument(this.node);
-    }
-
-    /**
-     * Check if attribute exists.
-     * @param name Attribute name.
-     * @param value Attribute value.
-     * @return True if attribute with specified value exists.
-     */
-    boolean hasAttribute(final String name, final String value) {
-        return this.attribute(name)
-            .map(String::valueOf)
-            .map(val -> val.equals(value))
-            .orElse(false);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -81,7 +81,7 @@ public final class XmlProgram {
      * Find top-level class.
      * @return Class.
      */
-    XmlClass top() {
+    public XmlClass top() {
         return new XmlNode(this.root)
             .child(XmlProgram.PROGRAM)
             .child("objects")

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import java.util.List;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodProperties;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -80,6 +81,46 @@ class XmlMethodTest {
             Matchers.equalTo(
                 new BytecodeMethodProperties(access, name, descriptor, null, exceptions)
             )
+        );
+    }
+
+    @Test
+    void createsMethodWithoutInstructions() {
+        MatcherAssert.assertThat(
+            "Method instructions are not empty",
+            new XmlMethod().instructions(),
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    void addsInstructions() {
+        final XmlMethod method = new XmlMethod();
+        final XmlInstruction instruction = new XmlInstruction(Opcodes.LDC, "Bye world!");
+        method.replaceInstructions(instruction.toNode());
+        final List<XmlBytecodeEntry> after = method.instructions();
+        MatcherAssert.assertThat(
+            "Exactly one instruction should be added",
+            after,
+            Matchers.contains(instruction)
+        );
+    }
+
+    @Test
+    void replacesInstructions() {
+        final XmlMethod method = new XmlMethod();
+        method.replaceInstructions(new XmlInstruction(Opcodes.LDC, "Bye world!").toNode());
+        final XmlInstruction first = new XmlInstruction(Opcodes.INVOKESPECIAL, 1);
+        final XmlInstruction second = new XmlInstruction(Opcodes.INVOKEVIRTUAL, 2);
+        method.replaceInstructions(
+            first.toNode(),
+            second.toNode()
+        );
+        final List<XmlBytecodeEntry> after = method.instructions();
+        MatcherAssert.assertThat(
+            "Exactly two instruction should be added",
+            after,
+            Matchers.containsInAnyOrder(first, second)
         );
     }
 }


### PR DESCRIPTION
I temporary allowed `XmlMethod.replaceInstruction` mutations. Now we can set any instructions (and xml nodes) instead of original
insturctions. This method mutates the original XML node, which is DANGAROUS. Thus I left the puzzle to fix it in the future.

Closes: #350.
____
History:
- feat(#350): open some useful methods
- feat(#350): add implementation for intructions replement
- feat(#350): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Made the `top()` method in `XmlProgram` public.
- Made the `operand()` method in `DirectivesMethod` public.
- Made the `properties()` method in `XmlClass` public.
- Made the `constructors()`, `methods()`, and `fields()` methods in `XmlClass` public.
- Added the `opcode()` and `operands()` methods in `XmlInstruction`.
- Added the `toNode()` method in `XmlInstruction`.
- Made the `child()`, `optchild()`, `firstChild()`, `children()`, `attribute()`, and `text()` methods in `XmlNode` public.
- Added the `append()` and `erase()` methods in `XmlNode`.
- Added the `toClass()` and `toCommand()` methods in `XmlNode`.
- Made the `asDocument()` method in `XmlNode` public.
- Added tests for `XmlMethod` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->