### PR TITLE
feat(#355): Add More Informative Exception Messages

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -146,23 +146,31 @@ public final class BytecodeClass {
      * @return Bytecode.
      */
     public Bytecode bytecode() {
-        this.props.write(this.writer, this.name);
-        this.methods.forEach(BytecodeMethod::write);
-        this.writer.visitEnd();
-        final byte[] bytes = this.writer.toByteArray();
         try {
+            this.props.write(this.writer, this.name);
+            this.methods.forEach(BytecodeMethod::write);
+            this.writer.visitEnd();
+            final byte[] bytes = this.writer.toByteArray();
             CheckClassAdapter.verify(
                 new ClassReader(bytes),
                 false,
                 new PrintWriter(System.err)
             );
+            return new Bytecode(bytes);
         } catch (final IllegalArgumentException exception) {
             throw new IllegalArgumentException(
                 String.format("Can't create bytecode for the class '%s' ", this.name),
                 exception
             );
+        } catch (final IllegalStateException exception) {
+            throw new IllegalStateException(
+                String.format(
+                    "Bytecode creation for the '%s' class is not possible due to unmet preconditions.",
+                    this.name
+                ),
+                exception
+            );
         }
-        return new Bytecode(bytes);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionEntry.java
@@ -661,9 +661,7 @@ final class BytecodeInstructionEntry implements BytecodeEntry {
                     return instruction;
                 }
             }
-            throw new IllegalStateException(
-                String.format("Unexpected instruction with opcode: %d", opcode)
-            );
+            throw new UnrecognizedOpcode(opcode);
         }
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionEntry.java
@@ -82,6 +82,20 @@ final class BytecodeInstructionEntry implements BytecodeEntry {
     private enum Instruction {
 
         /**
+         * Do nothing.
+         */
+        NOP(Opcodes.NOP, (visitor, arguments) ->
+            visitor.visitInsn(Opcodes.NOP)
+        ),
+
+        /**
+         * Push null.
+         */
+        ACONST_NULL(Opcodes.ACONST_NULL, (visitor, arguments) ->
+            visitor.visitInsn(Opcodes.ACONST_NULL)
+        ),
+
+        /**
          * Load the int value 0 onto the stack.
          */
         ICONST_0(Opcodes.ICONST_0, (visitor, arguments) ->
@@ -121,6 +135,41 @@ final class BytecodeInstructionEntry implements BytecodeEntry {
          */
         ICONST_5(Opcodes.ICONST_5, (visitor, arguments) ->
             visitor.visitInsn(Opcodes.ICONST_5)
+        ),
+
+        /**
+         * Load the long value 0 onto the stack.
+         */
+        LCONST_0(Opcodes.LCONST_0, (visitor, arguments) ->
+            visitor.visitInsn(Opcodes.LCONST_0)
+        ),
+
+        /**
+         * Load the long value 1 onto the stack.
+         */
+        LCONST_1(Opcodes.LCONST_1, (visitor, arguments) ->
+            visitor.visitInsn(Opcodes.LCONST_1)
+        ),
+
+        /**
+         * Load the float value 0 onto the stack.
+         */
+        FCONST_0(Opcodes.FCONST_0, (visitor, arguments) ->
+            visitor.visitInsn(Opcodes.FCONST_0)
+        ),
+
+        /**
+         * Load the float value 1 onto the stack.
+         */
+        FCONST_1(Opcodes.FCONST_1, (visitor, arguments) ->
+            visitor.visitInsn(Opcodes.FCONST_1)
+        ),
+
+        /**
+         * Load the float value 2 onto the stack.
+         */
+        FCONST_2(Opcodes.FCONST_2, (visitor, arguments) ->
+            visitor.visitInsn(Opcodes.FCONST_2)
         ),
 
         /**
@@ -251,6 +300,27 @@ final class BytecodeInstructionEntry implements BytecodeEntry {
          */
         ISTORE(Opcodes.ISTORE, (visitor, arguments) ->
             visitor.visitVarInsn(Opcodes.ISTORE, (int) arguments.get(0))
+        ),
+
+        /**
+         * Store long value into variable #index.
+         */
+        LSTORE(Opcodes.LSTORE, (visitor, arguments) ->
+            visitor.visitVarInsn(Opcodes.LSTORE, (int) arguments.get(0))
+        ),
+
+        /**
+         * Store float value into variable #index.
+         */
+        FSTORE(Opcodes.FSTORE, (visitor, arguments) ->
+            visitor.visitVarInsn(Opcodes.FSTORE, (int) arguments.get(0))
+        ),
+
+        /**
+         * Store double value into variable #index.
+         */
+        DSTORE(Opcodes.DSTORE, (visitor, arguments) ->
+            visitor.visitVarInsn(Opcodes.DSTORE, (int) arguments.get(0))
         ),
 
         /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -147,6 +147,14 @@ public final class BytecodeMethod {
                 ),
                 exception
             );
+        } catch (final UnrecognizedOpcode exception) {
+            throw new IllegalStateException(
+                String.format(
+                    "Failed to write method %s, because some of the opcodes are not recognized",
+                    this.properties
+                ),
+                exception
+            );
         }
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/UnrecognizedOpcode.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/UnrecognizedOpcode.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.bytecode;
+
+/**
+ * Unrecognized opcode.
+ * @since 0.1
+ */
+public final class UnrecognizedOpcode extends IllegalStateException {
+
+    /**
+     * Serial version UID.
+     */
+    private static final long serialVersionUID = 28L;
+
+    /**
+     * Constructor.
+     * @param opcode Opcode.
+     */
+    public UnrecognizedOpcode(final int opcode) {
+        super(String.format("Unrecognized opcode: %d", opcode));
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -49,6 +49,28 @@ class BytecodeClassTest {
     }
 
     @Test
+    void createsConstructorWithStoreInstructions() {
+        Assertions.assertDoesNotThrow(
+            () -> new BytecodeClass("Store")
+                .withConstructor()
+                .opcode(Opcodes.ICONST_0)
+                .opcode(Opcodes.ISTORE, 1)
+                .opcode(Opcodes.LCONST_0)
+                .opcode(Opcodes.LSTORE, 2)
+                .opcode(Opcodes.FCONST_0)
+                .opcode(Opcodes.FSTORE, 3)
+                .opcode(Opcodes.DCONST_0)
+                .opcode(Opcodes.DSTORE, 4)
+                .opcode(Opcodes.ACONST_NULL)
+                .opcode(Opcodes.ASTORE, 5)
+                .opcode(Opcodes.RETURN)
+                .up()
+                .bytecode(),
+            "We expect no exception here because all instructions are valid"
+        );
+    }
+
+    @Test
     void createsBytecodeWithDefaultConstructor() {
         MatcherAssert.assertThat(
             "Can't create bytecode with default public constructor",

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.bytecode;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 
@@ -57,6 +58,25 @@ class BytecodeClassTest {
                 .up()
                 .bytecode(),
             Matchers.notNullValue()
+        );
+    }
+
+    @Test
+    void createsClassWithUnknownInstruction() {
+        MatcherAssert.assertThat(
+            "Exception message is not equal to expected",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> new BytecodeClass("UnknownInstruction")
+                    .withConstructor()
+                    .opcode(305)
+                    .up()
+                    .bytecode(),
+                "We expect an exception here because 305 is not a valid opcode"
+            ).getMessage(),
+            Matchers.equalTo(
+                "Bytecode creation for the 'UnknownInstruction' class is not possible due to unmet preconditions."
+            )
         );
     }
 }


### PR DESCRIPTION
Add context if some opcode wasn't recognized.

Closes: #355.
_____
History:
- feat(#355): add careful exception handling if opcode is not recognized
- feat(#355): add const instructions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving error handling and exception messages in the BytecodeClass and BytecodeMethod classes. 

### Detailed summary
- Added a catch block to handle UnrecognizedOpcode exception in BytecodeMethod class
- Added error handling and exception messages in BytecodeClass class
- Added a new UnrecognizedOpcode class to represent the exception for unrecognized opcodes
- Updated the tests to cover the new error handling and exception messages

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->