### PR TITLE
feat(#363): update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
-      <version>0.33.0</version>
+      <version>0.34.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.volodya-lombrozo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-util</artifactId>
-      <version>9.5</version>
+      <version>9.6</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -27,7 +27,13 @@ SOFTWARE.
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.0</version>
+    <!--
+      The version of 3.2.0 and similar requires rather high java
+      version: 17 or higher. So we intentionally use the version 2.7.18
+      here that requires java 11 since our plugin should be compatible with
+      java 11.
+    -->
+    <version>2.7.18</version>
     <relativePath/>
   </parent>
   <groupId>org.eolang</groupId>

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.18</version>
+    <version>3.2.0</version>
     <relativePath/>
   </parent>
   <groupId>org.eolang</groupId>

--- a/src/test/java/it/EoSource.java
+++ b/src/test/java/it/EoSource.java
@@ -24,14 +24,9 @@
 package it;
 
 import com.jcabi.xml.XML;
-import com.jcabi.xml.XMLDocument;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-import org.cactoos.Output;
 import org.cactoos.io.ResourceOf;
 import org.eolang.parser.EoSyntax;
-import org.eolang.parser.Syntax;
 
 /**
  * EO source.
@@ -59,54 +54,12 @@ final class EoSource {
      */
     XML parse() {
         try {
-            final ResourceOf eolang = new ResourceOf(this.resource);
-            final XmlOutput output = new XmlOutput();
-            return new EoSyntax("scenario", eolang).parsed();
+            return new EoSyntax("scenario", new ResourceOf(this.resource)).parsed();
         } catch (final IOException exception) {
             throw new IllegalStateException(
                 String.format("Can't parse '%s'", this.resource),
                 exception
             );
-        }
-    }
-
-    /**
-     * XML output.
-     * @since 0.1.0
-     */
-    private static final class XmlOutput implements Output {
-
-        /**
-         * Output stream.
-         */
-        private final ByteArrayOutputStream baos;
-
-        /**
-         * Constructor.
-         */
-        private XmlOutput() {
-            this(new ByteArrayOutputStream());
-        }
-
-        /**
-         * Constructor.
-         * @param baos Output stream.
-         */
-        private XmlOutput(final ByteArrayOutputStream baos) {
-            this.baos = baos;
-        }
-
-        @Override
-        public OutputStream stream() {
-            return this.baos;
-        }
-
-        /**
-         * Convert to XML.
-         * @return XML.
-         */
-        XML xml() {
-            return new XMLDocument(this.baos.toByteArray());
         }
     }
 }

--- a/src/test/java/it/EoSource.java
+++ b/src/test/java/it/EoSource.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import org.cactoos.Output;
 import org.cactoos.io.ResourceOf;
+import org.eolang.parser.EoSyntax;
 import org.eolang.parser.Syntax;
 
 /**
@@ -60,8 +61,7 @@ final class EoSource {
         try {
             final ResourceOf eolang = new ResourceOf(this.resource);
             final XmlOutput output = new XmlOutput();
-            new Syntax("scenario", eolang, output).parse();
-            return output.xml();
+            return new EoSyntax("scenario", eolang).parsed();
         } catch (final IOException exception) {
             throw new IllegalStateException(
                 String.format("Can't parse '%s'", this.resource),


### PR DESCRIPTION
Update three dependencies and remove redundant code.

Closes: #363.
____
History:
- feat(#363): update org.ow2.asm:asm-util to v9.6 dependency
- feat(#363): update org.springframework.boot:spring-boot-starter-parent to v3 deps
- feat(#363): update org.eolang:eo-parser to v0.34.1 dependency
- feat(#363): fix all qulice suggestions

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Updated the version of `spring-boot-starter-parent` to `2.7.18` to ensure compatibility with Java 11.
- Updated the version of `asm-util` to `9.6`.
- Updated the version of `eo-parser` to `0.34.1`.
- Replaced the usage of `Syntax` class with `EoSyntax` class in `EoSource` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->