### PR TITLE
feat(#354): allow simple opcode names

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -158,6 +158,36 @@ public final class BytecodeRepresentation implements Representation {
         }
     }
 
+    public XML toEO(final boolean count) {
+        final DirectivesClassVisitor directives = new DirectivesClassVisitor(
+            new Base64Bytecode(this.input).asString()
+        );
+        try {
+            new ClassReader(this.input).accept(directives, 0);
+            final XMLDocument res = new XMLDocument(new Xembler(directives).xml());
+            new Schema(res).check();
+            return res;
+        } catch (final IllegalStateException exception) {
+            throw new IllegalStateException(
+                String.format(
+                    "Something went wrong during transformation %s into XML by using directives",
+                    this.className(),
+                    directives
+                ),
+                exception
+            );
+        } catch (final ImpossibleModificationException exception) {
+            throw new IllegalStateException(
+                String.format(
+                    "Can't build XML from %s by using directives %s",
+                    Arrays.toString(this.input),
+                    directives
+                ),
+                exception
+            );
+        }
+    }
+
     @Override
     public Bytecode toBytecode() {
         return new Bytecode(new UncheckedBytes(new BytesOf(this.input)).asBytes());

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -160,7 +160,8 @@ public final class BytecodeRepresentation implements Representation {
 
     public XML toEO(final boolean count) {
         final DirectivesClassVisitor directives = new DirectivesClassVisitor(
-            new Base64Bytecode(this.input).asString()
+            new Base64Bytecode(this.input).asString(),
+            count
         );
         try {
             new ClassReader(this.input).accept(directives, 0);

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -129,35 +129,14 @@ public final class BytecodeRepresentation implements Representation {
 
     @Override
     public XML toEO() {
-        final DirectivesClassVisitor directives = new DirectivesClassVisitor(
-            new Base64Bytecode(this.input).asString()
-        );
-        try {
-            new ClassReader(this.input).accept(directives, 0);
-            final XMLDocument res = new XMLDocument(new Xembler(directives).xml());
-            new Schema(res).check();
-            return res;
-        } catch (final IllegalStateException exception) {
-            throw new IllegalStateException(
-                String.format(
-                    "Something went wrong during transformation %s into XML by using directives",
-                    this.className(),
-                    directives
-                ),
-                exception
-            );
-        } catch (final ImpossibleModificationException exception) {
-            throw new IllegalStateException(
-                String.format(
-                    "Can't build XML from %s by using directives %s",
-                    Arrays.toString(this.input),
-                    directives
-                ),
-                exception
-            );
-        }
+        return this.toEO(true);
     }
 
+    /**
+     * Converts bytecode into XML.
+     * @param count Do we add number to opcode name or not?
+     * @return XML representation of bytecode.
+     */
     public XML toEO(final boolean count) {
         final DirectivesClassVisitor directives = new DirectivesClassVisitor(
             new Base64Bytecode(this.input).asString(),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -90,7 +90,7 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
      * @param api ASM API version.
      * @param program Program directives.
      */
-    public DirectivesClassVisitor(int api, String program) {
+    public DirectivesClassVisitor(final int api, final String program) {
         this(api, program, true);
     }
 
@@ -98,6 +98,7 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
      * Constructor.
      * @param api ASM API version.
      * @param listing Bytecode listing.
+     * @param counting Opcodes counting.
      */
     private DirectivesClassVisitor(
         final int api,
@@ -114,9 +115,9 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
      * @param counting Opcodes counting.
      */
     public DirectivesClassVisitor(
-        int api,
-        DirectivesProgram program,
-        boolean counting
+        final int api,
+        final DirectivesProgram program,
+        final boolean counting
     ) {
         super(api);
         this.program = program;

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -57,6 +57,11 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
     private final DirectivesProgram program;
 
     /**
+     * Opcodes counting.
+     */
+    private final boolean counting;
+
+    /**
      * Constructor.
      */
     DirectivesClassVisitor() {
@@ -73,15 +78,49 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
 
     /**
      * Constructor.
+     * @param listing Bytecode listing.
+     * @param counting Opcodes counting.
+     */
+    public DirectivesClassVisitor(final String listing, final boolean counting) {
+        this(new DefaultVersion().api(), listing, counting);
+    }
+
+    /**
+     * Constructor.
+     * @param api ASM API version.
+     * @param program Program directives.
+     */
+    public DirectivesClassVisitor(int api, String program) {
+        this(api, program, true);
+    }
+
+    /**
+     * Constructor.
      * @param api ASM API version.
      * @param listing Bytecode listing.
      */
     private DirectivesClassVisitor(
         final int api,
-        final String listing
+        final String listing,
+        final boolean counting
+    ) {
+        this(api, new DirectivesProgram(listing), counting);
+    }
+
+    /**
+     * Constructor.
+     * @param api ASM API version.
+     * @param program Program directives.
+     * @param counting Opcodes counting.
+     */
+    public DirectivesClassVisitor(
+        int api,
+        DirectivesProgram program,
+        boolean counting
     ) {
         super(api);
-        this.program = new DirectivesProgram(listing);
+        this.program = program;
+        this.counting = counting;
     }
 
     @Override
@@ -120,6 +159,7 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
         final String ename = new JavaName(name).encode();
         final DirectivesMethod method = new DirectivesMethod(
             ename,
+            this.counting,
             new DirectivesMethodProperties(access, descriptor, signature, exceptions)
         );
         this.program.top().method(method);

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
@@ -47,12 +47,33 @@ public final class DirectivesInstruction implements Iterable<Directive> {
     private final Object[] arguments;
 
     /**
+     * Opcodes counting.
+     * Do we add number to opcode name or not?
+     * if true then we add number to opcode name:
+     *   RETURN -> RETURN-1
+     * if false then we do not add number to opcode name:
+     *   RETURN -> RETURN
+     */
+    private final boolean counting;
+
+    /**
      * Constructor.
      * @param opcode Opcode
      * @param arguments Instruction arguments
      */
     public DirectivesInstruction(final int opcode, final Object... arguments) {
+        this(opcode, true, arguments);
+    }
+
+    /**
+     * Constructor.
+     * @param opcode Opcode
+     * @param counting Opcodes counting
+     * @param arguments Instruction arguments
+     */
+    public DirectivesInstruction(int opcode, boolean counting, Object... arguments) {
         this.opcode = opcode;
+        this.counting = counting;
         this.arguments = arguments.clone();
     }
 
@@ -61,7 +82,7 @@ public final class DirectivesInstruction implements Iterable<Directive> {
         try {
             final Directives directives = new Directives();
             directives.add("o")
-                .attr("name", new OpcodeName(this.opcode).asString())
+                .attr("name", this.name())
                 .attr("base", "opcode");
             directives.append(new DirectivesOperand(this.opcode));
             for (final Object operand : this.arguments) {
@@ -73,11 +94,25 @@ public final class DirectivesInstruction implements Iterable<Directive> {
             throw new IllegalStateException(
                 String.format(
                     "Failed to convert instruction %s with arguments %s to xembly directives",
-                    new OpcodeName(this.opcode).simplified(),
+                    this.name(),
                     Arrays.toString(this.arguments)
                 ),
                 exception
             );
         }
+    }
+
+    /**
+     * Get opcode name.
+     * @return Opcode name.
+     */
+    private String name() {
+        final String result;
+        if (this.counting) {
+            result = new OpcodeName(this.opcode).asString();
+        } else {
+            result = new OpcodeName(this.opcode).simplified();
+        }
+        return result;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
@@ -71,7 +71,11 @@ public final class DirectivesInstruction implements Iterable<Directive> {
      * @param counting Opcodes counting
      * @param arguments Instruction arguments
      */
-    public DirectivesInstruction(int opcode, boolean counting, Object... arguments) {
+    public DirectivesInstruction(
+        final int opcode,
+        final boolean counting,
+        final Object... arguments
+    ) {
         this.opcode = opcode;
         this.counting = counting;
         this.arguments = arguments.clone();

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -56,6 +56,11 @@ public final class DirectivesMethod implements Iterable<Directive> {
     private final List<Iterable<Directive>> exceptions;
 
     /**
+     * Opcodes counting.
+     */
+    private final boolean counting;
+
+    /**
      * Constructor.
      * @param name Method name
      */
@@ -69,8 +74,23 @@ public final class DirectivesMethod implements Iterable<Directive> {
      * @param properties Method properties
      */
     public DirectivesMethod(final String name, final DirectivesMethodProperties properties) {
+        this(name, true, properties);
+    }
+
+    /**
+     * Constructor.
+     * @param name Method name
+     * @param counting Opcodes counting
+     * @param properties Method properties
+     */
+    public DirectivesMethod(
+        final String name,
+        final boolean counting,
+        final DirectivesMethodProperties properties
+    ) {
         this.name = name;
         this.properties = properties;
+        this.counting = counting;
         this.instructions = new ArrayList<>(0);
         this.exceptions = new ArrayList<>(0);
     }
@@ -82,7 +102,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
      * @return This object
      */
     public DirectivesMethod opcode(final int opcode, final Object... operands) {
-        this.instructions.add(new DirectivesInstruction(opcode, operands));
+        this.instructions.add(new DirectivesInstruction(opcode, this.counting, operands));
         return this;
     }
 

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation.bytecode;
 
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XML;
-import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.BytecodeRepresentation;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -108,18 +108,22 @@ class BytecodeClassTest {
 
     @Test
     void transformsBytecodeIntoEoWithoutCountingOpcodes() {
+        final XML xmir = new BytecodeRepresentation(
+            new BytecodeClass("Hello")
+                .helloWorldMethod()
+                .bytecode()
+        ).toEO(false);
         MatcherAssert.assertThat(
-            "We expect to get the EO representation of the bytecode where each instruction has a simple name without sequence number",
-            new BytecodeRepresentation(
-                new BytecodeClass("Hello")
-                    .helloWorldMethod()
-                    .bytecode()
-            ).toEO(false).toString(),
+            String.format(
+                "We expect to get the EO representation of the bytecode where each instruction has a simple name without sequence number, please check the final XML:%n%s%n",
+                xmir
+            ),
+            xmir.toString(),
             XhtmlMatchers.hasXPaths(
-                "../o[@base='opcode' and @name='GETSTATIC']",
-                "../o[@base='opcode' and @name='LDC']",
-                "../o[@base='opcode' and @name='INVOKEVIRTUAL']",
-                "../o[@base='opcode' and @name='RETURN']"
+                "//o[@base='opcode' and @name='GETSTATIC']",
+                "//o[@base='opcode' and @name='LDC']",
+                "//o[@base='opcode' and @name='INVOKEVIRTUAL']",
+                "//o[@base='opcode' and @name='RETURN']"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -23,6 +23,10 @@
  */
 package org.eolang.jeo.representation.bytecode;
 
+import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import org.eolang.jeo.representation.BytecodeRepresentation;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -98,6 +102,24 @@ class BytecodeClassTest {
             ).getMessage(),
             Matchers.equalTo(
                 "Bytecode creation for the 'UnknownInstruction' class is not possible due to unmet preconditions."
+            )
+        );
+    }
+
+    @Test
+    void transformsBytecodeIntoEoWithoutCountingOpcodes() {
+        MatcherAssert.assertThat(
+            "We expect to get the EO representation of the bytecode where each instruction has a simple name without sequence number",
+            new BytecodeRepresentation(
+                new BytecodeClass("Hello")
+                    .helloWorldMethod()
+                    .bytecode()
+            ).toEO(false).toString(),
+            XhtmlMatchers.hasXPaths(
+                "../o[@base='opcode' and @name='GETSTATIC']",
+                "../o[@base='opcode' and @name='LDC']",
+                "../o[@base='opcode' and @name='INVOKEVIRTUAL']",
+                "../o[@base='opcode' and @name='RETURN']"
             )
         );
     }


### PR DESCRIPTION
Allow simple names during bytecode -> eo transformation.

We used to generate opcode names with the number:
```eo
opcode > RETURN-1
```
Now we can generate opcode names without the number:
```eo
opcode > RETURN
```

Closes: #354.
____
History:
- feat(#354): add the test for the future implementation
- feat(#354): add counting flag to several classes
- feat(#354): fix the test
- feat(#354): refactor the solution


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the ability to convert bytecode into XML representation with or without counting opcode numbers. 

### Detailed summary
- Added `toEO(boolean count)` method in `BytecodeRepresentation` class to convert bytecode into XML representation with or without counting opcode numbers.
- Added a new test case in `BytecodeClassTest` to verify the XML representation without counting opcode numbers.
- Added `counting` field in `DirectivesMethod` and `DirectivesClassVisitor` classes to control opcode counting.
- Modified constructors in `DirectivesMethod` and `DirectivesClassVisitor` classes to accept `counting` parameter.
- Modified `opcode` method in `DirectivesMethod` class to pass `counting` parameter to `DirectivesInstruction` constructor.
- Added `counting` field in `DirectivesInstruction` class to control opcode counting.
- Modified `iterator` method in `DirectivesInstruction` class to use `name` method to get opcode name based on `counting` field.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->