### PR TITLE
feat(#390): Hide trycatchblocks directive 

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -135,11 +135,13 @@ public final class DirectivesMethod implements Iterable<Directive> {
         this.instructions.forEach(directives::append);
         directives.up();
         directives.up();
-        directives.add("o")
-            .attr("base", "tuple")
-            .attr("name", "trycatchblocks");
-        this.exceptions.forEach(directives::append);
-        directives.up();
+        if (!this.exceptions.isEmpty()) {
+            directives.add("o")
+                .attr("base", "tuple")
+                .attr("name", "trycatchblocks");
+            this.exceptions.forEach(directives::append);
+            directives.up();
+        }
         directives.up();
         return directives.iterator();
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
@@ -30,6 +30,7 @@ import org.eolang.jeo.representation.bytecode.BytecodeMethodProperties;
 import org.eolang.jeo.representation.bytecode.BytecodeTryCatchBlock;
 import org.eolang.jeo.representation.xmir.AllLabels;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Label;
@@ -356,6 +357,15 @@ class DirectivesMethodVisitorTest {
             new HasMethod("bar")
                 .inside("Foo")
                 .withTryCatch("java/lang/Exception")
+        );
+    }
+
+    @Test
+    void doesNotContainTryCatchBlock() {
+        MatcherAssert.assertThat(
+            "We expect that method without try-catch block doesn't contain try-catch directives.",
+            new BytecodeClass().helloWorldMethod().xml().toString(),
+            Matchers.not(Matchers.containsString("trycatchblocks"))
         );
     }
 }


### PR DESCRIPTION
Hide `trycatchblocks` directives from final XMIR if a method doesn't have any try-catch blocks.

Closes: #390.
____
History:
- feat(#390): add trycatchblocks only if not empty
- feat(#390): add unit test
