### PR TITLE
feat(#387): Rename goals `assemble/disassemble`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ optimized performance.
 The plugin can be run using several approaches but for all of them you need
 at least Maven 3.1.+ and Java 11+.
 The plugin can convert compiled classes into EOlang by using
-the `bytecode-to-eo` goal. The `eo-to-bytecode` goal can convert EOlang back
+the `disassemble` goal. The `assemble` goal can convert EOlang back
 into bytecode. The default phase for the plugin
 is [process-classes](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle).
 If you are a developer of optimizations in EOlang you probably need to
 use the both goals in the following order:
 
-* `bytecode-to-eo` create EOlang files in the `target/generated-sources`
+* `disassemble` create EOlang files in the `target/generated-sources`
   directory.
 * Provide your optimizations are applied to the EOlang files
   in the `target/generated-sources` directory.
-* `eo-to-bytecode` scans the `target/generated-sources` directory for EOlang
+* `assemble` scans the `target/generated-sources` directory for EOlang
   files and converts them back to Java bytecode.
 
 More details about plugin usage you can find in our
@@ -42,13 +42,13 @@ You can run the plugin directly from the command line using the following
 commands:
 
 ```bash
-mvn jeo:bytecode-to-eo
+mvn jeo:disassemble
 ```
 
 or
 
 ```bash
-mvn jeo:eo-to-bytecode
+mvn jeo:assemble
 ```
 
 ## Invoke the plugin from the Maven lifecycle
@@ -69,14 +69,14 @@ configuration to your `pom.xml` file:
           <id>bytecode-to-eo</id>
           <phase>process-classes</phase>
           <goals>
-            <goal>bytecode-to-eo</goal>
+            <goal>disassemble</goal>
           </goals>
         </execution>
         <execution>
           <id>eo-to-bytecode</id>
           <phase>process-classes</phase>
           <goals>
-            <goal>eo-to-bytecode</goal>
+            <goal>assemble</goal>
           </goals>
         </execution>
       </executions>

--- a/src/it/bytecode-to-eo/pom.xml
+++ b/src/it/bytecode-to-eo/pom.xml
@@ -47,7 +47,7 @@ SOFTWARE.
           <execution>
             <id>bytecode-to-eo</id>
             <goals>
-              <goal>bytecode-to-eo</goal>
+              <goal>disassemble</goal>
             </goals>
           </execution>
           <!--
@@ -61,7 +61,7 @@ SOFTWARE.
           <execution>
             <id>bytecode-to-eo-second-time</id>
             <goals>
-              <goal>bytecode-to-eo</goal>
+              <goal>disassemble</goal>
             </goals>
           </execution>
         </executions>

--- a/src/it/custom-transformations/pom.xml
+++ b/src/it/custom-transformations/pom.xml
@@ -49,13 +49,13 @@ SOFTWARE.
           <execution>
             <id>bytecode-to-eo</id>
             <goals>
-              <goal>bytecode-to-eo</goal>
+              <goal>disassemble</goal>
             </goals>
           </execution>
           <execution>
             <id>eo-to-bytecode</id>
             <goals>
-              <goal>eo-to-bytecode</goal>
+              <goal>assemble</goal>
             </goals>
           </execution>
         </executions>

--- a/src/it/eo-to-bytecode/pom.xml
+++ b/src/it/eo-to-bytecode/pom.xml
@@ -47,7 +47,7 @@ SOFTWARE.
           <execution>
             <id>eo-to-bytecode</id>
             <goals>
-              <goal>eo-to-bytecode</goal>
+              <goal>assemble</goal>
             </goals>
           </execution>
           <!--
@@ -61,7 +61,7 @@ SOFTWARE.
           <execution>
             <id>eo-to-bytecode-second-time</id>
             <goals>
-              <goal>eo-to-bytecode</goal>
+              <goal>assemble</goal>
             </goals>
           </execution>
         </executions>

--- a/src/it/exceptions/pom.xml
+++ b/src/it/exceptions/pom.xml
@@ -67,13 +67,13 @@ SOFTWARE.
           <execution>
             <id>bytecode-to-eo</id>
             <goals>
-              <goal>bytecode-to-eo</goal>
+              <goal>disassemble</goal>
             </goals>
           </execution>
           <execution>
             <id>eo-to-bytecode</id>
             <goals>
-              <goal>eo-to-bytecode</goal>
+              <goal>assemble</goal>
             </goals>
           </execution>
         </executions>

--- a/src/it/exceptions/verify.groovy
+++ b/src/it/exceptions/verify.groovy
@@ -54,13 +54,13 @@ assert log.contains("Exception during closing resource")
  *     <execution>
  *       <id>bytecode-to-eo</id>
  *       <goals>
- *         <goal>bytecode-to-eo</goal>
+ *         <goal>disassemble</goal>
  *       </goals>
  *     </execution>
  *     <execution>
  *       <id>eo-to-bytecode</id>
  *       <goals>
- *         <goal>eo-to-bytecode</goal>
+ *         <goal>assemble</goal>
  *       </goals>
  *     </execution>
  *   </executions>

--- a/src/it/generics/pom.xml
+++ b/src/it/generics/pom.xml
@@ -49,13 +49,13 @@ SOFTWARE.
           <execution>
             <id>bytecode-to-eo</id>
             <goals>
-              <goal>bytecode-to-eo</goal>
+              <goal>disassemble</goal>
             </goals>
           </execution>
           <execution>
             <id>eo-to-bytecode</id>
             <goals>
-              <goal>eo-to-bytecode</goal>
+              <goal>assemble</goal>
             </goals>
           </execution>
         </executions>

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -68,13 +68,13 @@ SOFTWARE.
           <execution>
             <id>bytecode-to-eo</id>
             <goals>
-              <goal>bytecode-to-eo</goal>
+              <goal>disassemble</goal>
             </goals>
           </execution>
           <execution>
             <id>eo-to-bytecode</id>
             <goals>
-              <goal>eo-to-bytecode</goal>
+              <goal>assemble</goal>
             </goals>
           </execution>
         </executions>

--- a/src/it/takes/pom.xml
+++ b/src/it/takes/pom.xml
@@ -57,13 +57,13 @@ SOFTWARE.
           <execution>
             <id>bytecode-to-eo</id>
             <goals>
-              <goal>bytecode-to-eo</goal>
+              <goal>disassemble</goal>
             </goals>
           </execution>
           <execution>
             <id>eo-to-bytecode</id>
             <goals>
-              <goal>eo-to-bytecode</goal>
+              <goal>assemble</goal>
             </goals>
           </execution>
         </executions>

--- a/src/it/takes/verify.groovy
+++ b/src/it/takes/verify.groovy
@@ -49,13 +49,13 @@ assert log.contains("Request time: ")
  *     <execution>
  *       <id>bytecode-to-eo</id>
  *       <goals>
- *         <goal>bytecode-to-eo</goal>
+ *         <goal>disassemble</goal>
  *       </goals>
  *     </execution>
  *     <execution>
  *       <id>eo-to-bytecode</id>
  *       <goals>
- *         <goal>eo-to-bytecode</goal>
+ *         <goal>assemble</goal>
  *       </goals>
  *     </execution>
  *   </executions>

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementEoFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementEoFootprint.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import org.eolang.jeo.DisassembleMojo;
 import org.eolang.jeo.Improvement;
 import org.eolang.jeo.Representation;
 import org.eolang.jeo.representation.JavaName;
@@ -41,7 +42,7 @@ import org.eolang.parser.XMIR;
  * @since 0.1
  * @todo #215:60min Apply ImprovementEoFootprint.
  * Currently we don't use ImprovementEoFootprint. We have to add it to the next classes:
- * - {@link org.eolang.jeo.BytecodeToEoMojo}
+ * - {@link DisassembleMojo}
  * - {@link org.eolang.jeo.JeoMojo}
  * Don't forget to add checks for integration tests.
  */

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -25,14 +25,14 @@ JEO Maven Plugin
           <id>bytecode-to-eo</id>
           <phase>process-classes</phase>
           <goals>
-            <goal>bytecode-to-eo</goal>
+            <goal>disassemble</goal>
           </goals>
         </execution>
         <execution>
           <id>eo-to-bytecode</id>
           <phase>process-classes</phase>
           <goals>
-            <goal>eo-to-bytecode</goal>
+            <goal>assemble</goal>
           </goals>
         </execution>
       </executions>


### PR DESCRIPTION
Rename goals `bytecode-to-eo/eo-to-bytecode` -> `disassemble/assemble`.

Closes: #387
____
History:
- feat(#387): rename mojos
- feat(#387): use disassemble/assemble in integration tests
- feat(#387): update all docs related to goals naming


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Renamed the goals in the `pom.xml` files from `bytecode-to-eo` to `disassemble` and from `eo-to-bytecode` to `assemble`.
- Renamed the classes `BytecodeToEoMojo` to `DisassembleMojo` and `EoToBytecodeMojo` to `AssembleMojo`.
- Updated the documentation in `README.md` to reflect the changes in goal names.
- Added a reference to the `DisassembleMojo` class in `ImprovementEoFootprint.java`.

This PR focuses on renaming goals and classes related to the conversion of bytecode to EOlang and vice versa. It also updates the documentation to reflect the changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->