### PR TITLE
feat(#402): open XmlMethod nodes

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -178,6 +178,17 @@ public final class XmlMethod {
     }
 
     /**
+     * All the method instructions.
+     * @return Instructions.
+     */
+    public List<XmlNode> nodes() {
+        return this.node.child("base", "seq")
+            .child("base", "tuple")
+            .children()
+            .collect(Collectors.toList());
+    }
+
+    /**
      * Replace instructions.
      * @param entries Instructions to replace.
      * @todo #350 Remove mutable method from XmlMethod.

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
@@ -123,4 +123,20 @@ class XmlMethodTest {
             Matchers.containsInAnyOrder(first, second)
         );
     }
+
+    @Test
+    void retrievesMethodNodes() {
+        final XmlMethod method = new XmlMethod();
+        method.replaceInstructions(
+            new XmlInstruction(Opcodes.LDC, "first").toNode(),
+            new XmlInstruction(Opcodes.LDC, "second").toNode(),
+            new XmlNode("<o/>")
+        );
+        final List<XmlNode> nodes = method.nodes();
+        MatcherAssert.assertThat(
+            "Exactly three node should be added. Pay attention, that the last node is custom xml node",
+            nodes,
+            Matchers.hasSize(3)
+        );
+    }
 }


### PR DESCRIPTION
Closes: #402


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding a new method `nodes()` to the `XmlMethod` class that returns a list of XML nodes. 

### Detailed summary
- Added a new method `nodes()` to the `XmlMethod` class.
- The `nodes()` method returns a list of XML nodes.
- The method retrieves the nodes by traversing the XML structure using the `child()` and `children()` methods.
- Added a test case `retrievesMethodNodes()` to verify the functionality of the `nodes()` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->