### PR TITLE
feat(#406): correctly encode/decode label identifiers

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import com.jcabi.log.Logger;
 import com.jcabi.xml.XMLDocument;
 import java.util.ArrayList;
 import java.util.List;
@@ -161,7 +162,13 @@ public final class XmlInstruction implements XmlBytecodeEntry {
         if (attr.equals("int")) {
             result = new HexString(argument.text()).decodeAsInt();
         } else if (attr.equals("label")) {
-            result = this.labels.label(argument.text());
+            String text = argument.children().findFirst().orElseThrow().text();
+            if (!text.isEmpty()) {
+                text = new HexString(text.trim()).decode();
+            }
+//            String text =argument.text();
+            Logger.info(this, "Found label '%s'", text);
+            result = this.labels.label(text);
         } else if (attr.equals("reference")) {
             result = Type.getType(String.format("L%s;", new HexString(argument.text()).decode()));
         } else {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import com.jcabi.log.Logger;
 import com.jcabi.xml.XMLDocument;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -162,13 +162,15 @@ public final class XmlInstruction implements XmlBytecodeEntry {
         if (attr.equals("int")) {
             result = new HexString(argument.text()).decodeAsInt();
         } else if (attr.equals("label")) {
-            String text = argument.children().findFirst().orElseThrow().text();
-            if (!text.isEmpty()) {
-                text = new HexString(text.trim()).decode();
-            }
-//            String text =argument.text();
-            Logger.info(this, "Found label '%s'", text);
-            result = this.labels.label(text);
+            result = this.labels.label(
+                argument.children()
+                    .map(XmlNode::text)
+                    .map(String::trim)
+                    .map(HexString::new)
+                    .map(HexString::decode)
+                    .findFirst()
+                    .orElseThrow()
+            );
         } else if (attr.equals("reference")) {
             result = Type.getType(String.format("L%s;", new HexString(argument.text()).decode()));
         } else {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
@@ -53,6 +53,10 @@ public final class XmlLabel implements XmlBytecodeEntry {
 
     @Override
     public void writeTo(final BytecodeMethod method) {
-        method.label(this.labels.label(this.node.child("base", "string").text()));
+        method.label(
+            this.labels.label(
+                new HexString(this.node.child("base", "string").text()).decode()
+            )
+        );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
@@ -66,7 +66,9 @@ public final class XmlTryCatchEntry implements XmlBytecodeEntry {
      */
     Optional<String> label(final String name) {
         return this.xmlnode.optchild("name", name)
-            .map(node -> node.child("base", "string").text());
+            .map(node -> node.child("base", "string").text())
+            .map(HexString::new)
+            .map(HexString::decode);
     }
 
     /**


### PR DESCRIPTION
Correct encoding/decoding label identifiers.

Closes: #406
____
- feat(#406): add solution sketch
- feat(#406): refactor solution
- feat(#406): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on improving the handling of hexadecimal strings in the `XmlLabel`, `XmlTryCatchEntry`, and `XmlInstruction` classes.

### Detailed summary:
- In `XmlLabel`, the `writeTo` method now decodes the hexadecimal string before labeling.
- In `XmlTryCatchEntry`, the `label` method now decodes the hexadecimal string before returning an optional label.
- In `XmlInstruction`, the `label` method now decodes the hexadecimal string before labeling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->