### PR TITLE
feat(#418): `sourcesDir` and `outputDir` for DisassembleMojo

### DIFF
--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -55,32 +55,45 @@ public final class DisassembleMojo extends AbstractMojo {
     private MavenProject project;
 
     /**
-     * Project compiled classes.
+     * Source directory.
+     * Where to take classes from.
      *
-     * @since 0.1.0
+     * @since 0.2.0
+     * @checkstyle MemberNameCheck (6 lines)
      */
-    @Parameter(defaultValue = "${project.build.outputDirectory}")
-    private File classes;
+    @Parameter(
+        property = "jeo.disassemble.sourcesDir",
+        defaultValue = "${project.build.outputDirectory}"
+    )
+    private File sourcesDir;
 
     /**
-     * Project default target directory.
+     * Target directory.
+     * Where to save EO representations to.
      *
-     * @since 0.1.0
+     * @since 0.2.0
+     * @checkstyle MemberNameCheck (6 lines)
      */
-    @Parameter(defaultValue = "${project.build.directory}/generated-sources")
-    private File generated;
+    @Parameter(
+        property = "jeo.disassemble.outputDir",
+        defaultValue = "${project.build.directory}/generated-sources/jeo-xmir"
+    )
+    private File outputDir;
+
 
     @Override
     public void execute() throws MojoExecutionException {
         try {
             new PluginStartup(this.project).init();
-            new BytecodeTransformation(this.classes.toPath(), this.generated.toPath()).transpile();
+            new BytecodeTransformation(
+                this.sourcesDir.toPath(), this.outputDir.toPath()
+            ).transpile();
         } catch (final IOException | DependencyResolutionRequiredException exception) {
             throw new MojoExecutionException(
                 String.format(
                     "Can't transpile bytecode from '%s' to EO. Output directory: '%s'.",
-                    this.classes.toPath(),
-                    this.generated.toPath()
+                    this.sourcesDir.toPath(),
+                    this.outputDir.toPath()
                 ),
                 exception
             );

--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -80,7 +80,6 @@ public final class DisassembleMojo extends AbstractMojo {
     )
     private File outputDir;
 
-
     @Override
     public void execute() throws MojoExecutionException {
         try {

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementXmirFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementXmirFootprint.java
@@ -34,7 +34,6 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 import org.eolang.jeo.Improvement;
 import org.eolang.jeo.Representation;
-import org.eolang.jeo.XmirDefaultDirectory;
 import org.eolang.jeo.representation.EoRepresentation;
 import org.eolang.jeo.representation.JavaName;
 
@@ -63,7 +62,7 @@ public final class ImprovementXmirFootprint implements Improvement {
     public Collection<Representation> apply(
         final Collection<? extends Representation> representations
     ) {
-        Logger.info(this, "Writing .xmir files to %[file]s", this.folder());
+        Logger.info(this, "Writing .xmir files to %[file]s", this.target);
         return representations.stream()
             .map(this::transform)
             .collect(Collectors.toList());
@@ -77,7 +76,7 @@ public final class ImprovementXmirFootprint implements Improvement {
      */
     private Representation transform(final Representation representation) {
         final String name = new JavaName(representation.details().name()).decode();
-        final Path path = this.folder()
+        final Path path = this.target
             .resolve(String.format("%s.xmir", name.replace('/', File.separatorChar)));
         try {
             Files.createDirectories(path.getParent());
@@ -100,14 +99,5 @@ public final class ImprovementXmirFootprint implements Improvement {
                 exception
             );
         }
-    }
-
-    /**
-     * Folder where to save the XMIR.
-     *
-     * @return Folder where to save the XMIR.
-     */
-    private Path folder() {
-        return this.target.resolve(new XmirDefaultDirectory().toPath());
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/BytecodeTransformation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeTransformation.java
@@ -69,7 +69,7 @@ public class BytecodeTransformation {
     public void transpile() throws IOException {
         new ImprovementSet(
             new ImprovementXmirFootprint(this.target),
-            new ImprovementEoFootprint(this.target)
+            new ImprovementEoFootprint(this.target.getParent())
         ).apply(new BytecodeClasses(this.classes).bytecode());
     }
 }

--- a/src/test/java/org/eolang/jeo/improvement/ImprovementXmirFootprintTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/ImprovementXmirFootprintTest.java
@@ -56,7 +56,6 @@ final class ImprovementXmirFootprintTest {
      * Where the XML file is expected to be saved.
      */
     private final Path expected = Paths.get("")
-        .resolve(new XmirDefaultDirectory().toPath())
         .resolve("org")
         .resolve("eolang")
         .resolve("jeo")

--- a/src/test/java/org/eolang/jeo/improvement/ImprovementXmirFootprintTest.java
+++ b/src/test/java/org/eolang/jeo/improvement/ImprovementXmirFootprintTest.java
@@ -28,7 +28,6 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 import org.eolang.jeo.Representation;
-import org.eolang.jeo.XmirDefaultDirectory;
 import org.eolang.jeo.representation.EoRepresentation;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.hamcrest.MatcherAssert;

--- a/src/test/java/org/eolang/jeo/representation/BytecodeTransformationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/BytecodeTransformationTest.java
@@ -53,8 +53,7 @@ class BytecodeTransformationTest {
         MatcherAssert.assertThat(
             String.format("Can't find the transpiled file for the class '%s'.", name),
             Files.exists(
-                temp.resolve(new XmirDefaultDirectory().toPath())
-                    .resolve("org")
+                temp.resolve("org")
                     .resolve("eolang")
                     .resolve("jeo")
                     .resolve("MethodByte.xmir")

--- a/src/test/java/org/eolang/jeo/representation/BytecodeTransformationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/BytecodeTransformationTest.java
@@ -29,7 +29,6 @@ import java.nio.file.Path;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.bytes.UncheckedBytes;
 import org.cactoos.io.ResourceOf;
-import org.eolang.jeo.XmirDefaultDirectory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Closes: #418

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on improving the bytecode transformation process in the codebase.

### Detailed summary:
- Added a new improvement called `ImprovementXmirFootprint` to the `BytecodeTransformation` class.
- Removed the `ImprovementEoFootprint` improvement from the `BytecodeTransformation` class.
- Modified the `ImprovementXmirFootprintTest` class by removing an import statement and updating the file path.
- Modified the `BytecodeTransformationTest` class by removing an import statement and updating the file path.
- Updated the `ImprovementXmirFootprint` class by removing an import statement and updating the file path.
- Updated the `DisassembleMojo` class by modifying the `classes` and `generated` parameters to `sourcesDir` and `outputDir` respectively.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->