### PR TITLE
feat(#423): update eo-parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
-      <version>0.34.3</version>
+      <version>0.35.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.volodya-lombrozo</groupId>

--- a/src/main/java/org/eolang/jeo/improvement/ImprovementEoFootprint.java
+++ b/src/main/java/org/eolang/jeo/improvement/ImprovementEoFootprint.java
@@ -33,7 +33,7 @@ import org.eolang.jeo.DisassembleMojo;
 import org.eolang.jeo.Improvement;
 import org.eolang.jeo.Representation;
 import org.eolang.jeo.representation.JavaName;
-import org.eolang.parser.XMIR;
+import org.eolang.parser.xmir.Xmir;
 
 /**
  * It's not actually an improvement.
@@ -84,7 +84,7 @@ public final class ImprovementEoFootprint implements Improvement {
             Files.createDirectories(path.getParent());
             Files.write(
                 path,
-                new XMIR(representation.toEO()).toEO().getBytes(StandardCharsets.UTF_8)
+                new Xmir.Default(representation.toEO()).toEO().getBytes(StandardCharsets.UTF_8)
             );
             Logger.info(
                 this,

--- a/src/test/java/it/JavaToEoTest.java
+++ b/src/test/java/it/JavaToEoTest.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.BytecodeRepresentation;
-import org.eolang.parser.XMIR;
+import org.eolang.parser.xmir.Xmir;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
@@ -69,7 +69,7 @@ final class JavaToEoTest {
                 eolang,
                 java,
                 actual,
-                new XMIR(actual).toEO()
+                new Xmir.Default(actual).toEO()
             ),
             actual,
             Matchers.equalTo(new EoSource(eolang).parse())


### PR DESCRIPTION
Closes: #423.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the `eo-parser` artifact in the `pom.xml` file. 

### Detailed summary
- Updated the version of `eo-parser` from `0.34.3` to `0.35.0` in the `pom.xml` file.
- Replaced the import statement for `org.eolang.parser.XMIR` with `org.eolang.parser.xmir.Xmir` in the `JavaToEoTest.java` file.
- Replaced the import statement for `org.eolang.parser.XMIR` with `org.eolang.parser.xmir.Xmir` in the `ImprovementEoFootprint.java` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->