### PR TITLE
feat(#425): Assemble BA.xmir Example

### DIFF
--- a/src/it/eo-to-bytecode/target/generated-sources/opeo-xmir/org/eolang/benchmark/BA.xmir
+++ b/src/it/eo-to-bytecode/target/generated-sources/opeo-xmir/org/eolang/benchmark/BA.xmir
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<program dob="2023-12-25T18:13:56.947739Z"
+         ms="1703528036947"
+         name="j$BA"
+         revision="0.0.0"
+         time="2023-12-25T18:13:56.947739Z"
+         version="0.0.0">
+  <listing/>
+  <errors/>
+  <sheets/>
+  <metas>
+    <meta>
+      <head>package</head>
+      <tail>org/eolang/benchmark</tail>
+      <part>org/eolang/benchmark</part>
+    </meta>
+    <meta>
+      <head>alias</head>
+      <tail>org.eolang.jeo.opcode</tail>
+      <part>org.eolang.jeo.opcode</part>
+    </meta>
+    <meta>
+      <head>alias</head>
+      <tail>org.eolang.jeo.label</tail>
+      <part>org.eolang.jeo.label</part>
+    </meta>
+  </metas>
+  <objects>
+    <o abstract="" name="j$BA">
+      <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 20</o>
+      <o base="string" data="bytes" name="supername">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
+      <o base="tuple" data="tuple" name="interfaces"/>
+      <o base="field" name="j$d">
+        <o base="int" data="bytes">00 00 00 00 00 00 00 02</o>
+        <o base="string" data="bytes">49</o>
+        <o base="string" data="bytes"/>
+        <o base="string" data="bytes"/>
+      </o>
+      <o abstract="" name="new">
+        <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 00</o>
+        <o base="string" data="bytes" name="descriptor">28 49 29 56</o>
+        <o base="string" data="bytes" name="signature"/>
+        <o base="tuple" data="tuple" name="exceptions"/>
+        <o abstract="" name="arg__I__0"/>
+        <o base="seq" name="@">
+          <o base="tuple">
+            <o base="label">
+              <o base="string" data="bytes">32 36 62 66 35 33 33 61 2D 64 63 62 37 2D 34 63 33 65 2D 62 34 31 34 2D 62 36 61 39 34 33 66 33 39 39 63 35</o>
+            </o>
+            <o base="opcode" line="999" name="ALOAD-A">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
+              <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
+            </o>
+            <o base="opcode" line="999" name="INVOKESPECIAL-B">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 B7</o>
+              <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
+              <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
+              <o base="string" data="bytes">28 29 56</o>
+            </o>
+            <o base="label">
+              <o base="string" data="bytes">66 65 63 35 31 34 32 62 2D 34 33 61 39 2D 34 65 39 61 2D 61 37 39 64 2D 34 36 30 34 33 39 32 65 30 33 34 62</o>
+            </o>
+            <o base="opcode" line="999" name="ALOAD-C">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
+              <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
+            </o>
+            <o base="opcode" line="999" name="ILOAD-D">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 15</o>
+              <o base="int" data="bytes">00 00 00 00 00 00 00 01</o>
+            </o>
+            <o base="opcode" line="999" name="PUTFIELD-E">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 B5</o>
+              <o base="string" data="bytes">6f 72 67 2f 65 6f 6c 61 6e 67 2f 62 65 6e 63 68 6d 61 72 6b 2f 42 41</o>
+              <o base="string" data="bytes">64</o>
+              <o base="string" data="bytes">49</o>
+            </o>
+            <o base="label">
+              <o base="string" data="bytes">33 30 37 33 63 64 30 32 2D 39 63 33 62 2D 34 65 64 65 2D 62 64 30 37 2D 62 37 31 64 37 34 63 31 33 64 36 35</o>
+            </o>
+            <o base="opcode" line="999" name="RETURN-F">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 B1</o>
+            </o>
+            <o base="label">
+              <o base="string" data="bytes">30 66 62 39 62 37 33 66 2D 39 39 34 64 2D 34 65 64 62 2D 61 61 34 62 2D 39 61 66 31 62 65 32 63 32 37 66 64</o>
+            </o>
+          </o>
+        </o>
+        <o base="tuple" name="trycatchblocks"/>
+      </o>
+      <o abstract="" name="j$foo">
+        <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 01</o>
+        <o base="string" data="bytes" name="descriptor">28 29 49</o>
+        <o base="string" data="bytes" name="signature"/>
+        <o base="tuple" data="tuple" name="exceptions"/>
+        <o base="seq" name="@">
+          <o base="tuple">
+            <o base="label">
+              <o base="string" data="bytes">32 36 65 63 37 35 65 66 2D 35 63 64 65 2D 34 36 39 39 2D 39 36 34 31 2D 34 64 38 64 66 64 31 30 37 35 37 62</o>
+            </o>
+            <o base="opcode" line="999" name="ALOAD-10">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
+              <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
+            </o>
+            <o base="opcode" line="999" name="GETFIELD-11">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 B4</o>
+              <o base="string" data="bytes">6f 72 67 2f 65 6f 6c 61 6e 67 2f 62 65 6e 63 68 6d 61 72 6b 2f 42 41</o>
+              <o base="string" data="bytes">64</o>
+              <o base="string" data="bytes">49</o>
+            </o>
+            <o base="opcode" line="999" name="ICONST_1-12">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 04</o>
+            </o>
+            <o base="opcode" line="999" name="IADD-13">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 60</o>
+            </o>
+            <o base="opcode" line="999" name="IRETURN-14">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 AC</o>
+            </o>
+            <o base="label">
+              <o base="string" data="bytes">38 61 36 36 35 36 38 62 2D 61 32 37 34 2D 34 34 35 64 2D 38 33 62 39 2D 34 64 39 66 64 63 38 39 36 32 31 37</o>
+            </o>
+          </o>
+        </o>
+        <o base="tuple" name="trycatchblocks"/>
+      </o>
+      <o abstract="" name="j$bar">
+        <o base="int" data="bytes" name="access">00 00 00 00 00 00 00 00</o>
+        <o base="string" data="bytes" name="descriptor">28 29 49</o>
+        <o base="string" data="bytes" name="signature"/>
+        <o base="tuple" data="tuple" name="exceptions"/>
+        <o base="seq" name="@">
+          <o base="tuple">
+            <o base="label">
+              <o base="string" data="bytes">37 30 62 35 36 30 30 36 2D 38 35 36 65 2D 34 61 63 32 2D 62 65 39 39 2D 36 33 32 63 61 32 35 61 36 35 61 30</o>
+            </o>
+            <o base="opcode" line="999" name="ALOAD-15">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 19</o>
+              <o base="int" data="bytes">00 00 00 00 00 00 00 00</o>
+            </o>
+            <o base="opcode" line="999" name="INVOKEVIRTUAL-16">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 B6</o>
+              <o base="string" data="bytes">6f 72 67 2f 65 6f 6c 61 6e 67 2f 62 65 6e 63 68 6d 61 72 6b 2f 42 41</o>
+              <o base="string" data="bytes">66 6F 6F</o>
+              <o base="string" data="bytes">28 29 49</o>
+            </o>
+            <o base="opcode" line="999" name="ICONST_2-17">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 05</o>
+            </o>
+            <o base="opcode" line="999" name="IADD-18">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 60</o>
+            </o>
+            <o base="opcode" line="999" name="IRETURN-19">
+              <o base="int" data="bytes">00 00 00 00 00 00 00 AC</o>
+            </o>
+            <o base="label">
+              <o base="string" data="bytes">66 33 64 39 37 33 61 62 2D 63 35 30 32 2D 34 31 33 34 2D 38 64 36 66 2D 64 37 66 65 38 39 64 65 66 63 36 65</o>
+            </o>
+          </o>
+        </o>
+        <o base="tuple" name="trycatchblocks"/>
+      </o>
+    </o>
+  </objects>
+</program>


### PR DESCRIPTION
In this PR I provide the example of `BA.xmir` transformation to bytecode.

The `BA.xmir` file example contains inconsitency in `package` definition and opcode params.
Put it simply, `package.BA  == org/eolang/benchmark/BA`, but all the opcodes uses `com/exam/BA`.

Hex string for `com/exam/BA` is `63 6f 6d 2f 65 78 61 6d 2f 42 41`
Hex string for `org/eolang/benchmark/BA` is `6f 72 67 2f 65 6f 6c 61 6e 67 2f 62 65 6e 63 68 6d 61 72 6b 2f 42 41`.

In the initial `BA.xmir` example, I replaced all `com/exam/BA` (3 places) to `org/eolang/benchmark/BA`. Now, assemble phase works like a charm. 


Closes: #425


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding XML code to the file `BA.xmir` and introducing new objects and labels. 

### Detailed summary
- Added XML code to the file `BA.xmir`
- Introduced new objects and labels

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->