### PR TITLE
feat(#435): Disable Bytecode Verification

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,16 @@ SOFTWARE.
     </testResources>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <version>3.6.0</version>
+        <configuration>
+          <pomExcludes>
+            <exclude>fails-if-bytecode-broken/pom.xml</exclude>
+          </pomExcludes>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
         <configuration>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation.bytecode;
 
 import com.jcabi.xml.XML;
 import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.eolang.jeo.PluginStartup;
@@ -344,32 +343,32 @@ public final class BytecodeClass {
      *  <a href="https://stackoverflow.com/q/77854100/10423604">link</a>
      */
     private void verify(final byte[] bytes) {
-//       @checkstyle MethodBodyCommentsCheck (50 lines)
-//        @todo #435:90min Enable Bytecode Verification
-//         Currently we don't verify bytecode properly.
-//         It was done by purpose, you can check
-//         <a href="https://github.com/objectionary/jeo-maven-plugin/issues/435>here</a>
-//         why we did it. We need to enable bytecode verification.
-//         To do so, just enable the code below.
-//         Also you need to enable integration test: fails-if-bytecode-broken
+        //@checkstyle MethodBodyCommentsCheck (50 lines)
+        // @todo #435:90min Enable Bytecode Verification
+        //  Currently we don't verify bytecode properly.
+        //  It was done by purpose, you can check
+        //  <a href="https://github.com/objectionary/jeo-maven-plugin/issues/435>here</a>
+        //  why we did it. We need to enable bytecode verification.
+        //  To do so, just enable the code below.
+        //  Also you need to enable integration test: fails-if-bytecode-broken
         if (bytes.length == 0) {
             throw new IllegalStateException("Bytecode class is empty");
         }
-//        final StringWriter errors = new StringWriter();
-//        CheckClassAdapter.verify(
-//            new ClassReader(bytes),
-//            Thread.currentThread().getContextClassLoader(),
-//            false,
-//            new PrintWriter(errors)
-//        );
-//        if (!errors.toString().isEmpty()) {
-//            throw new IllegalStateException(
-//                String.format(
-//                    "Bytecode verification failed for the class '%s' due to the following reasons: %s",
-//                    this.name,
-//                    errors
-//                )
-//            );
-//        }
+        //        final StringWriter errors = new StringWriter();
+        //        CheckClassAdapter.verify(
+        //            new ClassReader(bytes),
+        //            Thread.currentThread().getContextClassLoader(),
+        //            false,
+        //            new PrintWriter(errors)
+        //        );
+        //        if (!errors.toString().isEmpty()) {
+        //            throw new IllegalStateException(
+        //                String.format(
+        //      "Bytecode verification failed for the class '%s' due to the following reasons: %s",
+        //                    this.name,
+        //                    errors
+        //                )
+        //            );
+        //        }
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -344,21 +344,31 @@ public final class BytecodeClass {
      *  <a href="https://stackoverflow.com/q/77854100/10423604">link</a>
      */
     private void verify(final byte[] bytes) {
-        final StringWriter errors = new StringWriter();
-        CheckClassAdapter.verify(
-            new ClassReader(bytes),
-            Thread.currentThread().getContextClassLoader(),
-            false,
-            new PrintWriter(errors)
-        );
-        if (!errors.toString().isEmpty()) {
-            throw new IllegalStateException(
-                String.format(
-                    "Bytecode verification failed for the class '%s' due to the following reasons: %s",
-                    this.name,
-                    errors
-                )
-            );
+//       @checkstyle MethodBodyCommentsCheck (50 lines)
+//        @todo #435:90min Enable Bytecode Verification
+//         Currently we don't verify bytecode properly.
+//         It was done by purpose, you can check
+//         <a href="https://github.com/objectionary/jeo-maven-plugin/issues/435>here</a>
+//         why we did it. We need to enable bytecode verification.
+//         To do so, just enable the code below.
+        if (bytes.length == 0) {
+            throw new IllegalStateException("Bytecode class is empty");
         }
+//        final StringWriter errors = new StringWriter();
+//        CheckClassAdapter.verify(
+//            new ClassReader(bytes),
+//            Thread.currentThread().getContextClassLoader(),
+//            false,
+//            new PrintWriter(errors)
+//        );
+//        if (!errors.toString().isEmpty()) {
+//            throw new IllegalStateException(
+//                String.format(
+//                    "Bytecode verification failed for the class '%s' due to the following reasons: %s",
+//                    this.name,
+//                    errors
+//                )
+//            );
+//        }
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -351,6 +351,7 @@ public final class BytecodeClass {
 //         <a href="https://github.com/objectionary/jeo-maven-plugin/issues/435>here</a>
 //         why we did it. We need to enable bytecode verification.
 //         To do so, just enable the code below.
+//         Also you need to enable integration test: fails-if-bytecode-broken
         if (bytes.length == 0) {
             throw new IllegalStateException("Bytecode class is empty");
         }


### PR DESCRIPTION
Disable bytecode verification. I also added the puzzle to enable verification again, when we will know how to add compiled classes on the fly.

Closes: #435
____
History:
- feat(#435): disable verification, add puzzle
- feat(#435): disable integration test that checks bytecode verification

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enabling bytecode verification in the `BytecodeClass` class. 

### Detailed summary
- Added `maven-invoker-plugin` in `pom.xml` to exclude a specific file from the configuration.
- Modified the `verify` method in `BytecodeClass` to enable bytecode verification.
- Added a check for empty bytecode class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->