### PR TITLE
feat(#452): refactor Details class

### DIFF
--- a/src/main/java/org/eolang/jeo/Details.java
+++ b/src/main/java/org/eolang/jeo/Details.java
@@ -23,7 +23,9 @@
  */
 package org.eolang.jeo;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -55,14 +57,14 @@ public class Details {
     /**
      * Storage with all the details.
      */
-    private final Map<String, Object> storage;
+    private final Map<String, String> storage;
 
     /**
      * Constructor.
      * @param name Name of the class or an object.
      * @param source Original source of the representation.
      */
-    public Details(final String name, final Object source) {
+    public Details(final String name, final String source) {
         this(Details.NAME_KEY, name, Details.SOURCE_KEY, source);
     }
 
@@ -70,7 +72,7 @@ public class Details {
      * Constructor.
      * @param inits Initializations.
      */
-    private Details(final Object... inits) {
+    private Details(final String... inits) {
         this(Details.initial(inits));
     }
 
@@ -78,7 +80,7 @@ public class Details {
      * Constructor.
      * @param storage Storage with all the details.
      */
-    private Details(final Map<String, Object> storage) {
+    private Details(final Map<String, String> storage) {
         this.storage = storage;
     }
 
@@ -87,7 +89,7 @@ public class Details {
      * @return Name.
      */
     public String name() {
-        return (String) this.storage.get(Details.NAME_KEY);
+        return this.storage.get(Details.NAME_KEY);
     }
 
     /**
@@ -96,9 +98,18 @@ public class Details {
      * @return Optional Source.
      */
     public Optional<Path> source() {
-        return Optional.ofNullable(this.storage.get(Details.SOURCE_KEY))
-            .filter(Path.class::isInstance)
-            .map(Path.class::cast);
+        final Optional<Path> result;
+        if (this.storage.containsKey(Details.SOURCE_KEY)) {
+            final Path path = Paths.get(this.storage.get(Details.SOURCE_KEY)).toAbsolutePath();
+            if (Files.exists(path)) {
+                result = Optional.of(path);
+            } else {
+                result = Optional.empty();
+            }
+        } else {
+            result = Optional.empty();
+        }
+        return result;
     }
 
     /**
@@ -106,14 +117,14 @@ public class Details {
      * @param pairs Pairs of key-value.
      * @return Map with all the details.
      */
-    private static Map<String, Object> initial(final Object... pairs) {
+    private static Map<String, String> initial(final String... pairs) {
         final int length = pairs.length;
         if (length % 2 == 1) {
             throw new IllegalArgumentException("Must have an even number of arguments");
         }
-        final Map<String, Object> map = new HashMap<>(pairs.length / 2);
+        final Map<String, String> map = new HashMap<>(pairs.length / 2);
         for (int index = 0; index < length; index += 2) {
-            map.put((String) pairs[index], pairs[index + 1]);
+            map.put(pairs[index], pairs[index + 1]);
         }
         return map;
     }

--- a/src/main/java/org/eolang/jeo/Details.java
+++ b/src/main/java/org/eolang/jeo/Details.java
@@ -34,10 +34,6 @@ import java.util.Optional;
  * Details of representation.
  * Additional info about representation.
  * @since 0.1
- * @todo #448:30min Continue refactoring of the Details#source() method.
- *  Here we have a method that returns an Optional Path and it is not clear why
- *  it is returning an Optional instead of just Path.
- *  We either should refactor this method to return a Path or justify why it is so.
  */
 public class Details {
 

--- a/src/main/java/org/eolang/jeo/LoggedTranslation.java
+++ b/src/main/java/org/eolang/jeo/LoggedTranslation.java
@@ -88,44 +88,40 @@ public final class LoggedTranslation implements Translation {
         return result;
     }
 
-
     private void logStartWithSize(final Path source) {
-        try {
-            Logger.info(
-                this,
-                "%s '%[file]s' (%[size]s)",
-                this.process,
-                source,
-                Files.size(source)
-            );
-        } catch (final IOException exception) {
-            throw new IllegalStateException(
-                String.format(
-                    "Can't log %s translation, since the source file a representation is not found, or its size can't be determined",
-                    this.original
-                ),
-                exception
-            );
-        }
+        Logger.info(
+            this,
+            "%s '%[file]s' (%[size]s)",
+            this.process,
+            source,
+            LoggedTranslation.size(source)
+        );
     }
 
     private void logEndWithSize(final Path source, final Path after, final long time) {
+        Logger.info(
+            this,
+            "'%[file]s' %s to '%[file]s' (%[size]s) in %[ms]s",
+            source,
+            this.participle,
+            after,
+            LoggedTranslation.size(after),
+            time
+        );
+    }
+
+    private static long size(final Path path) {
         try {
-            Logger.info(
-                this,
-                "'%[file]s' %s to '%[file]s' (%[size]s) in %[ms]s",
-                source,
-                this.participle,
-                after,
-                Files.size(after),
-                time
-            );
+            long result;
+            if (Files.exists(path) && !path.equals(LoggedTranslation.UNKNOWN)) {
+                result = Files.size(path);
+            } else {
+                result = 0L;
+            }
+            return result;
         } catch (final IOException exception) {
             throw new IllegalStateException(
-                String.format(
-                    "Can't log %s translation, since the output file after transformation is not found, or its size can't be determined",
-                    this.original
-                ),
+                String.format("Can't determine size of '%s'", path),
                 exception
             );
         }

--- a/src/main/java/org/eolang/jeo/LoggedTranslation.java
+++ b/src/main/java/org/eolang/jeo/LoggedTranslation.java
@@ -88,6 +88,10 @@ public final class LoggedTranslation implements Translation {
         return result;
     }
 
+    /**
+     * Log the start of the process.
+     * @param source Initial path.
+     */
     private void logStartWithSize(final Path source) {
         Logger.info(
             this,
@@ -98,6 +102,12 @@ public final class LoggedTranslation implements Translation {
         );
     }
 
+    /**
+     * Log the end of the process.
+     * @param source Initial path
+     * @param after Path after the process
+     * @param time Time spent
+     */
     private void logEndWithSize(final Path source, final Path after, final long time) {
         Logger.info(
             this,
@@ -110,9 +120,14 @@ public final class LoggedTranslation implements Translation {
         );
     }
 
+    /**
+     * Size of the file.
+     * @param path Path to the file
+     * @return Size of the file
+     */
     private static long size(final Path path) {
         try {
-            long result;
+            final long result;
             if (Files.exists(path) && !path.equals(LoggedTranslation.UNKNOWN)) {
                 result = Files.size(path);
             } else {

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -60,7 +60,7 @@ public final class BytecodeRepresentation implements Representation {
     /**
      * The source of the input.
      */
-    private final Object source;
+    private final String source;
 
     /**
      * Constructor.
@@ -96,7 +96,7 @@ public final class BytecodeRepresentation implements Representation {
      * @param source The source of the input
      */
     private BytecodeRepresentation(final Input input, final Path source) {
-        this(new UncheckedBytes(new BytesOf(input)).asBytes(), source);
+        this(new UncheckedBytes(new BytesOf(input)).asBytes(), source.toAbsolutePath().toString());
     }
 
     /**
@@ -116,7 +116,7 @@ public final class BytecodeRepresentation implements Representation {
      */
     private BytecodeRepresentation(
         final byte[] input,
-        final Object source
+        final String source
     ) {
         this.input = input.clone();
         this.source = source;

--- a/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
@@ -48,7 +48,7 @@ public final class XmirRepresentation implements Representation {
     /**
      * Source of the XML.
      */
-    private final Object source;
+    private final String source;
 
     /**
      * Verify bytecode.
@@ -70,7 +70,7 @@ public final class XmirRepresentation implements Representation {
      * @param verify Verify bytecode.
      */
     public XmirRepresentation(final Path path, final boolean verify) {
-        this(XmirRepresentation.open(path), path, verify);
+        this(XmirRepresentation.open(path), path.toAbsolutePath().toString(), verify);
     }
 
     /**
@@ -88,7 +88,7 @@ public final class XmirRepresentation implements Representation {
      */
     public XmirRepresentation(
         final XML xml,
-        final Object source
+        final String source
     ) {
         this(xml, source, true);
     }
@@ -101,7 +101,7 @@ public final class XmirRepresentation implements Representation {
      */
     public XmirRepresentation(
         final XML xml,
-        final Object source,
+        final String source,
         final boolean verify
     ) {
         this.xml = xml;


### PR DESCRIPTION
Refactor `Details` class.

Closes: #452.
____
History:
- feat(#452): sketchy refactoring
- feat(#452): fix all tests
- feat(#452): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on changing the type of the `source` field in multiple classes from `Object` to `String` to improve clarity and consistency.

### Detailed summary
- Changed the type of `source` field in `BytecodeRepresentation` and `XmirRepresentation` classes from `Object` to `String`.
- Updated constructor and method signatures to reflect the change.
- Modified the `Details` class to use `String` instead of `Object` for the `source` field.
- Updated the `Details` class to return an `Optional<Path>` for the `source()` method instead of `Optional<Object>`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->