### PR TITLE
feat(#429): use CheckClassAdapter instead of direct ClassWriter

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
@@ -1,24 +1,72 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.bytecode;
-
 
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 
+/**
+ * Bytecode annotation.
+ * @since 0.2
+ */
 public final class BytecodeAnnotation {
 
+    /**
+     * Descriptor.
+     */
     private final String descriptor;
+
+    /**
+     * Visible.
+     */
     private final boolean visible;
 
+    /**
+     * Constructor.
+     * @param descriptor Descriptor.
+     * @param visible Visible.
+     */
     public BytecodeAnnotation(final String descriptor, final boolean visible) {
         this.descriptor = descriptor;
         this.visible = visible;
     }
 
+    /**
+     * Write class annotation.
+     * @param visitor Visitor.
+     * @return This.
+     */
     public BytecodeAnnotation write(final ClassVisitor visitor) {
         visitor.visitAnnotation(this.descriptor, this.visible);
         return this;
     }
 
+    /**
+     * Write field annotation.
+     * @param visitor Visitor.
+     * @return This.
+     */
     public BytecodeAnnotation write(final FieldVisitor visitor) {
         visitor.visitAnnotation(this.descriptor, this.visible);
         return this;

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
@@ -1,0 +1,26 @@
+package org.eolang.jeo.representation.bytecode;
+
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+
+public final class BytecodeAnnotation {
+
+    private final String descriptor;
+    private final boolean visible;
+
+    public BytecodeAnnotation(final String descriptor, final boolean visible) {
+        this.descriptor = descriptor;
+        this.visible = visible;
+    }
+
+    public BytecodeAnnotation write(final ClassVisitor visitor) {
+        visitor.visitAnnotation(this.descriptor, this.visible);
+        return this;
+    }
+
+    public BytecodeAnnotation write(final FieldVisitor visitor) {
+        visitor.visitAnnotation(this.descriptor, this.visible);
+        return this;
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -34,7 +34,6 @@ import org.eolang.jeo.representation.xmir.XmlAnnotations;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.util.CheckClassAdapter;
 
@@ -361,13 +360,13 @@ public final class BytecodeClass implements Testable {
     }
 
     /**
-     * Add annotations.
+     * Add anns.
      *
-     * @param annotations Annotations.
+     * @param all Annotations.
      * @return This object.
      */
-    public BytecodeClass withAnnotations(final XmlAnnotations annotations) {
-        annotations.all()
+    public BytecodeClass withAnnotations(final XmlAnnotations all) {
+        all.all()
             .stream()
             .map(ann -> new BytecodeAnnotation(ann.descriptor(), ann.visible()))
             .forEach(this.annotations::add);
@@ -414,10 +413,11 @@ public final class BytecodeClass implements Testable {
     /**
      * Verify bytecode.
      * @param bytes Bytecode to verify.
-     * @todo #427:90min Use custom bytecode verifier instead of CheckClassAdapter#verify.
-     *  This class can only print the error message to the console. We need to have a custom
-     *  bytecode verifier that can throw an exception with the error message.
-     *  Here you can find the detailed problem description:
+     * @todo #429:60min Remove `verifyBytecode` method and its usage from the `BytecodeClass` class.
+     *  This method is used to verify the bytecode of the class. Since we added
+     *  CheckClassAdapter in the `bytecode` method, we can remove this method.
+     *  However, we need to make sure that by doing this we don't break any existing tests.
+     *  You can read more about the problem here:
      *  <a href="https://stackoverflow.com/q/77854100/10423604">link</a>
      */
     private void verifyBytecode(final byte[] bytes) {

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -201,7 +201,7 @@ public final class BytecodeClass implements Testable {
     ) {
         this.name = name;
         this.writer = writer;
-        this.visitor = new CheckClassAdapter(this.writer);
+        this.visitor = new CheckClassAdapter(this.writer, false);
         this.methods = methods;
         this.props = properties;
         this.fields = new ArrayList<>(0);

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClassProperties.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation.bytecode;
 
 import org.eolang.jeo.representation.DefaultVersion;
 import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.ClassWriter;
 
 /**
  * Class properties.

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClassProperties.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation.bytecode;
 
 import org.eolang.jeo.representation.DefaultVersion;
+import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 
 /**
@@ -83,11 +84,11 @@ public final class BytecodeClassProperties {
 
     /**
      * Start writing a class by using class writer.
-     * @param writer Class writer.
+     * @param visitor Class visitor.
      * @param name Class name.
      */
-    void write(final ClassWriter writer, final String name) {
-        writer.visit(
+    void write(final ClassVisitor visitor, final String name) {
+        visitor.visit(
             new DefaultVersion().java(),
             this.access,
             name,

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeField.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeField.java
@@ -1,6 +1,10 @@
 package org.eolang.jeo.representation.bytecode;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
 
 public final class BytecodeField {
     private final String name;
@@ -9,31 +13,35 @@ public final class BytecodeField {
     private final Object value;
     private final int access;
 
-    private final ClassVisitor visitor;
+    private final Collection<BytecodeAnnotation> annotations;
 
     public BytecodeField(
         final String name,
         final String descriptor,
         final String signature,
         final Object value,
-        final int access,
-        final ClassVisitor visitor
+        final int access
     ) {
         this.name = name;
         this.descriptor = descriptor;
         this.signature = signature;
         this.value = value;
         this.access = access;
-        this.visitor = visitor;
+        this.annotations = new ArrayList<>(0);
     }
 
-    public void write() {
-        this.visitor.visitField(
+    public void write(final ClassVisitor visitor) {
+        final FieldVisitor fvisitor = visitor.visitField(
             this.access,
             this.name,
             this.descriptor,
             this.signature,
             this.value
         );
+        this.annotations.forEach(annotation -> annotation.write(fvisitor));
+    }
+
+    public void withAnnotation(final String descriptor, final boolean visible) {
+        this.annotations.add(new BytecodeAnnotation(descriptor, visible));
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeField.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeField.java
@@ -1,0 +1,39 @@
+package org.eolang.jeo.representation.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+public final class BytecodeField {
+    private final String name;
+    private final String descriptor;
+    private final String signature;
+    private final Object value;
+    private final int access;
+
+    private final ClassVisitor visitor;
+
+    public BytecodeField(
+        final String name,
+        final String descriptor,
+        final String signature,
+        final Object value,
+        final int access,
+        final ClassVisitor visitor
+    ) {
+        this.name = name;
+        this.descriptor = descriptor;
+        this.signature = signature;
+        this.value = value;
+        this.access = access;
+        this.visitor = visitor;
+    }
+
+    public void write() {
+        this.visitor.visitField(
+            this.access,
+            this.name,
+            this.descriptor,
+            this.signature,
+            this.value
+        );
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeField.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeField.java
@@ -1,35 +1,97 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.bytecode;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 
+/**
+ * Bytecode field.
+ * @since 0.2
+ */
 public final class BytecodeField {
+
+    /**
+     * Field name.
+     */
     private final String name;
+
+    /**
+     * Descriptor.
+     */
     private final String descriptor;
+
+    /**
+     * Signature.
+     */
     private final String signature;
+
+    /**
+     * Set value.
+     */
     private final Object value;
+
+    /**
+     * Access.
+     */
     private final int access;
 
+    /**
+     * Annotations.
+     */
     private final Collection<BytecodeAnnotation> annotations;
 
+    /**
+     * Constructor.
+     * @param name Name.
+     * @param descr Descriptor.
+     * @param signature Signature.
+     * @param value Value.
+     * @param access Access.
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
     public BytecodeField(
         final String name,
-        final String descriptor,
+        final String descr,
         final String signature,
         final Object value,
         final int access
     ) {
         this.name = name;
-        this.descriptor = descriptor;
+        this.descriptor = descr;
         this.signature = signature;
         this.value = value;
         this.access = access;
         this.annotations = new ArrayList<>(0);
     }
 
+    /**
+     * Write field to a class.
+     * @param visitor Visitor.
+     */
     public void write(final ClassVisitor visitor) {
         final FieldVisitor fvisitor = visitor.visitField(
             this.access,
@@ -41,7 +103,12 @@ public final class BytecodeField {
         this.annotations.forEach(annotation -> annotation.write(fvisitor));
     }
 
-    public void withAnnotation(final String descriptor, final boolean visible) {
-        this.annotations.add(new BytecodeAnnotation(descriptor, visible));
+    /**
+     * Add annotation.
+     * @param descr Descriptor.
+     * @param visible Visible.
+     */
+    public void withAnnotation(final String descr, final boolean visible) {
+        this.annotations.add(new BytecodeAnnotation(descr, visible));
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -166,10 +166,12 @@ public final class BytecodeMethod implements Testable {
     void write() {
         try {
             final MethodVisitor visitor = this.properties.writeMethod(this.visitor);
-            visitor.visitCode();
-            this.trycatchblocks.forEach(block -> block.writeTo(visitor));
-            this.instructions.forEach(instruction -> instruction.writeTo(visitor));
-            visitor.visitMaxs(0, 0);
+            if (!this.properties.isAbstract()) {
+                visitor.visitCode();
+                this.trycatchblocks.forEach(block -> block.writeTo(visitor));
+                this.instructions.forEach(instruction -> instruction.writeTo(visitor));
+                visitor.visitMaxs(0, 0);
+            }
             visitor.visitEnd();
         } catch (final NegativeArraySizeException exception) {
             throw new IllegalStateException(

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -26,7 +26,6 @@ package org.eolang.jeo.representation.bytecode;
 import java.util.ArrayList;
 import java.util.List;
 import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 
@@ -49,7 +48,7 @@ public final class BytecodeMethod implements Testable {
     /**
      * Try-catch blocks.
      */
-    private final List<BytecodeEntry> trycatchblocks;
+    private final List<BytecodeEntry> tryblocks;
 
     /**
      * Method Instructions.
@@ -94,7 +93,7 @@ public final class BytecodeMethod implements Testable {
         this.properties = properties;
         this.visitor = visitor;
         this.clazz = clazz;
-        this.trycatchblocks = new ArrayList<>(0);
+        this.tryblocks = new ArrayList<>(0);
         this.instructions = new ArrayList<>(0);
     }
 
@@ -133,7 +132,7 @@ public final class BytecodeMethod implements Testable {
      * @return This object.
      */
     public BytecodeMethod trycatch(final BytecodeEntry entry) {
-        this.trycatchblocks.add(entry);
+        this.tryblocks.add(entry);
         return this;
     }
 
@@ -165,14 +164,14 @@ public final class BytecodeMethod implements Testable {
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
     void write() {
         try {
-            final MethodVisitor visitor = this.properties.writeMethod(this.visitor);
+            final MethodVisitor mvisitor = this.properties.writeMethod(this.visitor);
             if (!this.properties.isAbstract()) {
-                visitor.visitCode();
-                this.trycatchblocks.forEach(block -> block.writeTo(visitor));
-                this.instructions.forEach(instruction -> instruction.writeTo(visitor));
-                visitor.visitMaxs(0, 0);
+                mvisitor.visitCode();
+                this.tryblocks.forEach(block -> block.writeTo(mvisitor));
+                this.instructions.forEach(instruction -> instruction.writeTo(mvisitor));
+                mvisitor.visitMaxs(0, 0);
             }
-            visitor.visitEnd();
+            mvisitor.visitEnd();
         } catch (final NegativeArraySizeException exception) {
             throw new IllegalStateException(
                 String.format(

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -47,6 +47,11 @@ public final class BytecodeMethod implements Testable {
     private final BytecodeClass clazz;
 
     /**
+     * Try-catch blocks.
+     */
+    private final List<BytecodeEntry> trycatchblocks;
+
+    /**
      * Method Instructions.
      */
     private final List<BytecodeEntry> instructions;
@@ -89,6 +94,7 @@ public final class BytecodeMethod implements Testable {
         this.properties = properties;
         this.visitor = visitor;
         this.clazz = clazz;
+        this.trycatchblocks = new ArrayList<>(0);
         this.instructions = new ArrayList<>(0);
     }
 
@@ -122,6 +128,16 @@ public final class BytecodeMethod implements Testable {
     }
 
     /**
+     * Add try-catch block.
+     * @param entry Try-catch block.
+     * @return This object.
+     */
+    public BytecodeMethod trycatch(final BytecodeEntry entry) {
+        this.trycatchblocks.add(entry);
+        return this;
+    }
+
+    /**
      * Add some bytecode entry.
      * @param entry Entry.
      * @return This object.
@@ -151,6 +167,7 @@ public final class BytecodeMethod implements Testable {
         try {
             final MethodVisitor visitor = this.properties.writeMethod(this.visitor);
             visitor.visitCode();
+            this.trycatchblocks.forEach(block -> block.writeTo(visitor));
             this.instructions.forEach(instruction -> instruction.writeTo(visitor));
             visitor.visitMaxs(0, 0);
             visitor.visitEnd();

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.bytecode;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
@@ -36,9 +37,9 @@ import org.objectweb.asm.MethodVisitor;
 public final class BytecodeMethod implements Testable {
 
     /**
-     * ASM class writer.
+     * ASM class visitor.
      */
-    private final ClassWriter writer;
+    private final ClassVisitor visitor;
 
     /**
      * Original class.
@@ -58,7 +59,7 @@ public final class BytecodeMethod implements Testable {
     /**
      * Constructor.
      * @param name Method name.
-     * @param writer ASM class writer.
+     * @param visitor ASM class writer.
      * @param clazz Original class.
      * @param descriptor Method descriptor.
      * @param modifiers Method modifiers.
@@ -66,27 +67,27 @@ public final class BytecodeMethod implements Testable {
      */
     BytecodeMethod(
         final String name,
-        final ClassWriter writer,
+        final ClassVisitor visitor,
         final BytecodeClass clazz,
         final String descriptor,
         final int... modifiers
     ) {
-        this(new BytecodeMethodProperties(name, descriptor, modifiers), writer, clazz);
+        this(new BytecodeMethodProperties(name, descriptor, modifiers), visitor, clazz);
     }
 
     /**
      * Constructor.
      * @param properties Method properties.
-     * @param writer ASM class writer.
+     * @param visitor ASM class writer.
      * @param clazz Original class.
      */
     BytecodeMethod(
         final BytecodeMethodProperties properties,
-        final ClassWriter writer,
+        final ClassVisitor visitor,
         final BytecodeClass clazz
     ) {
         this.properties = properties;
-        this.writer = writer;
+        this.visitor = visitor;
         this.clazz = clazz;
         this.instructions = new ArrayList<>(0);
     }
@@ -148,7 +149,8 @@ public final class BytecodeMethod implements Testable {
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
     void write() {
         try {
-            final MethodVisitor visitor = this.properties.writeMethod(this.writer);
+            final MethodVisitor visitor = this.properties.writeMethod(this.visitor);
+            visitor.visitCode();
             this.instructions.forEach(instruction -> instruction.writeTo(visitor));
             visitor.visitMaxs(0, 0);
             visitor.visitEnd();

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
@@ -30,6 +30,7 @@ import lombok.ToString;
 import org.eolang.jeo.representation.JavaName;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 
 /**
  * Bytecode method properties.
@@ -122,6 +123,14 @@ public final class BytecodeMethodProperties implements Testable {
     @Override
     public String testCode() {
         return String.format("\"%s\", \"%s\", %d", this.name, this.descriptor, this.access);
+    }
+
+    /**
+     * Is method abstract.
+     * @return True if method is abstract.
+     */
+    public boolean isAbstract() {
+        return (this.access & Opcodes.ACC_ABSTRACT) != 0;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
@@ -28,7 +28,7 @@ import java.util.stream.IntStream;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.JavaName;
-import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 
 /**
@@ -129,7 +129,7 @@ public final class BytecodeMethodProperties implements Testable {
      * @param writer Class writer.
      * @return Method visitor.
      */
-    MethodVisitor writeMethod(final ClassWriter writer) {
+    MethodVisitor writeMethod(final ClassVisitor writer) {
         Logger.debug(
             this,
             String.format("Creating method visitor with the following properties %s", this)

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
@@ -31,7 +31,6 @@ import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.eolang.jeo.representation.bytecode.BytecodeField;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
-import org.objectweb.asm.FieldVisitor;
 
 /**
  * XML to Java bytecode.
@@ -105,22 +104,6 @@ public final class XmlBytecode {
                         )
                     )
             );
-//            final FieldVisitor visitor = bytecode.withField(
-//                new JavaName(field.name()).decode(),
-//                field.descriptor(),
-//                field.signature(),
-//                field.value(),
-//                field.access()
-//            );
-//            field.annotations().ifPresent(
-//                annotations -> annotations.all()
-//                    .forEach(
-//                        annotation -> visitor.visitAnnotation(
-//                            annotation.descriptor(),
-//                            annotation.visible()
-//                        )
-//                    )
-//            );
         }
         for (final XmlMethod xmlmethod : clazz.methods()) {
             final BytecodeMethod method = bytecode.withMethod(xmlmethod.properties());

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
@@ -29,6 +29,7 @@ import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.JavaName;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
+import org.eolang.jeo.representation.bytecode.BytecodeField;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.objectweb.asm.FieldVisitor;
 
@@ -88,12 +89,21 @@ public final class XmlBytecode {
         );
         clazz.annotations().ifPresent(bytecode::withAnnotations);
         for (final XmlField field : clazz.fields()) {
-            bytecode.withField(
+            final BytecodeField bfield = bytecode.withField(
                 new JavaName(field.name()).decode(),
                 field.descriptor(),
                 field.signature(),
                 field.value(),
                 field.access()
+            );
+            field.annotations().ifPresent(
+                annotations -> annotations.all()
+                    .forEach(
+                        annotation -> bfield.withAnnotation(
+                            annotation.descriptor(),
+                            annotation.visible()
+                        )
+                    )
             );
 //            final FieldVisitor visitor = bytecode.withField(
 //                new JavaName(field.name()).decode(),

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
@@ -88,22 +88,29 @@ public final class XmlBytecode {
         );
         clazz.annotations().ifPresent(bytecode::withAnnotations);
         for (final XmlField field : clazz.fields()) {
-            final FieldVisitor visitor = bytecode.withField(
+            bytecode.withField(
                 new JavaName(field.name()).decode(),
                 field.descriptor(),
                 field.signature(),
                 field.value(),
                 field.access()
             );
-            field.annotations().ifPresent(
-                annotations -> annotations.all()
-                    .forEach(
-                        annotation -> visitor.visitAnnotation(
-                            annotation.descriptor(),
-                            annotation.visible()
-                        )
-                    )
-            );
+//            final FieldVisitor visitor = bytecode.withField(
+//                new JavaName(field.name()).decode(),
+//                field.descriptor(),
+//                field.signature(),
+//                field.value(),
+//                field.access()
+//            );
+//            field.annotations().ifPresent(
+//                annotations -> annotations.all()
+//                    .forEach(
+//                        annotation -> visitor.visitAnnotation(
+//                            annotation.descriptor(),
+//                            annotation.visible()
+//                        )
+//                    )
+//            );
         }
         for (final XmlMethod xmlmethod : clazz.methods()) {
             final BytecodeMethod method = bytecode.withMethod(xmlmethod.properties());

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
@@ -49,7 +49,7 @@ public final class XmlTryCatchEntry implements XmlBytecodeEntry {
     @Override
     public void writeTo(final BytecodeMethod method) {
         final AllLabels labels = new AllLabels();
-        method.entry(
+        method.trycatch(
             new BytecodeTryCatchBlock(
                 this.label("start").map(labels::label).orElse(null),
                 this.label("end").map(labels::label).orElse(null),

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -72,8 +72,9 @@ class XmirRepresentationTest {
 
     @Test
     void returnsBytecodeRepresentationOfEo() {
-        final BytecodeClass clazz = new BytecodeClass("Bar");
-        final Bytecode expected = clazz.bytecode();
+        final String name = "Bar";
+        final BytecodeClass clazz = new BytecodeClass(name);
+        final Bytecode expected = new BytecodeClass(name).bytecode();
         final Bytecode actual = new XmirRepresentation(clazz.xml()).toBytecode();
         MatcherAssert.assertThat(
             String.format(XmirRepresentationTest.MESSAGE, expected, actual),

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -163,4 +163,15 @@ class BytecodeClassTest {
             }, "We expect no exception here because all instructions are valid"
         );
     }
+
+    @Test
+    void generatesCodeForInterface() {
+        Assertions.assertDoesNotThrow(
+            () -> new BytecodeClass("org/eolang/benchmark/F")
+                .withMethod("j$foo", "()I", 1025)
+                .up()
+                .bytecode(),
+            "We expect no exception here because all instructions are valid"
+        );
+    }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
@@ -344,7 +344,7 @@ class DirectivesMethodVisitorTest {
             .label(end)
             .label(handler)
             .opcode(Opcodes.RETURN)
-            .entry(new BytecodeTryCatchBlock(start, end, handler, "java/lang/Exception"))
+            .trycatch(new BytecodeTryCatchBlock(start, end, handler, "java/lang/Exception"))
             .up()
             .xml()
             .toString();


### PR DESCRIPTION
Use `CheckClassAdapter` instead of `ClassWriter` to generate bytecode.
This change revealed some problems with the order of bytecode generation. All this problems were fixed in this PR.

Closes: #429
____
History:
- feat(#429): sketchy refactoring
- feat(#429): fix all tests
- feat(#429): fix all qulice suggestions
- feat(#429): add BytecodeField
- feat(#429): fix all unit tests
- feat(#429): don't insert code instructions for abstract methods
- feat(#429): fix all integration tests
- feat(#429): fix all qulice suggestions
- feat(#429): disable data glow analysis


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring and improving the code structure. 

### Detailed summary
- Renamed method `entry` to `trycatch` in class `BytecodeMethod`.
- Renamed method `write` to `writeMethod` in class `BytecodeMethodProperties`.
- Added new method `isAbstract` in class `BytecodeMethodProperties`.
- Added new method `withAnnotation` in class `BytecodeField`.
- Added new class `BytecodeAnnotation`.
- Added new class `BytecodeField`.
- Added new method `trycatch` in class `BytecodeMethod`.
- Added new field `tryblocks` in class `BytecodeMethod`.
- Added new method `write` in class `BytecodeField`.
- Updated method `write` in class `BytecodeAnnotation`.
- Updated method `write` in class `BytecodeMethodProperties`.
- Updated method `write` in class `BytecodeMethod`.

> The following files were skipped due to too many changes: `src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java`, `src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->