### PR TITLE
feat(#458): add VerifiedClassWriter to verify bytecode

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -50,7 +50,7 @@ public final class BytecodeClass implements Testable {
     /**
      * Class writer.
      */
-    private final CustomClassWriter writer;
+    private final CustomClassWriter visitor;
 
     /**
      * Methods.
@@ -154,7 +154,7 @@ public final class BytecodeClass implements Testable {
         final BytecodeClassProperties properties
     ) {
         this.name = name;
-        this.writer = writer;
+        this.visitor = writer;
         this.methods = methods;
         this.props = properties;
         this.fields = new ArrayList<>(0);
@@ -185,12 +185,12 @@ public final class BytecodeClass implements Testable {
      */
     public Bytecode bytecode() {
         try {
-            this.props.write(this.writer, this.name);
-            this.annotations.forEach(annotation -> annotation.write(this.writer));
-            this.fields.forEach(field -> field.write(this.writer));
+            this.props.write(this.visitor, this.name);
+            this.annotations.forEach(annotation -> annotation.write(this.visitor));
+            this.fields.forEach(field -> field.write(this.visitor));
             this.methods.forEach(BytecodeMethod::write);
-            this.writer.visitEnd();
-            return new Bytecode(this.writer.toByteArray());
+            this.visitor.visitEnd();
+            return new Bytecode(this.visitor.toByteArray());
         } catch (final IllegalArgumentException exception) {
             throw new IllegalArgumentException(
                 String.format("Can't create bytecode for the class '%s' ", this.name),
@@ -225,7 +225,7 @@ public final class BytecodeClass implements Testable {
      * @return This object.
      */
     public BytecodeMethod withMethod(final BytecodeMethodProperties properties) {
-        final BytecodeMethod method = new BytecodeMethod(properties, this.writer, this);
+        final BytecodeMethod method = new BytecodeMethod(properties, this.visitor, this);
         this.methods.add(method);
         return method;
     }
@@ -256,7 +256,7 @@ public final class BytecodeClass implements Testable {
     ) {
         final BytecodeMethod method = new BytecodeMethod(
             mname,
-            this.writer,
+            this.visitor,
             this,
             descriptor,
             modifiers

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.bytecode;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.eolang.jeo.representation.xmir.AllLabels;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
@@ -105,6 +106,15 @@ public final class BytecodeMethod implements Testable {
     @SuppressWarnings("PMD.ShortMethodName")
     public BytecodeClass up() {
         return this.clazz;
+    }
+
+    /**
+     * Add label.
+     * @param label Label.
+     * @return This object.
+     */
+    public BytecodeMethod label(final String label) {
+        return this.label(new AllLabels().label(label));
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/CustomClassWriter.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/CustomClassWriter.java
@@ -41,7 +41,7 @@ import org.objectweb.asm.ClassWriter;
  *
  * @since 0.1
  */
-public final class CustomClassWriter extends ClassWriter {
+public class CustomClassWriter extends ClassWriter {
 
     /**
      * Constructor.

--- a/src/main/java/org/eolang/jeo/representation/bytecode/CustomClassWriter.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/CustomClassWriter.java
@@ -51,7 +51,7 @@ public class CustomClassWriter extends ClassWriter {
     }
 
     @Override
-    public ClassLoader getClassLoader() {
+    public final ClassLoader getClassLoader() {
         return Thread.currentThread().getContextClassLoader();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/VerifiedClassWriter.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/VerifiedClassWriter.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.bytecode;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.eolang.jeo.representation.DefaultVersion;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.analysis.Analyzer;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.SimpleVerifier;
+import org.objectweb.asm.util.CheckClassAdapter;
+
+/**
+ * Class writer that verifies the bytecode.
+ * @since 0.2
+ */
+public final class VerifiedClassWriter extends CustomClassWriter {
+
+    @Override
+    public byte[] toByteArray() {
+        final byte[] bytes = super.toByteArray();
+        this.verify(bytes);
+        return bytes;
+    }
+
+    /**
+     * Verify the bytecode.
+     * @param bytes The bytecode to verify.
+     */
+    private void verify(final byte[] bytes) {
+        ClassNode classNode = new ClassNode();
+        new ClassReader(bytes).accept(
+            new CheckClassAdapter(new DefaultVersion().api(), classNode, false) {
+            },
+            ClassReader.SKIP_DEBUG
+        );
+        List<MethodNode> methods = classNode.methods;
+        Type syperType = classNode.superName == null ? null : Type.getObjectType(
+            classNode.superName);
+        List<Type> interfaces = new ArrayList<>();
+        for (String interfaceName : classNode.interfaces) {
+            interfaces.add(Type.getObjectType(interfaceName));
+        }
+        final String name = classNode.name;
+        for (MethodNode method : methods) {
+            try {
+                SimpleVerifier verifier =
+                    new SimpleVerifier(
+                        Type.getObjectType(name),
+                        syperType,
+                        interfaces,
+                        (classNode.access & Opcodes.ACC_INTERFACE) != 0
+                    );
+                Analyzer<BasicValue> analyzer = new Analyzer<>(verifier);
+                verifier.setClassLoader(Thread.currentThread().getContextClassLoader());
+                analyzer.analyze(name, method);
+            } catch (final AnalyzerException exception) {
+                throw new IllegalStateException(
+                    String.format(
+                        "Bytecode verification failed for the class '%s' and method '%s'",
+                        name,
+                        method
+                    ),
+                    exception
+                );
+            }
+        }
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/bytecode/VerifiedClassWriter.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/VerifiedClassWriter.java
@@ -45,7 +45,7 @@ public final class VerifiedClassWriter extends CustomClassWriter {
     @Override
     public byte[] toByteArray() {
         final byte[] bytes = super.toByteArray();
-        this.verify(bytes);
+        VerifiedClassWriter.verify(bytes);
         return bytes;
     }
 

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -180,7 +180,7 @@ class BytecodeClassTest {
         Assertions.assertThrows(
             IllegalStateException.class,
             () -> new BytecodeClass("Broken")
-                .withMethod("j$bar", "()I", 0)
+                .withMethod("j$bar", "()I", Opcodes.ACC_PUBLIC)
                 .label("70b56006-856e-4ac2-be99-632ca25a65a0")
                 .opcode(Opcodes.ALOAD, 0)
                 .opcode(Opcodes.INVOKEVIRTUAL, "com/exam/BA", "foo", "()I")

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -171,7 +171,26 @@ class BytecodeClassTest {
                 .withMethod("j$foo", "()I", 1025)
                 .up()
                 .bytecode(),
-            "We expect no exception here because all instructions are valid"
+            "We expect no exception here because all instructions are valid. This is an abstract method."
+        );
+    }
+
+    @Test
+    void failsBecauseBytecodeIsBroken() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new BytecodeClass("Broken")
+                .withMethod("j$bar", "()I", 0)
+                .label("70b56006-856e-4ac2-be99-632ca25a65a0")
+                .opcode(Opcodes.ALOAD, 0)
+                .opcode(Opcodes.INVOKEVIRTUAL, "com/exam/BA", "foo", "()I")
+                .opcode(Opcodes.ICONST_2)
+                .opcode(Opcodes.IADD)
+                .opcode(Opcodes.IRETURN)
+                .label("f3d973ab-c502-4134-8d6f-d7fe89defc6e")
+                .up()
+                .bytecode(),
+            "We expect an exception here because the bytecode is broken"
         );
     }
 }


### PR DESCRIPTION
Add VerifiedClasVriter in order to avoid parsing of errors from string output and catch exceptions directly.

Closes: #458.
____
History:
- feat(#458): add unit test that checks if bytecode fails
- feat(#458): remove redundant code
- feat(#458): add prestructor for BytecodeClass constructor
- feat(#458): fix all qulice suggestions
- feat(#458): use correct static invocation


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving bytecode verification in the `CustomClassWriter` class. 

### Detailed summary
- Changed `CustomClassWriter` to extend `ClassWriter` instead of being a final class.
- Added a new class `VerifiedClassWriter` that verifies the bytecode.
- Updated `BytecodeClass` to use the new `VerifiedClassWriter` for bytecode generation.
- Removed the `verifyBytecode` method from `BytecodeClass`.
- Refactored the constructor of `BytecodeClass` to use the appropriate class writer based on the verification flag.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->