### PR TITLE
feat(#462): open HexString making it public

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/HexString.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/HexString.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
  * Hex string.
  * @since 0.1.0
  */
-final class HexString {
+public final class HexString {
 
     /**
      * Hex radix.
@@ -48,7 +48,7 @@ final class HexString {
      * Constructor.
      * @param hex Hex string.
      */
-    HexString(final String hex) {
+    public HexString(final String hex) {
         this.hex = hex;
     }
 
@@ -58,7 +58,7 @@ final class HexString {
      *  "48 65 6C 6C 6F 20 57 6F 72 6C 64 21" -> "Hello World!"
      * @return Human-readable string.
      */
-    String decode() {
+    public String decode() {
         try {
             final String result;
             if (this.hex.isEmpty()) {
@@ -82,7 +82,7 @@ final class HexString {
      * Convert hex string to integer.
      * @return Integer.
      */
-    int decodeAsInt() {
+    public int decodeAsInt() {
         return Integer.parseInt(this.hex.trim().replace(" ", ""), HexString.RADIX);
     }
 
@@ -90,7 +90,7 @@ final class HexString {
      * Convert hex string to boolean.
      * @return Boolean.
      */
-    boolean decodeAsBoolean() {
+    public boolean decodeAsBoolean() {
         final String value = this.hex.trim();
         if (value.length() != 2) {
             throw new IllegalArgumentException(


### PR DESCRIPTION
Closes: #462


<!-- start pr-codex -->

---

## PR-Codex overview
This PR changes the access modifier of the `HexString` class to public and makes the `decode()`, `decodeAsInt()`, and `decodeAsBoolean()` methods public as well.

### Detailed summary
- Changed the access modifier of the `HexString` class to public.
- Made the `decode()`, `decodeAsInt()`, and `decodeAsBoolean()` methods public.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->