### PR TITLE
feat(#466): Print Correct Labels in Test Code

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionEntry.java
@@ -30,6 +30,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.ToString;
 import org.eolang.jeo.representation.directives.OpcodeName;
+import org.eolang.jeo.representation.xmir.AllLabels;
+import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
@@ -92,9 +94,13 @@ final class BytecodeInstructionEntry implements BytecodeEntry {
                 if (arg instanceof String) {
                     return String.format("\"%s\"", arg);
                 }
+                if (arg instanceof Label) {
+                    final String uid = new AllLabels().uid((Label) arg);
+                    return String.format("labels.label(\"%s\")", uid);
+                }
                 return arg.toString();
             })
-        ).collect(Collectors.joining(","));
+        ).collect(Collectors.joining(", "));
         return String.format(".opcode(%s)", args);
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionEntry.java
@@ -31,7 +31,6 @@ import java.util.stream.Stream;
 import lombok.ToString;
 import org.eolang.jeo.representation.directives.OpcodeName;
 import org.eolang.jeo.representation.xmir.AllLabels;
-import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
@@ -94,9 +93,11 @@ final class BytecodeInstructionEntry implements BytecodeEntry {
                 if (arg instanceof String) {
                     return String.format("\"%s\"", arg);
                 }
-                if (arg instanceof Label) {
-                    final String uid = new AllLabels().uid((Label) arg);
-                    return String.format("labels.label(\"%s\")", uid);
+                if (arg instanceof org.objectweb.asm.Label) {
+                    return String.format(
+                        "labels.label(\"%s\")",
+                        new AllLabels().uid((org.objectweb.asm.Label) arg)
+                    );
                 }
                 return arg.toString();
             })


### PR DESCRIPTION
Print correct opcode label operands in test code.

Closes: #466.
____
History:
- feat(#466): print labels correctly
- feat(#466): fix all qulice suggestions


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding support for representing ASM labels in the bytecode instruction entry. 

### Detailed summary
- Added import for `org.eolang.jeo.representation.xmir.AllLabels`
- Updated the `testCode()` method to handle ASM labels and format them as `labels.label("labelName")`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->