### PR TITLE
feat(#464): Add Integration Test For Spring Boot Application That Still Fails

### DIFF
--- a/src/it/spring-fat/README.md
+++ b/src/it/spring-fat/README.md
@@ -1,0 +1,16 @@
+# Spring Fat Jar Integration Test
+
+Integration test that checks the correct transformation of an application
+written with using of the Springs Framework. This integration test starts the
+application with several beans and prints results to the console.
+This is a similar integration test with the "spring" test in
+the [spring](../spring) test.
+
+The only difference is that in this test we download all the dependencies,
+unpack them, transform using jeo-maven-plugin and then pack them back. In other
+words, we test the fat jar transformation.
+
+If you need to run only this test, use the following command:
+```shell
+mvn clean integration-test invoker:run -Dinvoker.test=spring-fat -DskipTests
+```

--- a/src/it/spring-fat/invoker.properties
+++ b/src/it/spring-fat/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean spring-boot:run -e

--- a/src/it/spring-fat/invoker.properties
+++ b/src/it/spring-fat/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = clean spring-boot:run -e
+invoker.goals=clean process-classes -e

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -63,27 +63,66 @@ SOFTWARE.
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eolang</groupId>
-        <artifactId>jeo-maven-plugin</artifactId>
-        <version>@project.version@</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.2.0</version>
         <executions>
           <execution>
-            <id>bytecode-to-eo</id>
+            <id>unpack-dependencies</id>
             <goals>
-              <goal>disassemble</goal>
+              <goal>unpack-dependencies</goal>
             </goals>
-          </execution>
-          <execution>
-            <id>eo-to-bytecode</id>
-            <goals>
-              <goal>assemble</goal>
-            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+            </configuration>
           </execution>
         </executions>
       </plugin>
+      <!--      <plugin>-->
+      <!--        <groupId>org.eolang</groupId>-->
+      <!--        <artifactId>jeo-maven-plugin</artifactId>-->
+      <!--        <version>@project.version@</version>-->
+      <!--        <executions>-->
+      <!--          <execution>-->
+      <!--            <id>bytecode-to-eo</id>-->
+      <!--            <goals>-->
+      <!--              <goal>disassemble</goal>-->
+      <!--            </goals>-->
+      <!--          </execution>-->
+      <!--          <execution>-->
+      <!--            <id>eo-to-bytecode</id>-->
+      <!--            <goals>-->
+      <!--              <goal>assemble</goal>-->
+      <!--            </goals>-->
+      <!--          </execution>-->
+      <!--        </executions>-->
+      <!--      </plugin>-->
+      <!--      <plugin>-->
+      <!--        <groupId>org.springframework.boot</groupId>-->
+      <!--        <artifactId>spring-boot-maven-plugin</artifactId>-->
+      <!--      </plugin>-->
       <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <phase>
+              process-classes
+            </phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <executable>java</executable>
+          <arguments>
+            <argument>-classpath</argument>
+            <argument>${project.build.outputDirectory}</argument>
+            <argument>org.eolang.jeo.spring.Application</argument>
+          </arguments>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -83,6 +83,13 @@ SOFTWARE.
         <artifactId>jeo-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>
+          <!--
+            @todo #464:90min Enable 'spring-fat' Integration Test.
+             Currently, the 'spring-fat' integration test is disabled because
+             it fails. The reason is that the 'jeo-maven-plugin' does not
+             support many java features. We need to implement them and enable
+             the test.
+          -->
           <disabled>true</disabled>
         </configuration>
         <executions>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -37,14 +37,17 @@ SOFTWARE.
     <relativePath/>
   </parent>
   <groupId>org.eolang</groupId>
-  <artifactId>jeo-spring-it</artifactId>
+  <artifactId>jeo-spring-fat-it</artifactId>
   <version>@project.version@</version>
   <packaging>jar</packaging>
   <description>
     Integration test that checks correct transformation of an application written with using of the Springs Framework.
     This integration test starts the application with several beans and prints results to the console.
+    This is a similar integration test with the "spring" test in the "src/it/spring" test.
+    The only difference is that in this test we download all the dependencies, unpack them, transform using jeo-maven-plugin
+    and then pack them back. In other words, we test the fat jar transformation.
     If you need to run only this test, use the following command:
-    "mvn clean integration-test invoker:run -Dinvoker.test=spring -DskipTests"
+    "mvn clean integration-test invoker:run -Dinvoker.test=spring-fat -DskipTests"
   </description>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -78,29 +78,28 @@ SOFTWARE.
           </execution>
         </executions>
       </plugin>
-      <!--      <plugin>-->
-      <!--        <groupId>org.eolang</groupId>-->
-      <!--        <artifactId>jeo-maven-plugin</artifactId>-->
-      <!--        <version>@project.version@</version>-->
-      <!--        <executions>-->
-      <!--          <execution>-->
-      <!--            <id>bytecode-to-eo</id>-->
-      <!--            <goals>-->
-      <!--              <goal>disassemble</goal>-->
-      <!--            </goals>-->
-      <!--          </execution>-->
-      <!--          <execution>-->
-      <!--            <id>eo-to-bytecode</id>-->
-      <!--            <goals>-->
-      <!--              <goal>assemble</goal>-->
-      <!--            </goals>-->
-      <!--          </execution>-->
-      <!--        </executions>-->
-      <!--      </plugin>-->
-      <!--      <plugin>-->
-      <!--        <groupId>org.springframework.boot</groupId>-->
-      <!--        <artifactId>spring-boot-maven-plugin</artifactId>-->
-      <!--      </plugin>-->
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>jeo-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <disabled>true</disabled>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bytecode-to-eo</id>
+            <goals>
+              <goal>disassemble</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>eo-to-bytecode</id>
+            <goals>
+              <goal>assemble</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/src/it/spring-fat/src/main/java/org/eolang/jeo/spring/Application.java
+++ b/src/it/spring-fat/src/main/java/org/eolang/jeo/spring/Application.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.spring;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Spring Application Entry Point.
+ * @since 0.2
+ */
+@SpringBootApplication
+public class Application implements CommandLineRunner {
+
+    @Autowired
+    private Receptionist receptionist;
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+    @Override
+    public void run(final String... args) {
+        this.receptionist.sayHello("Fat Spring");
+    }
+}

--- a/src/it/spring-fat/src/main/java/org/eolang/jeo/spring/Receptionist.java
+++ b/src/it/spring-fat/src/main/java/org/eolang/jeo/spring/Receptionist.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.spring;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Greeter bean.
+ * @since 0.2
+ */
+@Component
+public class Receptionist {
+    public void sayHello(final String who) {
+        System.out.printf("Glad to see you, %s...%n", who);
+    }
+}

--- a/src/it/spring-fat/verify.groovy
+++ b/src/it/spring-fat/verify.groovy
@@ -1,0 +1,31 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+//Check logs first.
+String log = new File(basedir, 'build.log').text;
+assert log.contains("BUILD SUCCESS")
+assert log.contains("Glad to see you, Fat Spring...")
+//Check that we have generated EO object files.
+assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/spring/Application.xmir').exists()
+assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/spring/Receptionist.xmir').exists()
+true

--- a/src/it/spring-fat/verify.groovy
+++ b/src/it/spring-fat/verify.groovy
@@ -26,6 +26,6 @@ String log = new File(basedir, 'build.log').text;
 assert log.contains("BUILD SUCCESS")
 assert log.contains("Glad to see you, Fat Spring...")
 //Check that we have generated EO object files.
-assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/spring/Application.xmir').exists()
-assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/spring/Receptionist.xmir').exists()
+//assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/spring/Application.xmir').exists()
+//assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/spring/Receptionist.xmir').exists()
 true

--- a/src/it/spring/README.md
+++ b/src/it/spring/README.md
@@ -1,0 +1,11 @@
+# Spring Fat Jar Integration Test
+
+Integration test that checks the correct transformation of an application
+written with using of the Springs Framework. This integration test starts the
+application with several beans and prints results to the console.
+
+If you need to run only this test, use the following command:
+
+```shell
+mvn clean integration-test invoker:run -Dinvoker.test=spring -DskipTests
+```

--- a/src/it/spring/invoker.properties
+++ b/src/it/spring/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = clean spring-boot:run -e
+invoker.goals=clean spring-boot:run -e

--- a/src/main/java/org/eolang/jeo/AssembleMojo.java
+++ b/src/main/java/org/eolang/jeo/AssembleMojo.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo;
 
+import com.jcabi.log.Logger;
 import java.io.File;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.AbstractMojo;
@@ -89,15 +90,32 @@ public final class AssembleMojo extends AbstractMojo {
     )
     private boolean skipVerification;
 
+    /**
+     * Whether the plugin is disabled.
+     * If it's disabled, then it won't do anything.
+     *
+     * @since 0.2.0
+     * @checkstyle MemberNameCheck (6 lines)
+     */
+    @Parameter(
+        property = "jeo.disassemble.disabled",
+        defaultValue = "false"
+    )
+    private boolean disabled;
+
     @Override
     public void execute() throws MojoExecutionException {
         try {
             new PluginStartup(this.project).init();
-            new Assembler(
-                this.sourcesDir.toPath(),
-                this.outputDir.toPath(),
-                !this.skipVerification
-            ).assemble();
+            if (this.disabled) {
+                Logger.info(this, "Assemble mojo is disabled. Skipping.");
+            } else {
+                new Assembler(
+                    this.sourcesDir.toPath(),
+                    this.outputDir.toPath(),
+                    !this.skipVerification
+                ).assemble();
+            }
         } catch (final DependencyResolutionRequiredException exception) {
             throw new MojoExecutionException(exception);
         }

--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -79,7 +79,6 @@ public final class DisassembleMojo extends AbstractMojo {
     )
     private File outputDir;
 
-
     /**
      * Whether the plugin is disabled.
      * If it's disabled, then it won't do anything.

--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo;
 
+import com.jcabi.log.Logger;
 import java.io.File;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.AbstractMojo;
@@ -78,13 +79,31 @@ public final class DisassembleMojo extends AbstractMojo {
     )
     private File outputDir;
 
+
+    /**
+     * Whether the plugin is disabled.
+     * If it's disabled, then it won't do anything.
+     *
+     * @since 0.2.0
+     * @checkstyle MemberNameCheck (6 lines)
+     */
+    @Parameter(
+        property = "jeo.disassemble.disabled",
+        defaultValue = "false"
+    )
+    private boolean disabled;
+
     @Override
     public void execute() throws MojoExecutionException {
         try {
             new PluginStartup(this.project).init();
-            new Disassembler(
-                this.sourcesDir.toPath(), this.outputDir.toPath()
-            ).disassemble();
+            if (this.disabled) {
+                Logger.info(this, "Disassemble mojo is disabled. Skipping.");
+            } else {
+                new Disassembler(
+                    this.sourcesDir.toPath(), this.outputDir.toPath()
+                ).disassemble();
+            }
         } catch (final DependencyResolutionRequiredException exception) {
             throw new MojoExecutionException(
                 String.format(


### PR DESCRIPTION
In this PR I added one more integration test that has 'spring-fat' name. Its purpose is to download dependencies, transform them using `jeo-maven-plugin`
and then try to run the application with translated dependencies.
Of course the test doesn't work because we have to implement more bytecode features transformations, so I left one more puzzle for it.

Closes: #464.
____
History:
- **feat(#464): add the dummy integration test for the spring spring framework**
- **feat(#464): make fat test works as expected with downloading all the required dependencies and using only classpath without maven dependencies**
- **feat(#464): add 'disabled' plugin property to disable plugin invocation**
- **feat(#464): add one more puzzle to enable 'spring-fat' integration test**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances integration tests for Spring applications. It introduces a fat jar transformation test, adds a new Spring bean, and includes a new Spring application entry point.

### Detailed summary
- Added a fat jar transformation test for Spring applications
- Introduced a new Spring bean called `Receptionist`
- Included a new Spring application entry point in `Application.java`
- Updated integration test READMEs and properties
- Added license headers to relevant files

> The following files were skipped due to too many changes: `src/it/spring-fat/pom.xml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->