### PR TITLE
feat(#483): remove `.0pdd.yaml` config

### DIFF
--- a/.0pdd.yaml
+++ b/.0pdd.yaml
@@ -1,5 +1,0 @@
-format:
-  - short-title
-tags:
-  - pdd
-  - bug


### PR DESCRIPTION
Try to remove `.0pdd.yaml` config to repair pdd bot.

Closes: #483.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the `.0pdd.yaml` file from the repository.

### Detailed summary
- Deleted the `.0pdd.yaml` file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->