### PR TITLE
chore: update jtcop version 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@ SOFTWARE.
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
-            <version>1.1.1</version>
+            <version>1.2.0</version>
             <executions>
               <execution>
                 <phase>verify</phase>

--- a/src/test/java/org/eolang/jeo/representation/directives/HasClass.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasClass.java
@@ -36,7 +36,11 @@ import org.hamcrest.TypeSafeMatcher;
  * Matcher to check if the received XMIR document has a class with a given name.
  * @since 0.1.0
  */
-@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleCorrectTestName"})
+@SuppressWarnings({
+    "JTCOP.RuleAllTestsHaveProductionClass",
+    "JTCOP.RuleCorrectTestName",
+    "JTCOP.RuleInheritanceInTests"
+})
 final class HasClass extends TypeSafeMatcher<String> {
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
@@ -42,7 +42,8 @@ import org.objectweb.asm.Label;
 @SuppressWarnings({
     "PMD.TooManyMethods",
     "JTCOP.RuleAllTestsHaveProductionClass",
-    "JTCOP.RuleCorrectTestName"
+    "JTCOP.RuleCorrectTestName",
+    "JTCOP.RuleInheritanceInTests"
 })
 public final class HasMethod extends TypeSafeMatcher<String> {
 


### PR DESCRIPTION
Update jtcop-maven-plugin version to `1.2.0`. 


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of `jtcop-maven-plugin`, adds a new rule `JTCOP.RuleInheritanceInTests`, and includes it in relevant test classes.

### Detailed summary
- Updated `jtcop-maven-plugin` version to `1.2.0` in `pom.xml`
- Added `JTCOP.RuleInheritanceInTests` rule in `HasMethod` and `HasClass` test classes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->