### PR TITLE
feat(#499): Speed Up Integration Tests

### DIFF
--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -90,7 +90,7 @@ SOFTWARE.
              support many java features. We need to implement them and enable
              the test.
           -->
-          <disabled>false</disabled>
+          <disabled>true</disabled>
         </configuration>
         <executions>
           <execution>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -90,7 +90,7 @@ SOFTWARE.
              support many java features. We need to implement them and enable
              the test.
           -->
-          <disabled>true</disabled>
+          <disabled>false</disabled>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/org/eolang/jeo/Assemble.java
+++ b/src/main/java/org/eolang/jeo/Assemble.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.eolang.jeo.representation.BytecodeRepresentation;
 import org.eolang.jeo.representation.JavaName;
+import org.eolang.jeo.representation.xmir.AllLabels;
 
 /**
  * Assemble a representation.
@@ -51,6 +52,7 @@ public final class Assemble implements Translation {
 
     @Override
     public Representation apply(final Representation representation) {
+        new AllLabels().clearCache();
         final Details details = representation.details();
         final String name = new JavaName(details.name()).decode();
         try {

--- a/src/main/java/org/eolang/jeo/Disassemble.java
+++ b/src/main/java/org/eolang/jeo/Disassemble.java
@@ -53,6 +53,13 @@ public final class Disassemble implements Translation {
 
     @Override
     public Representation apply(final Representation representation) {
+        // @checkstyle MethodBodyCommentsCheck (6 lines)
+        //  @todo #499:90min Use AllLabels properly to avoid the need to clear the cache.
+        //   It's better to create a new instance of AllLabels for each method that is parsed.
+        //   AllLabels shouldn't share common cache between different methods.
+        //   The following line were added to optimize the performance of the code.
+        //   This is dangerous and should be removed as soon as possible.
+        //   Moreover, we have the same solution in {@link Assemble} class.
         new AllLabels().clearCache();
         final String name = new JavaName(representation.details().name()).decode();
         final Path path = this.target

--- a/src/main/java/org/eolang/jeo/Disassemble.java
+++ b/src/main/java/org/eolang/jeo/Disassemble.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.eolang.jeo.representation.JavaName;
 import org.eolang.jeo.representation.XmirRepresentation;
+import org.eolang.jeo.representation.xmir.AllLabels;
 
 /**
  * Disassemble a representation to a file.
@@ -52,6 +53,7 @@ public final class Disassemble implements Translation {
 
     @Override
     public Representation apply(final Representation representation) {
+        new AllLabels().clearCache();
         final String name = new JavaName(representation.details().name()).decode();
         final Path path = this.target
             .resolve(String.format("%s.xmir", name.replace('/', File.separatorChar)));

--- a/src/main/java/org/eolang/jeo/representation/xmir/AllLabels.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/AllLabels.java
@@ -95,6 +95,13 @@ public final class AllLabels {
     }
 
     /**
+     * Clear the cache.
+     */
+    public void clearCache() {
+        this.labels.clear();
+    }
+
+    /**
      * Clean the UID.
      * @param uid UID with new lines and spaces.
      * @return Cleaned UID.


### PR DESCRIPTION
This PR drastically improves the performance of all integration tests. Particullary `spring-fat` integration test has been accellerated in `x24` times. Was `42 min`, become `101 sec`.
Although it worth mention that the solution provided looks like an ad-hoc solution and reqires further consideration, so I've left 'todo' puzzle to refactor this code.

Closes: #499
____
History:
- **feat(#499): provide the optimization that speeds up spring-fat integration test x24**
- **feat(#499): add one more puzzle to refactor AllLabels class in the future**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR optimizes the performance of the code by properly using `AllLabels` to avoid sharing cache between methods in `Assemble` and `Disassemble` classes.

### Detailed summary
- Added `clearCache` method to `AllLabels` class.
- Called `clearCache` method in `Assemble` and `Disassemble` classes to optimize performance.
- Added comments in `Disassemble` class to address optimization concerns.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->