### PR TITLE
chore: update qulice version 0.22.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@ SOFTWARE.
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.22.1</version>
+            <version>0.22.2</version>
             <configuration>
               <license>file:${basedir}/LICENSE.txt</license>
               <excludes>

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -325,14 +325,15 @@ public final class BytecodeClass implements Testable {
 
     @Override
     public String testCode() {
-        final StringBuilder builder = new StringBuilder(
-            "AllLabels labels = new AllLabels();\nnew BytecodeClass("
-        ).append('"').append(this.name).append('"').append(')').append('\n');
+        final StringBuilder builder = new StringBuilder(0);
         for (final BytecodeMethod method : this.methods) {
             builder.append('.').append(method.testCode()).append('\n');
         }
-        builder.append(".bytecode();");
-        return builder.toString();
+        return String.format(
+            "AllLabels labels = new AllLabels();\nnew BytecodeClass(\"%s\")\n%s.bytecode();",
+            this.name,
+            builder
+        );
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -118,7 +118,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         final Directives directives = new Directives();
         final String eoname;
-        if (this.name.equals("<init>")) {
+        if ("<init>".equals(this.name)) {
             eoname = "new";
         } else {
             eoname = this.name;

--- a/src/main/java/org/eolang/jeo/representation/xmir/HexString.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/HexString.java
@@ -108,6 +108,6 @@ public final class HexString {
                 )
             );
         }
-        return value.equals("01");
+        return "01".equals(value);
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -239,7 +239,7 @@ public final class XmlNode {
     XmlBytecodeEntry toEntry() {
         final XmlBytecodeEntry result;
         final Optional<String> base = this.attribute("base");
-        if (base.isPresent() && base.get().equals("label")) {
+        if (base.isPresent() && "label".equals(base.get())) {
             result = new XmlLabel(this);
         } else {
             result = new XmlInstruction(this);
@@ -279,7 +279,7 @@ public final class XmlNode {
         final List<Node> res = new ArrayList<>(children.getLength());
         for (int index = 0; index < children.getLength(); ++index) {
             final Node child = children.item(index);
-            if (child.getNodeName().equals("o")) {
+            if ("o".equals(child.getNodeName())) {
                 res.add(child);
             }
         }


### PR DESCRIPTION
Update qulice version up to `0.22.2`.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves code readability by changing string comparison order, updating Qulice plugin version, and enhancing string formatting for better maintainability.

### Detailed summary
- Changed string comparison order in `HexString.java` and `XmlNode.java`
- Updated Qulice plugin version in `pom.xml`
- Improved string formatting in `BytecodeClass.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->