### PR TITLE
feat(#515): Lambdas Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,21 +231,6 @@ SOFTWARE.
     </testResources>
     <plugins>
       <plugin>
-        <artifactId>maven-invoker-plugin</artifactId>
-        <configuration>
-          <!--
-          @todo #488:90min Implement lambdas assembling and disassembling.
-           Enable the execution of the `custom-transformations` integration test.
-           Currently, the `spring-fat` integration test is disabled because it fails.
-           The reason is that the `jeo-maven-plugin` does not support lamdas.
-           We need to implement them and enable the test.
-          -->
-          <pomExcludes>
-            <exclude>custom-transformations/pom.xml</exclude>
-          </pomExcludes>
-        </configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
         <configuration>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/src/it/custom-transformations/src/main/java/org/eolang/jeo/Application.java
+++ b/src/it/custom-transformations/src/main/java/org/eolang/jeo/Application.java
@@ -40,7 +40,11 @@ public class Application {
         Runnable r = () -> System.out.println("Runnable test passed successfully!");
         r.run();
         Predicate<String> p = s -> s.length() > 10;
-        System.out.println(p.test("Predicate test passed successfully!"));
+        System.out.println(
+            "Predicate test passed successfully " +
+                p.test("String length is greater than 10!") +
+                "!"
+        );
         Consumer<String> c = s -> System.out.println("Consumer test passed successfully with " + s);
         c.accept("Consumer!");
         Function<String, Integer> f = s -> s.length();
@@ -48,7 +52,7 @@ public class Application {
     }
 
     private static void streams() {
-        List<String> list = Arrays.asList("Streams", "test", "passed", "successfully!");
+        List<String> list = Arrays.asList("Streams", "Test", "paSSed", "successfuLLy!");
         final String res = list.stream().map(String::toLowerCase).collect(Collectors.joining(" "));
         System.out.println(res);
     }

--- a/src/it/custom-transformations/verify.groovy
+++ b/src/it/custom-transformations/verify.groovy
@@ -26,10 +26,10 @@ String log = new File(basedir, 'build.log').text;
 assert log.contains("BUILD SUCCESS")
 assert log.contains("Hello, World!")
 assert log.contains("Runnable test passed successfully!")
-assert log.contains("Predicate test passed successfully!")
+assert log.contains("Predicate test passed successfully true!")
 assert log.contains("Consumer test passed successfully with Consumer!")
 assert log.contains("Function test passed successfully with 8!")
-assert log.contains("Streams test passed successfully!")
+assert log.contains("streams test passed successfully!")
 //Check that we have generated XMIR object file.
 assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/Application.xmir').exists()
 assert new File(basedir, 'target/generated-sources/jeo-eo/org/eolang/jeo/Application.eo').exists()

--- a/src/main/java/org/eolang/jeo/representation/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/DataType.java
@@ -28,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.function.Function;
 import org.eolang.jeo.representation.xmir.AllLabels;
-import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Type;
 

--- a/src/main/java/org/eolang/jeo/representation/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/DataType.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.function.Function;
 import org.eolang.jeo.representation.xmir.AllLabels;
+import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Type;
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlHandler.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlHandler.java
@@ -42,7 +42,7 @@ final class XmlHandler {
      * Constructor.
      * @param node Node.
      */
-    public XmlHandler(final XmlNode node) {
+    XmlHandler(final XmlNode node) {
         this.node = node;
     }
 
@@ -50,7 +50,7 @@ final class XmlHandler {
      * Convert to a handler.
      * @return Handler.
      */
-    public Handle asHandle() {
+    Handle asHandle() {
         final List<XmlOperand> operands = this.node.children()
             .map(XmlOperand::new)
             .collect(Collectors.toList());

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlHandler.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlHandler.java
@@ -21,48 +21,45 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.jeo.representation.directives;
+package org.eolang.jeo.representation.xmir;
 
-import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.objectweb.asm.Handle;
-import org.xembly.Directive;
-import org.xembly.Directives;
 
 /**
- * Directives Handle.
- * Xmir representation of the Java ASM Handle object.
- * @since 0.1
- * @todo #329:30min Implement DirectivesHandle class.
- *  The {@link Handle} class is one of the parameters for INVOKEDYNAMIC instruction.
- *  The class should be implemented in the same way as {@link DirectivesLabel}.
- *  Don't forget to add tests.
+ * XML representation of handler.
+ * @since 0.3
  */
-public final class DirectivesHandle implements Iterable<Directive> {
+final class XmlHandler {
 
     /**
-     * ASM Handle object.
+     * XML node.
      */
-    private final Handle handle;
+    private final XmlNode node;
 
     /**
      * Constructor.
-     * @param handle ASM Handle object.
+     * @param node Node.
      */
-    public DirectivesHandle(final Handle handle) {
-        this.handle = handle;
+    public XmlHandler(final XmlNode node) {
+        this.node = node;
     }
 
-    @Override
-    public Iterator<Directive> iterator() {
-        return new Directives()
-            .add("o")
-            .attr("base", "handle")
-            .append(new DirectivesData(this.handle.getTag()))
-            .append(new DirectivesData(this.handle.getOwner()))
-            .append(new DirectivesData(this.handle.getName()))
-            .append(new DirectivesData(this.handle.getDesc()))
-            .append(new DirectivesData(this.handle.isInterface()))
-            .up()
-            .iterator();
+    /**
+     * Convert to a handler.
+     * @return Handler.
+     */
+    public Handle asHandle() {
+        final List<XmlOperand> operands = this.node.children()
+            .map(XmlOperand::new)
+            .collect(Collectors.toList());
+        return new Handle(
+            Integer.class.cast(operands.get(0).asObject()),
+            operands.get(1).asObject().toString(),
+            operands.get(2).asObject().toString(),
+            operands.get(3).asObject().toString(),
+            Boolean.class.cast(operands.get(4).asObject())
+        );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlOperand.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlOperand.java
@@ -61,7 +61,7 @@ public final class XmlOperand {
                     )
                 )
             );
-        if (base.equals("handle")) {
+        if ("handle".equals(base)) {
             result = new XmlHandler(this.raw).asHandle();
         } else {
             result = DataType.find(base).decode(this.raw.text());

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesHandleTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesHandleTest.java
@@ -36,7 +36,7 @@ import org.xembly.Xembler;
  *
  * @since 0.3
  */
-class DirectivesHandleTest {
+final class DirectivesHandleTest {
 
     @Test
     void convertsHandleToDirectives() throws ImpossibleModificationException {

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesHandleTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesHandleTest.java
@@ -23,46 +23,36 @@
  */
 package org.eolang.jeo.representation.directives;
 
-import java.util.Iterator;
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Handle;
-import org.xembly.Directive;
-import org.xembly.Directives;
+import org.objectweb.asm.Opcodes;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
 
 /**
- * Directives Handle.
- * Xmir representation of the Java ASM Handle object.
- * @since 0.1
- * @todo #329:30min Implement DirectivesHandle class.
- *  The {@link Handle} class is one of the parameters for INVOKEDYNAMIC instruction.
- *  The class should be implemented in the same way as {@link DirectivesLabel}.
- *  Don't forget to add tests.
+ * Test case for {@link DirectivesHandle}.
+ *
+ * @since 0.3
  */
-public final class DirectivesHandle implements Iterable<Directive> {
+class DirectivesHandleTest {
 
-    /**
-     * ASM Handle object.
-     */
-    private final Handle handle;
-
-    /**
-     * Constructor.
-     * @param handle ASM Handle object.
-     */
-    public DirectivesHandle(final Handle handle) {
-        this.handle = handle;
-    }
-
-    @Override
-    public Iterator<Directive> iterator() {
-        return new Directives()
-            .add("o")
-            .attr("base", "handle")
-            .append(new DirectivesData(this.handle.getTag()))
-            .append(new DirectivesData(this.handle.getOwner()))
-            .append(new DirectivesData(this.handle.getName()))
-            .append(new DirectivesData(this.handle.getDesc()))
-            .append(new DirectivesData(this.handle.isInterface()))
-            .up()
-            .iterator();
+    @Test
+    void convertsHandleToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesHandle(
+                new Handle(Opcodes.H_INVOKESTATIC, "java/lang/Math", "max", "(II)I", false)
+            )
+        ).xml();
+        MatcherAssert.assertThat(
+            String.format("Can't convert Handle to DirectivesHandle. Expected XML:%n%s%n", xml),
+            xml,
+            XhtmlMatchers.hasXPaths(
+                "/o[@base='handle']",
+                "/o[@base='handle']/o[@base='int']",
+                "/o[@base='handle']/o[@base='string']"
+            )
+        );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlHandlerTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlHandlerTest.java
@@ -31,13 +31,12 @@ import org.objectweb.asm.Handle;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
-
 /**
  * Test case for {@link XmlHandler}.
  *
  * @since 0.3
  */
-class XmlHandlerTest {
+final class XmlHandlerTest {
 
     @Test
     void convertsToHandleObject() throws ImpossibleModificationException {

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlHandlerTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlHandlerTest.java
@@ -23,49 +23,32 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import lombok.ToString;
-import org.eolang.jeo.representation.DataType;
+import org.eolang.jeo.representation.directives.DirectivesHandle;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Handle;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
 
 /**
- * XML operand.
+ * Test case for {@link XmlHandler}.
+ *
  * @since 0.3
  */
-@ToString
-public final class XmlOperand {
+class XmlHandlerTest {
 
-    /**
-     * Raw XML node which represents an instruction operand.
-     */
-    private final XmlNode raw;
-
-    /**
-     * Constructor.
-     * @param node Raw XML operand node.
-     */
-    public XmlOperand(final XmlNode node) {
-        this.raw = node;
+    @Test
+    void convertsToHandleObject() throws ImpossibleModificationException {
+        final Handle handle = new Handle(
+            1, "owner", "name", "desc", false
+        );
+        MatcherAssert.assertThat(
+            "Can't convert XML handler to the correct handle object",
+            new XmlHandler(new XmlNode(new Xembler(new DirectivesHandle(handle)).xml())).asHandle(),
+            Matchers.equalTo(handle)
+        );
     }
 
-    /**
-     * Convert XML operand to an object.
-     * @return Object.
-     */
-    public Object asObject() {
-        final Object result;
-        final String base = this.raw.attribute("base")
-            .orElseThrow(
-                () -> new IllegalStateException(
-                    String.format(
-                        "'%s' is not an argument because it doesn't have 'base' attribute",
-                        this.raw
-                    )
-                )
-            );
-        if (base.equals("handle")) {
-            result = new XmlHandler(this.raw).asHandle();
-        } else {
-            result = DataType.find(base).decode(this.raw.text());
-        }
-        return result;
-    }
 }


### PR DESCRIPTION
In this PR I add the implementation of labels disassembling/assembling. Now `jeo-maven-plugin` can work with lambdas.
Closes: #515.
____
History:
- **feat(#515): add ASM Handler disassebmbling/assembling logic**
- **feat(#515): stabilaize custom-transformations integration test**
- **feat(#515): enable custom-transformations integration test**
- **feat(#515): fix all qulice suggestions**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances XML handling in Java by adding new features and improving existing functionalities. 

### Detailed summary
- Added new methods and classes for XML handling
- Updated XML parsing and conversion logic
- Improved testing coverage for XML-related classes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->