### PR TITLE
feat(#518): Extend Data Types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,23 +231,6 @@ SOFTWARE.
     </testResources>
     <plugins>
       <plugin>
-        <artifactId>maven-invoker-plugin</artifactId>
-        <configuration>
-          <!--
-          @todo #488:90min Enable 'exceptions' integration test.
-           Enable the execution of the `exceptions` integration test.
-           Currently, the `exceptions` integration test is disabled because it fails.
-           The reason is that we broke something in field parsing and we need to fix it.
-           Actually, it's important to pay attention to XmlField, DirectivesField and DataType classes.
-           The problem started after the 'null' return of the `DataType#decode` method.
-           So it's important to cover all this classes by unit tests and then enable the integration test.
-          -->
-          <pomExcludes>
-            <exclude>exceptions/pom.xml</exclude>
-          </pomExcludes>
-        </configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
         <configuration>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/src/it/exceptions/README.md
+++ b/src/it/exceptions/README.md
@@ -1,0 +1,10 @@
+# Exceptions Integration Test
+
+Integration test that checks correct transformation simple Java application
+that utilizes exceptions. 
+
+If you need to run only this test, use the following command:
+
+```shell
+mvn clean integration-test invoker:run -Dinvoker.test=exceptions -DskipTests
+```

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -90,7 +90,7 @@ SOFTWARE.
              support many java features. We need to implement them and enable
              the test.
           -->
-          <disabled>true</disabled>
+          <disabled>false</disabled>
           <skipVerification>true</skipVerification>
         </configuration>
         <executions>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -90,7 +90,7 @@ SOFTWARE.
              support many java features. We need to implement them and enable
              the test.
           -->
-          <disabled>false</disabled>
+          <disabled>true</disabled>
           <skipVerification>true</skipVerification>
         </configuration>
         <executions>

--- a/src/main/java/org/eolang/jeo/representation/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/DataType.java
@@ -180,7 +180,7 @@ public enum DataType {
      */
     public Object decode(final String raw) {
         final Object result;
-        if (raw == null || raw.isEmpty()) {
+        if (raw == null) {
             result = null;
         } else {
             final char[] chars = raw.trim().replace(" ", "").toCharArray();

--- a/src/main/java/org/eolang/jeo/representation/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/DataType.java
@@ -41,9 +41,17 @@ public enum DataType {
     /**
      * Boolean.
      */
-    BOOL("bool", Boolean.class, boolean.class, value ->
-        DataType.hexBoolean(Boolean.class.cast(value)),
+    BOOL("bool", Boolean.class, boolean.class, value -> {
+
+        if (value == null) {
+            return null;
+        }
+        return DataType.hexBoolean(Boolean.class.cast(value));
+    },
         bytes -> {
+            if (bytes == null) {
+                return null;
+            }
             return Boolean.valueOf(bytes[0] != 0);
         }
     ),
@@ -51,63 +59,126 @@ public enum DataType {
     /**
      * Integer.
      */
-    INT("int", Integer.class, int.class, value ->
-        ByteBuffer.allocate(Long.BYTES).putLong((int) value).array(),
-        bytes -> (int) ByteBuffer.wrap(bytes).getLong()
+    INT("int", Integer.class, int.class, value -> {
+        if (value == null) {
+            return null;
+        }
+        return ByteBuffer.allocate(Long.BYTES).putLong((int) value).array();
+    },
+        bytes -> {
+            if (bytes == null) {
+                return null;
+            }
+            return (int) ByteBuffer.wrap(bytes).getLong();
+        }
     ),
     /**
      * Long.
      */
-    LONG("long", Long.class, long.class, value ->
-        ByteBuffer.allocate(Long.BYTES).putLong((long) value).array(),
-        bytes -> ByteBuffer.wrap(bytes).getLong()
+    LONG("long", Long.class, long.class, value -> {
+        if (value == null) {
+            return null;
+        }
+        return ByteBuffer.allocate(Long.BYTES).putLong((long) value).array();
+    },
+        bytes -> {
+            if (bytes == null) {
+                return null;
+            }
+            return ByteBuffer.wrap(bytes).getLong();
+        }
     ),
 
     /**
      * Float.
      */
-    FLOAT("float", Float.class, float.class, value ->
-        ByteBuffer.allocate(Float.BYTES).putFloat((float) value).array(),
-        bytes -> ByteBuffer.wrap(bytes).getFloat()
+    FLOAT("float", Float.class, float.class, value -> {
+        if (value == null) {
+            return null;
+        }
+        return ByteBuffer.allocate(Float.BYTES).putFloat((float) value).array();
+    },
+        bytes -> {
+            if (bytes == null) {
+                return null;
+            }
+            return ByteBuffer.wrap(bytes).getFloat();
+        }
     ),
 
     /**
      * Double.
      */
-    DOUBLE("double", Double.class, double.class, value ->
-        ByteBuffer.allocate(Double.BYTES).putDouble((double) value).array(),
-        bytes -> ByteBuffer.wrap(bytes).getDouble()
+    DOUBLE("double", Double.class, double.class, value -> {
+        if (value == null) {
+            return null;
+        }
+        return ByteBuffer.allocate(Double.BYTES).putDouble((double) value).array();
+    },
+        bytes -> {
+            if (bytes == null) {
+                return null;
+            }
+            return ByteBuffer.wrap(bytes).getDouble();
+        }
     ),
 
     /**
      * String.
      */
-    STRING("string", String.class, String.class, value ->
-        Optional.ofNullable(value).map(String::valueOf).map(String::getBytes).orElse(null),
-        bytes -> new String(bytes, StandardCharsets.UTF_8)
+    STRING("string", String.class, String.class, value -> {
+        if (value == null) {
+            return null;
+        }
+        return Optional.ofNullable(value).map(String::valueOf).map(String::getBytes).orElse(null);
+    },
+        bytes -> {
+            if (bytes == null) {
+                return null;
+            }
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
     ),
 
     /**
      * Bytes.
      */
-    BYTES("bytes", byte[].class, Byte[].class, value -> byte[].class.cast(value),
+    BYTES("bytes", byte[].class, Byte[].class, value -> {
+        if (value == null) {
+            return null;
+        }
+        return byte[].class.cast(value);
+    },
         bytes -> bytes
     ),
 
     /**
      * Label.
      */
-    LABEL("label", Label.class, Label.class, value ->
-        new AllLabels().uid(Label.class.cast(value)).getBytes(StandardCharsets.UTF_8),
-        bytes -> new AllLabels().label(new String(bytes, StandardCharsets.UTF_8))
+    LABEL("label", Label.class, Label.class, value -> {
+        if (value == null) {
+            return null;
+        }
+        return new AllLabels().uid(Label.class.cast(value)).getBytes(StandardCharsets.UTF_8);
+    },
+        bytes -> {
+            if (bytes == null) {
+                return null;
+            }
+            return new AllLabels().label(new String(bytes, StandardCharsets.UTF_8));
+        }
     ),
 
     /**
      * Type reference.
      */
     TYPE_REFERENCE(
-        "type", Type.class, Type.class, DataType::typeBytes, bytes ->
-        Type.getType(String.format(new String(bytes, StandardCharsets.UTF_8)))
+        "type", Type.class, Type.class, DataType::typeBytes, bytes -> {
+        if (bytes == null) {
+            return null;
+        }
+        return Type.getType(String.format(new String(bytes, StandardCharsets.UTF_8)));
+    }
     ),
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/DataType.java
@@ -36,6 +36,10 @@ import org.objectweb.asm.Type;
 /**
  * All supported data types.
  * @since 0.3
+ * @todo #518:90min Refactor DataType, HexData and HexString classes.
+ *  This classes has some sort of intersection in their responsibilities.
+ *  We should refactor them to make them more clear and separate. Maybe we can
+ *  merge them into one class or split them into more classes.
  */
 public enum DataType {
 

--- a/src/main/java/org/eolang/jeo/representation/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/DataType.java
@@ -42,9 +42,11 @@ public enum DataType {
      * Boolean.
      */
     BOOL("bool", Boolean.class, boolean.class, value -> {
-
         if (value == null) {
             return null;
+        }
+        if (value instanceof Integer) {
+            return DataType.hexBoolean((int) value != 0);
         }
         return DataType.hexBoolean(Boolean.class.cast(value));
     },
@@ -53,6 +55,57 @@ public enum DataType {
                 return null;
             }
             return Boolean.valueOf(bytes[0] != 0);
+        }
+    ),
+
+    /**
+     * Character.
+     */
+    CHAR("char", Character.class, char.class, value -> {
+        if (value == null) {
+            return null;
+        }
+        return ByteBuffer.allocate(Character.BYTES).putChar((char) (int) value).array();
+    },
+        bytes -> {
+            if (bytes == null) {
+                return null;
+            }
+            return ByteBuffer.wrap(bytes).getChar();
+        }
+    ),
+
+    /**
+     * Byte.
+     */
+    BYTE("byte", Byte.class, byte.class, value -> {
+        if (value == null) {
+            return null;
+        }
+        return ByteBuffer.allocate(Byte.BYTES).put((byte) (int) value).array();
+    },
+        bytes -> {
+            if (bytes == null) {
+                return null;
+            }
+            return ByteBuffer.wrap(bytes).get();
+        }
+    ),
+
+    /**
+     * Short.
+     */
+    SHORT("short", Short.class, short.class, value -> {
+        if (value == null) {
+            return null;
+        }
+        return ByteBuffer.allocate(Short.BYTES).putShort((short) (int)  value).array();
+    },
+        bytes -> {
+            if (bytes == null) {
+                return null;
+            }
+            return ByteBuffer.wrap(bytes).getShort();
         }
     ),
 

--- a/src/main/java/org/eolang/jeo/representation/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/DataType.java
@@ -38,218 +38,116 @@ import org.objectweb.asm.Type;
  * @since 0.3
  */
 public enum DataType {
+
     /**
      * Boolean.
      */
-    BOOL("bool", Boolean.class, boolean.class, value -> {
-        if (value == null) {
-            return null;
-        }
-        if (value instanceof Integer) {
-            return DataType.hexBoolean((int) value != 0);
-        }
-        return DataType.hexBoolean(Boolean.class.cast(value));
-    },
-        bytes -> {
-            if (bytes == null) {
-                return null;
+    BOOL("bool", Boolean.class, boolean.class,
+        value -> {
+            final byte[] result;
+            if (value instanceof Integer) {
+                result = DataType.hexBoolean((int) value != 0);
+            } else {
+                result = DataType.hexBoolean(Boolean.class.cast(value));
             }
-            return Boolean.valueOf(bytes[0] != 0);
-        }
+            return result;
+        },
+        bytes -> Boolean.valueOf(bytes[0] != 0)
     ),
 
     /**
      * Character.
      */
-    CHAR("char", Character.class, char.class, value -> {
-        if (value == null) {
-            return null;
-        }
-        return ByteBuffer.allocate(Character.BYTES).putChar((char) (int) value).array();
-    },
-        bytes -> {
-            if (bytes == null) {
-                return null;
-            }
-            return ByteBuffer.wrap(bytes).getChar();
-        }
+    CHAR("char", Character.class, char.class,
+        value -> ByteBuffer.allocate(Character.BYTES).putChar((char) (int) value).array(),
+        bytes -> ByteBuffer.wrap(bytes).getChar()
     ),
 
     /**
      * Byte.
      */
-    BYTE("byte", Byte.class, byte.class, value -> {
-        if (value == null) {
-            return null;
-        }
-        return ByteBuffer.allocate(Byte.BYTES).put((byte) (int) value).array();
-    },
-        bytes -> {
-            if (bytes == null) {
-                return null;
-            }
-            return ByteBuffer.wrap(bytes).get();
-        }
+    BYTE("byte", Byte.class, byte.class,
+        value -> ByteBuffer.allocate(Byte.BYTES).put((byte) (int) value).array(),
+        bytes -> ByteBuffer.wrap(bytes).get()
     ),
 
     /**
      * Short.
      */
-    SHORT("short", Short.class, short.class, value -> {
-        if (value == null) {
-            return null;
-        }
-        return ByteBuffer.allocate(Short.BYTES).putShort((short) (int)  value).array();
-    },
-        bytes -> {
-            if (bytes == null) {
-                return null;
-            }
-            return ByteBuffer.wrap(bytes).getShort();
-        }
+    SHORT("short", Short.class, short.class,
+        value -> ByteBuffer.allocate(Short.BYTES).putShort((short) (int) value).array(),
+        bytes -> ByteBuffer.wrap(bytes).getShort()
     ),
 
     /**
      * Integer.
      */
-    INT("int", Integer.class, int.class, value -> {
-        if (value == null) {
-            return null;
-        }
-        return ByteBuffer.allocate(Long.BYTES).putLong((int) value).array();
-    },
-        bytes -> {
-            if (bytes == null) {
-                return null;
-            }
-            return (int) ByteBuffer.wrap(bytes).getLong();
-        }
+    INT("int", Integer.class, int.class,
+        value -> ByteBuffer.allocate(Long.BYTES).putLong((int) value).array(),
+        bytes -> (int) ByteBuffer.wrap(bytes).getLong()
     ),
     /**
      * Long.
      */
-    LONG("long", Long.class, long.class, value -> {
-        if (value == null) {
-            return null;
-        }
-        return ByteBuffer.allocate(Long.BYTES).putLong((long) value).array();
-    },
-        bytes -> {
-            if (bytes == null) {
-                return null;
-            }
-            return ByteBuffer.wrap(bytes).getLong();
-        }
+    LONG("long", Long.class, long.class,
+        value -> ByteBuffer.allocate(Long.BYTES).putLong((long) value).array(),
+        bytes -> ByteBuffer.wrap(bytes).getLong()
     ),
 
     /**
      * Float.
      */
-    FLOAT("float", Float.class, float.class, value -> {
-        if (value == null) {
-            return null;
-        }
-        return ByteBuffer.allocate(Float.BYTES).putFloat((float) value).array();
-    },
-        bytes -> {
-            if (bytes == null) {
-                return null;
-            }
-            return ByteBuffer.wrap(bytes).getFloat();
-        }
+    FLOAT("float", Float.class, float.class,
+        value -> ByteBuffer.allocate(Float.BYTES).putFloat((float) value).array(),
+        bytes -> ByteBuffer.wrap(bytes).getFloat()
     ),
 
     /**
      * Double.
      */
-    DOUBLE("double", Double.class, double.class, value -> {
-        if (value == null) {
-            return null;
-        }
-        return ByteBuffer.allocate(Double.BYTES).putDouble((double) value).array();
-    },
-        bytes -> {
-            if (bytes == null) {
-                return null;
-            }
-            return ByteBuffer.wrap(bytes).getDouble();
-        }
+    DOUBLE("double", Double.class, double.class,
+        value -> ByteBuffer.allocate(Double.BYTES).putDouble((double) value).array(),
+        bytes -> ByteBuffer.wrap(bytes).getDouble()
     ),
 
     /**
      * String.
      */
-    STRING("string", String.class, String.class, value -> {
-        if (value == null) {
-            return null;
-        }
-        return Optional.ofNullable(value).map(String::valueOf).map(String::getBytes).orElse(null);
-    },
-        bytes -> {
-            if (bytes == null) {
-                return null;
-            }
-            return new String(bytes, StandardCharsets.UTF_8);
-        }
+    STRING("string", String.class, String.class,
+        value -> Optional.ofNullable(value).map(String::valueOf).map(String::getBytes).orElse(null),
+        bytes -> new String(bytes, StandardCharsets.UTF_8)
     ),
 
     /**
      * Bytes.
      */
-    BYTES("bytes", byte[].class, Byte[].class, value -> {
-        if (value == null) {
-            return null;
-        }
-        return byte[].class.cast(value);
-    },
+    BYTES("bytes", byte[].class, Byte[].class,
+        value -> byte[].class.cast(value),
         bytes -> bytes
     ),
 
     /**
      * Label.
      */
-    LABEL("label", Label.class, Label.class, value -> {
-        if (value == null) {
-            return null;
-        }
-        return new AllLabels().uid(Label.class.cast(value)).getBytes(StandardCharsets.UTF_8);
-    },
-        bytes -> {
-            if (bytes == null) {
-                return null;
-            }
-            return new AllLabels().label(new String(bytes, StandardCharsets.UTF_8));
-        }
+    LABEL("label", Label.class, Label.class,
+        value -> new AllLabels().uid(Label.class.cast(value)).getBytes(StandardCharsets.UTF_8),
+        bytes -> new AllLabels().label(new String(bytes, StandardCharsets.UTF_8))
     ),
 
     /**
      * Type reference.
      */
     TYPE_REFERENCE(
-        "type", Type.class, Type.class, DataType::typeBytes, bytes -> {
-        if (bytes == null) {
-            return null;
-        }
-        return Type.getType(String.format(new String(bytes, StandardCharsets.UTF_8)));
-    }
+        "type", Type.class, Type.class, DataType::typeBytes, bytes ->
+        Type.getType(String.format(new String(bytes, StandardCharsets.UTF_8)))
     ),
 
     /**
      * Class reference.
      */
-    CLASS_REFERENCE("class", Class.class, Class.class, value -> {
-        if (value == null) {
-            return null;
-        }
-        return DataType.hexClass(Class.class.cast(value).getName());
-    },
-        bytes -> {
-            if (bytes == null) {
-                return null;
-
-            }
-            return new String(bytes, StandardCharsets.UTF_8);
-        }
+    CLASS_REFERENCE("class", Class.class, Class.class,
+        value -> DataType.hexClass(Class.class.cast(value).getName()),
+        bytes -> new String(bytes, StandardCharsets.UTF_8)
     );
 
     /**
@@ -281,6 +179,7 @@ public enum DataType {
      * Constructor.
      * @param base Base type.
      * @param clazz Class.
+     * @param primitive Primitive class.
      * @param encoder Converter to hex.
      * @param decoder Converter from hex.
      * @checkstyle ParameterNumberCheck (5 lines)
@@ -324,20 +223,14 @@ public enum DataType {
     @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
     public static DataType find(final Type type) {
         return Arrays.stream(DataType.values())
-            .filter(dataType -> {
-                final Type real = Type.getType(dataType.clazz);
-                final Type prim = Type.getType(dataType.primitive);
-                return prim.equals(type) || real.equals(type);
-            })
+            .filter(
+                dataType -> {
+                    final Type real = Type.getType(dataType.clazz);
+                    final Type prim = Type.getType(dataType.primitive);
+                    return prim.equals(type) || real.equals(type);
+                }
+            )
             .findFirst()
-//            .orElseThrow(
-//                () -> new IllegalArgumentException(
-//                    String.format(
-//                        "Unknown data type of %s",
-//                        type.getDescriptor()
-//                    )
-//                )
-//            );
             .orElse(DataType.CLASS_REFERENCE);
     }
 
@@ -367,9 +260,29 @@ public enum DataType {
                     String.copyValueOf(new char[]{chars[index], chars[index + 1]}), 16
                 );
             }
-            result = this.decoder.apply(res);
+            result = this.decode(res);
         }
         return result;
+    }
+
+    /**
+     * Convert data to hex string.
+     * @param data Data.
+     * @return Hex string.
+     */
+    public String toHexString(final Object data) {
+        final byte[] bytes = this.encode(data);
+        final String res;
+        if (bytes == null) {
+            res = null;
+        } else {
+            final StringJoiner out = new StringJoiner(" ");
+            for (final byte bty : bytes) {
+                out.add(String.format("%02X", bty));
+            }
+            res = out.toString();
+        }
+        return res;
     }
 
     /**
@@ -387,25 +300,7 @@ public enum DataType {
      * @return Hex representation of data.
      */
     static byte[] toBytes(final Object data) {
-        return DataType.from(data).encoder.apply(data);
-    }
-
-    /**
-     * Convert data to hex string.
-     * @param data Data.
-     * @return Hex string.
-     */
-    public String toHexString(final Object data) {
-        final byte[] bytes = this.encoder.apply(data);
-        if (bytes == null) {
-            return null;
-
-        }
-        final StringJoiner out = new StringJoiner(" ");
-        for (final byte bty : bytes) {
-            out.add(String.format("%02X", bty));
-        }
-        return out.toString();
+        return DataType.from(data).encode(data);
     }
 
     /**
@@ -421,6 +316,14 @@ public enum DataType {
             result = new byte[]{0x00};
         }
         return result;
+    }
+
+    private byte[] encode(final Object data) {
+        return Optional.ofNullable(data).map(this.encoder).orElse(null);
+    }
+
+    private Object decode(final byte[] data) {
+        return Optional.ofNullable(data).map(this.decoder).orElse(null);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/DataType.java
@@ -113,9 +113,19 @@ public enum DataType {
     /**
      * Class reference.
      */
-    CLASS_REFERENCE("class", Class.class, Class.class, value ->
-        DataType.hexClass(Class.class.cast(value).getName()),
-        bytes -> new String(bytes, StandardCharsets.UTF_8)
+    CLASS_REFERENCE("class", Class.class, Class.class, value -> {
+        if (value == null) {
+            return null;
+        }
+        return DataType.hexClass(Class.class.cast(value).getName());
+    },
+        bytes -> {
+            if (bytes == null) {
+                return null;
+
+            }
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
     );
 
     /**
@@ -196,14 +206,15 @@ public enum DataType {
                 return prim.equals(type) || real.equals(type);
             })
             .findFirst()
-            .orElseThrow(
-                () -> new IllegalArgumentException(
-                    String.format(
-                        "Unknown data type of %s",
-                        type.getDescriptor()
-                    )
-                )
-            );
+//            .orElseThrow(
+//                () -> new IllegalArgumentException(
+//                    String.format(
+//                        "Unknown data type of %s",
+//                        type.getDescriptor()
+//                    )
+//                )
+//            );
+            .orElse(DataType.CLASS_REFERENCE);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/DataType.java
@@ -52,7 +52,9 @@ public enum DataType {
             }
             return result;
         },
-        bytes -> Boolean.valueOf(bytes[0] != 0)
+        bytes -> {
+            return Boolean.valueOf(bytes[0] != 0);
+        }
     ),
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/HexData.java
+++ b/src/main/java/org/eolang/jeo/representation/HexData.java
@@ -24,11 +24,13 @@
 package org.eolang.jeo.representation;
 
 import java.util.StringJoiner;
+import lombok.ToString;
 
 /**
  * Hexadecimal data.
  * @since 0.1
  */
+@ToString
 public final class HexData {
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
@@ -93,7 +93,7 @@ public final class DirectivesField implements Iterable<Directive> {
      * Constructor.
      */
     public DirectivesField() {
-        this(Opcodes.ACC_PUBLIC, "unknown", "I", "", "0");
+        this(Opcodes.ACC_PUBLIC, "unknown", "I", "", 0);
     }
 
     /**
@@ -116,7 +116,7 @@ public final class DirectivesField implements Iterable<Directive> {
         this.name = name;
         this.descriptor = Optional.ofNullable(descriptor).orElse("");
         this.signature = Optional.ofNullable(signature).orElse("");
-        this.value = Optional.ofNullable(value).orElse("");
+        this.value = value;
         this.annotations = new DirectivesAnnotations();
     }
 
@@ -138,7 +138,7 @@ public final class DirectivesField implements Iterable<Directive> {
             .append(new DirectivesData(this.title("access"), this.access))
             .append(new DirectivesData(this.title("descriptor"), this.descriptor))
             .append(new DirectivesData(this.title("signature"), this.signature))
-            .append(new DirectivesData(this.title("value"), this.value))
+            .append(new DirectivesTypedData(this.title("value"), this.value, this.descriptor))
             .append(this.annotations)
             .up()
             .iterator();

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
@@ -132,16 +132,23 @@ public final class DirectivesField implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        return new Directives().add("o")
-            .attr("base", "field")
-            .attr("name", this.name)
-            .append(new DirectivesData(this.title("access"), this.access))
-            .append(new DirectivesData(this.title("descriptor"), this.descriptor))
-            .append(new DirectivesData(this.title("signature"), this.signature))
-            .append(new DirectivesTypedData(this.title("value"), this.value, this.descriptor))
-            .append(this.annotations)
-            .up()
-            .iterator();
+        try {
+            return new Directives().add("o")
+                .attr("base", "field")
+                .attr("name", this.name)
+                .append(new DirectivesData(this.title("access"), this.access))
+                .append(new DirectivesData(this.title("descriptor"), this.descriptor))
+                .append(new DirectivesData(this.title("signature"), this.signature))
+                .append(new DirectivesTypedData(this.title("value"), this.value, this.descriptor))
+                .append(this.annotations)
+                .up()
+                .iterator();
+        } catch (final IllegalStateException exception) {
+            throw new IllegalStateException(
+                String.format("Failed to create directives for field %n%s", this),
+                exception
+            );
+        }
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesTypedData.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesTypedData.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.Iterator;
+import lombok.ToString;
+import org.eolang.jeo.representation.DataType;
+import org.objectweb.asm.Type;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+/**
+ * Typed data directives.
+ *
+ * @since 0.3
+ */
+@ToString
+public final class DirectivesTypedData implements Iterable<Directive> {
+
+    private final String name;
+    private final Object data;
+    private final Type type;
+
+    public DirectivesTypedData(final String name, final Object data, final String descriptor) {
+        this(name, data, Type.getType(descriptor));
+    }
+
+    public DirectivesTypedData(final String name, final Object data, final Type type) {
+        this.name = name;
+        this.data = data;
+        this.type = type;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        try {
+            final DataType base = DataType.find(this.type);
+            final Directives directives = new Directives().add("o")
+                .attr("base", base.type())
+                .attr("data", "bytes");
+            final String hex = base.toHexString(this.data);
+            if (!this.name.isEmpty()) {
+                directives.attr("name", this.name);
+            }
+            if (hex != null) {
+                directives.set(hex);
+            } else {
+                directives.attr("scope", "nullable");
+            }
+            return directives.up().iterator();
+        } catch (final IllegalArgumentException exception) {
+            throw new IllegalStateException(
+                String.format("Failed to create directives for %s", this), exception
+            );
+        }
+
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesTypedData.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesTypedData.java
@@ -38,14 +38,37 @@ import org.xembly.Directives;
 @ToString
 public final class DirectivesTypedData implements Iterable<Directive> {
 
+    /**
+     * Name of the value.
+     */
     private final String name;
+
+    /**
+     * Value.
+     */
     private final Object data;
+
+    /**
+     * Type of the value.
+     */
     private final Type type;
 
+    /**
+     * Constructor.
+     * @param name Name of the value
+     * @param data Value
+     * @param descriptor Type descriptor
+     */
     public DirectivesTypedData(final String name, final Object data, final String descriptor) {
         this(name, data, Type.getType(descriptor));
     }
 
+    /**
+     * Constructor.
+     * @param name Name of the value
+     * @param data Value
+     * @param type Type of the value
+     */
     public DirectivesTypedData(final String name, final Object data, final Type type) {
         this.name = name;
         this.data = data;
@@ -74,6 +97,5 @@ public final class DirectivesTypedData implements Iterable<Directive> {
                 String.format("Failed to create directives for %s", this), exception
             );
         }
-
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesTypedData.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesTypedData.java
@@ -69,7 +69,7 @@ public final class DirectivesTypedData implements Iterable<Directive> {
                 directives.attr("scope", "nullable");
             }
             return directives.up().iterator();
-        } catch (final IllegalArgumentException exception) {
+        } catch (final IllegalArgumentException | ClassCastException exception) {
             throw new IllegalStateException(
                 String.format("Failed to create directives for %s", this), exception
             );

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlOperand.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlOperand.java
@@ -64,7 +64,14 @@ public final class XmlOperand {
         if ("handle".equals(base)) {
             result = new XmlHandler(this.raw).asHandle();
         } else {
-            result = DataType.find(base).decode(this.raw.text());
+            final boolean nullable = this.raw.attribute("scope").map("nullable"::equals)
+                .orElse(false);
+            if (nullable) {
+                result = null;
+            } else {
+                final String text = this.raw.text();
+                result = DataType.find(base).decode(text);
+            }
         }
         return result;
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesFieldTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesFieldTest.java
@@ -50,7 +50,7 @@ final class DirectivesFieldTest {
                 "/o/o[@name='access-unknown' and contains(text(),'01')]",
                 "/o/o[@name='descriptor-unknown' and text()='49']",
                 "/o/o[@name='signature-unknown']",
-                "/o/o[@name='value-unknown' and text()='30']"
+                "/o/o[@base='int' and @name='value-unknown' and contains(text(),'0')]"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlFieldTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlFieldTest.java
@@ -96,4 +96,47 @@ final class XmlFieldTest {
         );
     }
 
+    @Test
+    void parsesFieldWithEmptyStringValue() throws ImpossibleModificationException {
+        final String expected = "";
+        MatcherAssert.assertThat(
+            "Failed to parse XMIR field with empty initial value",
+            new XmlField(
+                new XmlNode(
+                    new Xembler(
+                        new DirectivesField(
+                            Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL,
+                            "serialVersionUID",
+                            "Ljava/lang/String;",
+                            "",
+                            expected
+                        )
+                    ).xml()
+                )
+            ).value(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    void parsesFieldWithNullableStringValue() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "Failed to parse XMIR field with null initial value",
+            new XmlField(
+                new XmlNode(
+                    new Xembler(
+                        new DirectivesField(
+                            Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL,
+                            "serialVersionUID",
+                            "Ljava/lang/String;",
+                            "",
+                            null
+                        )
+                    ).xml()
+                )
+            ).value(),
+            Matchers.nullValue()
+        );
+    }
+
 }


### PR DESCRIPTION
In this PR I extend `DataType` class in order to correctly handle all default field values in bytecode.
Additionaly, I correctly handle `null` values and now NPE doesn't break the disassembling/assembling.

Closes: #518
____
History:
- **feat(#518): add README.md for exceptions integration test**
- **feat(#518): fix the bug with null values for empty LDC instruction**
- **feat(#518): fix all unit tests**
- **feat(#518): fix sprint integration test**
- **feat(#518): fix all the rest integration tests**
- **feat(#518): add more types for DataType class**
- **feat(#518): fix all qulice suggestions**
- **feat(#518): enable exceptions integration test**
- **feat(#518): fix the rest of a linter suggestions**
- **feat(#518): add one more puzzle for the future refactoring**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds Lombok's `@ToString` annotation, refactors field parsing logic, and introduces typed data directives for XML representation.

### Detailed summary
- Added Lombok's `@ToString` annotation to `HexData`
- Refactored field parsing logic in `DirectivesField`
- Introduced `DirectivesTypedData` class for typed data directives in XML representation

> The following files were skipped due to too many changes: `src/main/java/org/eolang/jeo/representation/DataType.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->