### PR TITLE
feat(#526): Enable 'eo-to-bytecode' Integration Test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,24 +231,6 @@ SOFTWARE.
     </testResources>
     <plugins>
       <plugin>
-        <artifactId>maven-invoker-plugin</artifactId>
-        <configuration>
-          <!--
-          @todo #488:90min Enable 'eo-to-bytecode' integration test.
-           Enable the execution of the `eo-to-bytecode` integration test.
-           Currently, the `eo-to-bytecode` integration test is disabled because it fails.
-           After disabling automatic computation of bytecode frames, max locals and max stack
-           we broke backward compatibility with the `eo-to-bytecode` integration test.
-           We need to enable automatic computation of bytecode frames, max locals and max stack
-           in case of missing frame information.
-           Don't forget to remove ClassWriter.COMPUTE_FRAMES from CustomClassWriter.
-          -->
-          <pomExcludes>
-            <exclude>eo-to-bytecode/pom.xml</exclude>
-          </pomExcludes>
-        </configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
         <configuration>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/src/it/eo-to-bytecode/README.md
+++ b/src/it/eo-to-bytecode/README.md
@@ -1,5 +1,11 @@
 # Integration test for the eo-to-bytecode goal
+
+This integration test checks the correct transformation of already
+generated XMIR files to bytecode. In other words, it checks the
+`assemble` goal of the `jeo-maven-plugin` plugin.
+
 If you need to run only this test, use the following command:
+
 ```shell
 mvn clean integration-test invoker:run -Dinvoker.test=eo-to-bytecode -DskipTests
 ```

--- a/src/it/eo-to-bytecode/target/generated-sources/opeo-xmir/org/eolang/benchmark/BA.xmir
+++ b/src/it/eo-to-bytecode/target/generated-sources/opeo-xmir/org/eolang/benchmark/BA.xmir
@@ -54,6 +54,7 @@
               <o base="string" data="bytes">6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o>
               <o base="string" data="bytes">3C 69 6E 69 74 3E</o>
               <o base="string" data="bytes">28 29 56</o>
+              <o base="bool" data="bytes">00</o>
             </o>
             <o base="label" data="bytes">66 65 63 35 31 34 32 62 2D 34 33 61 39 2D 34 65 39 61 2D 61 37 39 64 2D 34 36 30 34 33 39 32 65 30 33 34 62</o>
             <o base="opcode" line="999" name="ALOAD-C">
@@ -128,6 +129,7 @@
               <o base="string" data="bytes">6f 72 67 2f 65 6f 6c 61 6e 67 2f 62 65 6e 63 68 6d 61 72 6b 2f 42 41</o>
               <o base="string" data="bytes">66 6F 6F</o>
               <o base="string" data="bytes">28 29 49</o>
+              <o base="bool" data="bytes">00</o>
             </o>
             <o base="opcode" line="999" name="ICONST_2-17">
               <o base="int" data="bytes">00 00 00 00 00 00 00 05</o>


### PR DESCRIPTION
In this PR I enabled `eo-to-bytecode` integration test and added a bit more information about the test itself to the corresponding `README.md` file.

Closes: #526.
History:
- **feat(#526): enable 'eo-to-bytecode' integration test**
- **feat(#526): remove the puzzle for #526 issue**
- **feat(#526): add a bit more info to integration test description**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enabling the `eo-to-bytecode` integration test by fixing bytecode computation issues.

### Detailed summary
- Added instructions and command to run `eo-to-bytecode` test
- Updated XMIR files with new bytecode data
- Removed exclusion of `eo-to-bytecode/pom.xml` in `pom.xml`
- Removed comments about enabling the test in `pom.xml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->