### PR TITLE
feat(#488): Enable 'spring-fat' Integration Tests

### DIFF
--- a/.github/workflows/maven.test.yaml
+++ b/.github/workflows/maven.test.yaml
@@ -12,8 +12,8 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-12]
-        java: [11, 20]
+        os: [ ubuntu-20.04, windows-2022, macos-12 ]
+        java: [ 11, 20 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -27,4 +27,4 @@ jobs:
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
-      - run: mvn clean install -Pqulice --errors --batch-mode
+      - run: mvn clean install -Pqulice,long --errors --batch-mode

--- a/.github/workflows/maven.test.yaml
+++ b/.github/workflows/maven.test.yaml
@@ -27,4 +27,4 @@ jobs:
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
-      - run: mvn clean install -Pqulice,long --errors --batch-mode
+      - run: mvn clean install -P"qulice,long" --errors --batch-mode

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ setting the `skipVerification` parameter to `true`:
   <skipVerification>true</skipVerification>
 </configuration>
 ```
+
 At times, it might be beneficial to generate intentionally flawed bytecode.
 
 ## Transformation method
@@ -344,6 +345,19 @@ compromised. Therefore, it is extremely important to preserve most of the
 labels. However, it's worth noting that you can omit certain labels used solely
 for debugging purposes when generating your own classes. For instance, you can
 omit labels at the start and end of a method.
+
+## How to Build the Plugin
+
+To build the plugin from the source code, you need to clone the repository and
+run the following command:
+
+```bash
+$ mvn clean install -Pqulice,long
+```
+
+Pay attention to the `qulice` profile, which activates the static analysis
+tools. The `long` profile is optional and runs the full test suite, including
+long-running integration tests.
 
 ## How to Contribute
 

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,21 @@ SOFTWARE.
     </testResources>
     <plugins>
       <plugin>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <configuration>
+          <!--
+            The 'spring-fat' integration test is disabled in the default profile.
+            It's done intentionally to speed up the build process. However, this
+            test is still available in the 'long' profile. So if you want to run
+            it, you can use the following command:
+            mvn clean install -Plong
+          -->
+          <pomExcludes>
+            <exclude>spring-fat/pom.xml</exclude>
+          </pomExcludes>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
         <configuration>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
@@ -373,6 +388,26 @@ SOFTWARE.
                 </goals>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>long</id>
+      <!--
+        This profile is used to run integration tests that take a long time.
+        For example, the 'spring-fat' integration test is disabled in the default
+        profile.
+      -->
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-invoker-plugin</artifactId>
+            <configuration>
+              <pomIncludes>
+                <include>spring-fat/pom.xml</include>
+              </pomIncludes>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -403,10 +403,11 @@ SOFTWARE.
         <plugins>
           <plugin>
             <artifactId>maven-invoker-plugin</artifactId>
-            <configuration>
-              <pomIncludes>
-                <include>spring-fat/pom.xml</include>
-              </pomIncludes>
+            <configuration combine.self="override">
+              <!--
+                All integration tests are enabled in the 'long' profile.
+              -->
+              <pomExcludes/>
             </configuration>
           </plugin>
         </plugins>

--- a/src/it/spring-fat/README.md
+++ b/src/it/spring-fat/README.md
@@ -1,16 +1,70 @@
 # Spring Fat Jar Integration Test
 
-Integration test that checks the correct transformation of an application
-written with using of the Springs Framework. This integration test starts the
-application with several beans and prints results to the console.
-This is a similar integration test with the "spring" test in
-the [spring](../spring) test.
+This integration test verifies the accurate transformation of applications
+developed with the Spring Framework. It initiates the application with various
+beans and outputs the results to the console, functioning similarly to the
+integration test found in the [spring](../spring) directory.
 
-The only difference is that in this test we download all the dependencies,
-unpack them, transform using jeo-maven-plugin and then pack them back. In other
-words, we test the fat jar transformation.
+The distinctive aspect of this test is its comprehensive process of handling
+dependencies: it downloads all required dependencies, unpacks them, applies
+transformations via the `jeo-maven-plugin`, and subsequently repackages them.
 
-If you need to run only this test, use the following command:
+The process is as follows:
+
+1. **Download all dependencies**
+2. **Unpack them**
+3. **Disassemble**: Apply transformation via the `jeo-maven-plugin:dissassemble`
+   goal for all the
+   unpacked dependencies
+4. **Assemble**: Apply back transformation via the `jeo-maven-plugin:assemble`
+   goal
+5. **Build the application**: Compiles the transformed application into a fat
+   jar.
+
+To exclusively run this test, execute the command below:
+
 ```shell
 mvn clean integration-test invoker:run -Dinvoker.test=spring-fat -DskipTests
 ```
+
+## The First Results
+
+
+Here is the summary of the first results of the `spring-fat` integration test:
+
+- The application starts and runs successfully.
+- The average test time is approximately **130 seconds**.
+- The total number of classes is **5844**.
+- The Disassembly phase takes approximately **1 minute**.
+- The Assembly phase takes approximately **21 seconds**.
+
+## Developer Notes
+
+### Excluded from the default build pipeline
+
+This test remains rather long and has not yet been optimized. As a result, it
+is excluded from the default build pipeline. To run this test alongside all
+others, you need to activate the `long` Maven profile. Use the command below:
+
+```bash
+mvn clean install -Plong
+```
+
+### Bytecode verification
+
+Some Spring Boot components were compiled with optional dependencies, and these
+dependencies are not present in the corresponding POM files. Therefore, we
+cannot find these dependencies during the test. However, the current
+implementation of bytecode verification requires that all classes are loaded by
+the `ClassLoader` before verification, which is not possible in this case. As a
+result, we skip bytecode verification for this test.
+
+```xml
+
+<skipVerification>true</skipVerification>
+```
+
+You can read more about this problem in [pom.xml](pom.xml) in
+the `jeo-maven-plugin` configuration.
+
+

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -83,14 +83,14 @@ SOFTWARE.
         <artifactId>jeo-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>
+          <disabled>false</disabled>
           <!--
-            @todo #464:90min Enable 'spring-fat' Integration Test.
-             Currently, the 'spring-fat' integration test is disabled because
-             it fails. The reason is that the 'jeo-maven-plugin' does not
-             support many java features. We need to implement them and enable
-             the test.
+            @todo #488:90min Enable Bytecode Verification For Spring Fat Integration Test.
+             We skip verification because the Spring Framework uses many classes that
+             are not in the classpath and the plugin cannot verify the correctness of
+             the transformation. For not it's not so crucial, but in the future, we
+             should enable it.
           -->
-          <disabled>true</disabled>
           <skipVerification>true</skipVerification>
         </configuration>
         <executions>


### PR DESCRIPTION
In this PR I finally enable full 'spring-fat' integration test that extensively test `disassemble` and `assemble` goals of `jeo-maven-plugin`.

Here is the summary of the first results of the `spring-fat` integration test:

- The application starts and runs successfully.
- The average test time is approximately **130 seconds**.
- The total number of classes is **5844**.
- The Disassembly phase takes approximately **1 minute**.
- The Assembly phase takes approximately **21 seconds**.


Closes: #488
History:
- **feat(#488): exclude 'spring-fat' from the default build pipeline**
- **feat(#488): add 'long' maven profile**
- **feat(#488): fully enable 'spring-fat' integration test**
- **feat(#488): add 'long' profile to the testin github workflow**
- **feat(#488): add 'spring-fat' integration test description**

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enable bytecode verification for the Spring Fat integration test and provide detailed instructions on building and running the test suite.

### Detailed summary
- Updated `pom.xml` to enable Bytecode Verification for Spring Fat Integration Test
- Added detailed instructions on building the plugin and running the test suite
- Modified `README.md` for the Spring Fat Integration Test to provide detailed process information

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->