### PR TITLE
codecov token

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -23,5 +23,6 @@ jobs:
       - run: mvn clean install -Pqulice --errors --batch-mode
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./target/site/jacoco/jacoco.xml
           fail_ci_if_error: true


### PR DESCRIPTION
This should fix the build

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `codecov.yaml` workflow file to use a secret `CODECOV_TOKEN` and specifies the location of the Jacoco XML file.

### Detailed summary
- Updated `codecov.yaml` to use `${{ secrets.CODECOV_TOKEN }}`
- Specified the location of Jacoco XML file as `./target/site/jacoco/jacoco.xml`
- Set `fail_ci_if_error` to `true`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->