### PR TITLE
feat(#352): Remove Mutable Methods

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -247,6 +247,11 @@ public final class XmlMethod {
         return res;
     }
 
+    /**
+     * Clear max stack and max locals.
+     *
+     * @return Copy of the method without max stack and max locals.
+     */
     public XmlMethod withoutMaxs() {
         try {
             return new XmlMethod(
@@ -325,28 +330,6 @@ public final class XmlMethod {
                 ),
                 exception
             );
-        }
-    }
-
-    /**
-     * Replace instructions.
-     *
-     * @param entries Instructions to replace.
-     * @todo #350 Remove mutable method from XmlMethod.
-     *  Here we just remove all instructions and add new ones, this makes XmlMethod class
-     *  mutable, which is a significant architecture flaw. It's much better to
-     *  implement copying of this class with creation of a new XmlMethod, but in order to
-     *  implement this we will have to implement copying all the top level classes like
-     *  XmlProgram, XmlClass and so on, which requires lots of work.
-     */
-    public void replaceInstructions(final XmlNode... entries) {
-        final XmlNode seq = this.node.child("base", "seq")
-            .child("base", "tuple");
-        seq.children()
-            .filter(element -> element.attribute("base").isPresent())
-            .forEach(XmlNode::erase);
-        for (final XmlNode entry : entries) {
-            seq.append(entry);
         }
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -210,21 +210,6 @@ public final class XmlNode {
     }
 
     /**
-     * Append entry to the end of the node.
-     * @param entry Entry.
-     */
-    public void append(final XmlNode entry) {
-        this.node.appendChild(this.node.getOwnerDocument().adoptNode(entry.node.cloneNode(true)));
-    }
-
-    /**
-     * Remove this node from parent.
-     */
-    public void erase() {
-        this.node.getParentNode().removeChild(this.node);
-    }
-
-    /**
      * Convert to class.
      * @return Class.
      */


### PR DESCRIPTION
In this PR I remove mutable methods from `XmlMethod`. Now we can't change inner state of the `XmlMethod`. But we can create a modified copies of the same `XmlMethod`, which is more safe.

Closes: #352

History:
- **feat(#352): remove mutators - methods that mutate object state**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring methods in `XmlNode` and `XmlMethod` classes in the `XmlNode.java` and `XmlMethod.java` files.

### Detailed summary
- In `XmlNode.java`:
  - Removed `append` method.
  - Removed `erase` method.
- In `XmlMethod.java`:
  - Added `withoutMaxs` method.
  - Removed `replaceInstructions` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->