### PR TITLE
feat(#557): Use direct xpath instead of global in XmlMethod implementation

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -294,7 +294,7 @@ public final class XmlMethod {
     public XmlMethod withInstructions(final XmlNode... entries) {
         try {
             final Directives directives = new Directives()
-                .xpath("//o[@base='seq']/o[@base='tuple']");
+                .xpath("./o[@base='seq']/o[@base='tuple']");
             for (final XmlNode entry : entries) {
                 directives.add("o").append(Directives.copyOf(entry.node())).up();
             }
@@ -328,7 +328,7 @@ public final class XmlMethod {
                 new XmlNode(
                     new Xembler(
                         new Directives()
-                            .xpath("//o[@base='seq']/o[@base='tuple']/o")
+                            .xpath("./o[@base='seq']/o[@base='tuple']/o")
                             .remove()
                     ).apply(this.node.node())
                 )


### PR DESCRIPTION
Fix the bug related to global xpaths in `XmlMethod` implementation.

Closes: #557

History:
- **feat(#557): use direct xpath instead of global xpath**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the XPath expressions in `XmlMethod.java` to target elements relative to the current node.

### Detailed summary
- Updated XPath expressions to target elements relative to the current node instead of absolute paths.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->