### PR TITLE
feat(#576): Handle Char Values Correctly

### DIFF
--- a/src/it/annotations/src/main/java/org/eolang/jeo/annotations/FixedWidth.java
+++ b/src/it/annotations/src/main/java/org/eolang/jeo/annotations/FixedWidth.java
@@ -1,0 +1,26 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This is an annotation from JUnit library.
+ * We use it in this test pack because it caused some errors:
+ * https://github.com/objectionary/jeo-maven-plugin/issues/576
+ * We need to check if the plugin can handle this annotation.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+public @interface FixedWidth {
+    int value() default -1;
+
+    char padding() default ' ';
+
+    boolean keepPadding() default false;
+
+    int from() default -1;
+
+    int to() default -1;
+}

--- a/src/main/java/org/eolang/jeo/representation/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/DataType.java
@@ -65,7 +65,7 @@ public enum DataType {
      * Character.
      */
     CHAR("char", Character.class, char.class,
-        value -> ByteBuffer.allocate(Character.BYTES).putChar((char) (int) value).array(),
+        value -> ByteBuffer.allocate(Character.BYTES).putChar((char) value).array(),
         bytes -> ByteBuffer.wrap(bytes).getChar()
     ),
 

--- a/src/main/java/org/eolang/jeo/representation/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/DataType.java
@@ -65,7 +65,15 @@ public enum DataType {
      * Character.
      */
     CHAR("char", Character.class, char.class,
-        value -> ByteBuffer.allocate(Character.BYTES).putChar((char) value).array(),
+        value -> {
+            final char val;
+            if (value instanceof Integer) {
+                val = (char) (int) value;
+            } else {
+                val = (char) value;
+            }
+            return ByteBuffer.allocate(Character.BYTES).putChar(val).array();
+        },
         bytes -> ByteBuffer.wrap(bytes).getChar()
     ),
 

--- a/src/test/java/org/eolang/jeo/representation/HexDataTest.java
+++ b/src/test/java/org/eolang/jeo/representation/HexDataTest.java
@@ -161,7 +161,7 @@ final class HexDataTest {
             Arguments.of(new byte[]{1, 2, 3}, "01 02 03"),
             Arguments.of(true, "01"),
             Arguments.of(false, "00"),
-            Arguments.of('a', "61"),
+            Arguments.of('a', "00 61"),
             Arguments.of(0.1d, "3F B9 99 99 99 99 99 9A"),
             Arguments.of(
                 HexDataTest.class,
@@ -180,7 +180,7 @@ final class HexDataTest {
             Arguments.of(10, "00 00 00 00 00 00 00 0A"),
             Arguments.of("Hello!", "48 65 6C 6C 6F 21"),
             Arguments.of(new byte[]{1, 2, 3}, "01 02 03"),
-            Arguments.of('1', "31"),
+            Arguments.of('a', "00 61"),
             Arguments.of(true, "01"),
             Arguments.of(false, "00"),
             Arguments.of(0.1d, "3F B9 99 99 99 99 99 9A"),

--- a/src/test/java/org/eolang/jeo/representation/HexDataTest.java
+++ b/src/test/java/org/eolang/jeo/representation/HexDataTest.java
@@ -144,7 +144,8 @@ final class HexDataTest {
             Arguments.of(true, "bool"),
             Arguments.of(0.1f, "float"),
             Arguments.of(0.1d, "double"),
-            Arguments.of(HexDataTest.class, "class")
+            Arguments.of(HexDataTest.class, "class"),
+            Arguments.of(' ', "char")
         );
     }
 
@@ -160,6 +161,7 @@ final class HexDataTest {
             Arguments.of(new byte[]{1, 2, 3}, "01 02 03"),
             Arguments.of(true, "01"),
             Arguments.of(false, "00"),
+            Arguments.of('a', "61"),
             Arguments.of(0.1d, "3F B9 99 99 99 99 99 9A"),
             Arguments.of(
                 HexDataTest.class,
@@ -178,6 +180,7 @@ final class HexDataTest {
             Arguments.of(10, "00 00 00 00 00 00 00 0A"),
             Arguments.of("Hello!", "48 65 6C 6C 6F 21"),
             Arguments.of(new byte[]{1, 2, 3}, "01 02 03"),
+            Arguments.of('1', "31"),
             Arguments.of(true, "01"),
             Arguments.of(false, "00"),
             Arguments.of(0.1d, "3F B9 99 99 99 99 99 9A"),


### PR DESCRIPTION
In thir PR I fix the bug related to chars handling. `jeo` used to produce some `ClassCastException`s when handled annotations with default values that uses chars. Now I fixed this.
Closes: #576

History:
- **feat(#576): add example of code which causes cast exception**
- **feat(#576): add unit tests that identidy the problem**
- **feat(#576): fix the bug**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the `DataType` class by adding support for `char` data type conversion. Additionally, it includes new test cases for `char` data representation and introduces a new custom annotation `FixedWidth`.

### Detailed summary
- Added support for `char` data type conversion in `DataType` class
- Added test cases for `char` data representation in `HexDataTest`
- Introduced a new custom annotation `FixedWidth` in `FixedWidth.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->