### PR TITLE
feat(#578): Optimize Bytes to String Convertion

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/HexData.java
+++ b/src/main/java/org/eolang/jeo/representation/HexData.java
@@ -82,14 +82,20 @@ public final class HexData {
      * @param bytes Bytes.
      * @return Hexadecimal value as string.
      */
-    private static String bytesToHex(byte[] bytes) {
-        char[] hex = new char[bytes.length * 3];
-        for (int index = 0; index < bytes.length; index++) {
-            int value = bytes[index] & 0xFF;
-            hex[index * 3] = HexData.HEX_ARRAY[value >>> 4];
-            hex[index * 3 + 1] = HexData.HEX_ARRAY[value & 0x0F];
-            hex[index * 3 + 2] = ' ';
+    private static String bytesToHex(final byte[] bytes) {
+        final String res;
+        if (bytes == null || bytes.length == 0) {
+            res = "";
+        } else {
+            final char[] hex = new char[bytes.length * 3];
+            for (int index = 0; index < bytes.length; ++index) {
+                final int value = bytes[index] & 0xFF;
+                hex[index * 3] = HexData.HEX_ARRAY[value >>> 4];
+                hex[index * 3 + 1] = HexData.HEX_ARRAY[value & 0x0F];
+                hex[index * 3 + 2] = ' ';
+            }
+            res = new String(hex, 0, hex.length - 1);
         }
-        return new String(hex, 0, hex.length - 1);
+        return res;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/HexData.java
+++ b/src/main/java/org/eolang/jeo/representation/HexData.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.jeo.representation;
 
-import java.util.StringJoiner;
 import lombok.ToString;
 
 /**
@@ -32,6 +31,13 @@ import lombok.ToString;
  */
 @ToString
 public final class HexData {
+
+    /**
+     * Array of hexadecimal characters.
+     * Used for converting bytes to hexadecimal.
+     * See {@link #bytesToHex(byte[])}.
+     */
+    private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 
     /**
      * Data to convert.
@@ -65,16 +71,25 @@ public final class HexData {
 
     /**
      * Bytes to HEX.
+     * The efficient way to convert bytes to hexadecimal.
+     * ATTENTION!
+     * Do not modify this method.
+     * It is an optimized version that saves memory and CPU.
+     * Actually, the solution is based on the following StackOverflow answer:
+     * <a href="https://stackoverflow.com/a/9855338/10423604">here</a>
+     * You can find the full explanation or any other examples there.
      *
      * @param bytes Bytes.
      * @return Hexadecimal value as string.
      */
-    private static String bytesToHex(final byte... bytes) {
-        final StringJoiner out = new StringJoiner(" ");
-        for (final byte bty : bytes) {
-            out.add(String.format("%02X", bty));
+    private static String bytesToHex(byte[] bytes) {
+        char[] hex = new char[bytes.length * 3];
+        for (int index = 0; index < bytes.length; index++) {
+            int value = bytes[index] & 0xFF;
+            hex[index * 3] = HexData.HEX_ARRAY[value >>> 4];
+            hex[index * 3 + 1] = HexData.HEX_ARRAY[value & 0x0F];
+            hex[index * 3 + 2] = ' ';
         }
-        return out.toString();
+        return new String(hex, 0, hex.length - 1);
     }
-
 }


### PR DESCRIPTION
We used to have a suboptimal solution by converting raw byte arrays to hex strings. Now I optimized this part and this method doesn't consume much heap space anymore.

Related to #578
History:
- **feat(#578): optimize 'bytesToHex' method**
- **feat(#578): fix all qulice suggestions**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR optimizes the `bytesToHex` method in `HexData.java` for efficient byte to hexadecimal conversion, following a StackOverflow solution.

### Detailed summary
- Added `HEX_ARRAY` constant for optimized conversion
- Updated `bytesToHex` method for memory and CPU efficiency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->