### PR TITLE
feat(#244): The First Attempt To Localize Labels

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionEntry.java
@@ -54,6 +54,9 @@ final class BytecodeInstructionEntry implements BytecodeEntry {
      */
     private final List<Object> args;
 
+    /**
+     * All labels.
+     */
     private final AllLabels labels;
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionEntry.java
@@ -54,17 +54,21 @@ final class BytecodeInstructionEntry implements BytecodeEntry {
      */
     private final List<Object> args;
 
+    private final AllLabels labels;
+
     /**
      * Constructor.
      *
+     * @param labels All labels.
      * @param opcode Opcode.
      * @param args Arguments.
      */
     BytecodeInstructionEntry(
+        final AllLabels labels,
         final int opcode,
         final Object... args
     ) {
-        this(opcode, Arrays.asList(args));
+        this(labels, opcode, Arrays.asList(args));
     }
 
     /**
@@ -74,9 +78,11 @@ final class BytecodeInstructionEntry implements BytecodeEntry {
      * @param args Arguments.
      */
     BytecodeInstructionEntry(
+        final AllLabels labels,
         final int opcode,
         final List<Object> args
     ) {
+        this.labels = labels;
         this.opcode = opcode;
         this.args = args;
     }
@@ -97,7 +103,7 @@ final class BytecodeInstructionEntry implements BytecodeEntry {
                 if (arg instanceof Label) {
                     return String.format(
                         "labels.label(\"%s\")",
-                        new AllLabels().uid((Label) arg)
+                        this.labels.uid((Label) arg)
                     );
                 }
                 return String.valueOf(arg);

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabelEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabelEntry.java
@@ -40,6 +40,9 @@ public final class BytecodeLabelEntry implements BytecodeEntry {
      */
     private final Label label;
 
+    /**
+     * All method labels.
+     */
     private final AllLabels labels;
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabelEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabelEntry.java
@@ -40,12 +40,16 @@ public final class BytecodeLabelEntry implements BytecodeEntry {
      */
     private final Label label;
 
+    private final AllLabels labels;
+
     /**
      * Constructor.
      * @param label Label.
+     * @param labels All labels.
      */
-    BytecodeLabelEntry(final Label label) {
+    public BytecodeLabelEntry(final Label label, final AllLabels labels) {
         this.label = label;
+        this.labels = labels;
     }
 
     @Override
@@ -55,6 +59,6 @@ public final class BytecodeLabelEntry implements BytecodeEntry {
 
     @Override
     public String testCode() {
-        return String.format(".label(\"%s\")", new AllLabels().uid(this.label));
+        return String.format(".label(\"%s\")", this.labels.uid(this.label));
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -168,7 +168,7 @@ public final class BytecodeMethod implements Testable {
      * @return This object.
      */
     public BytecodeMethod opcode(final int opcode, final Object... args) {
-        return this.entry(new BytecodeInstructionEntry(opcode, args));
+        return this.entry(new BytecodeInstructionEntry(this.labels, opcode, args));
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -80,7 +80,10 @@ public final class BytecodeMethod implements Testable {
      */
     private final int locals;
 
-    private final AllLabels labels = new AllLabels();
+    /**
+     * All Method Labels.
+     */
+    private final AllLabels labels;
 
     /**
      * Constructor.
@@ -140,6 +143,7 @@ public final class BytecodeMethod implements Testable {
         this.defvalues = new ArrayList<>(0);
         this.stack = stack;
         this.locals = locals;
+        this.labels = new AllLabels();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -155,15 +155,6 @@ public final class BytecodeMethod implements Testable {
      * @param label Label.
      * @return This object.
      */
-    public BytecodeMethod label(final String label) {
-        return this.label(new AllLabels().label(label));
-    }
-
-    /**
-     * Add label.
-     * @param label Label.
-     * @return This object.
-     */
     public BytecodeMethod label(final Label label) {
         return this.entry(new BytecodeLabelEntry(label));
     }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -80,6 +80,8 @@ public final class BytecodeMethod implements Testable {
      */
     private final int locals;
 
+    private final AllLabels labels = new AllLabels();
+
     /**
      * Constructor.
      * @param name Method name.
@@ -156,7 +158,7 @@ public final class BytecodeMethod implements Testable {
      * @return This object.
      */
     public BytecodeMethod label(final Label label) {
-        return this.entry(new BytecodeLabelEntry(label));
+        return this.entry(new BytecodeLabelEntry(label, this.labels));
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -58,6 +58,9 @@ public final class XmlMethod {
     @ToString.Include
     private final XmlNode node;
 
+    @EqualsAndHashCode.Exclude
+    private final AllLabels labels = new AllLabels();
+
     /**
      * Constructor.
      */
@@ -168,7 +171,7 @@ public final class XmlMethod {
         return this.node.children()
             .filter(element -> element.hasAttribute("name", "trycatchblocks"))
             .flatMap(XmlNode::children)
-            .map(XmlTryCatchEntry::new)
+            .map(node -> new XmlTryCatchEntry(node, this.labels))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -58,8 +58,11 @@ public final class XmlMethod {
     @ToString.Include
     private final XmlNode node;
 
+    /**
+     * Method labels.
+     */
     @EqualsAndHashCode.Exclude
-    private final AllLabels labels = new AllLabels();
+    private final AllLabels labels;
 
     /**
      * Constructor.
@@ -112,6 +115,7 @@ public final class XmlMethod {
      */
     public XmlMethod(final XmlNode xmlnode) {
         this.node = xmlnode;
+        this.labels = new AllLabels();
     }
 
     /**
@@ -171,7 +175,7 @@ public final class XmlMethod {
         return this.node.children()
             .filter(element -> element.hasAttribute("name", "trycatchblocks"))
             .flatMap(XmlNode::children)
-            .map(node -> new XmlTryCatchEntry(node, this.labels))
+            .map(entry -> new XmlTryCatchEntry(entry, this.labels))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
@@ -38,22 +38,28 @@ public final class XmlTryCatchEntry implements XmlBytecodeEntry {
      */
     private final XmlNode xmlnode;
 
+    private final AllLabels labels;
+
+    public XmlTryCatchEntry(final XmlNode xmlnode) {
+        this(xmlnode, new AllLabels());
+    }
+
     /**
      * Constructor.
      * @param node XML node
      */
-    public XmlTryCatchEntry(final XmlNode node) {
+    public XmlTryCatchEntry(final XmlNode node, final AllLabels labels) {
         this.xmlnode = node;
+        this.labels = labels;
     }
 
     @Override
     public void writeTo(final BytecodeMethod method) {
-        final AllLabels labels = new AllLabels();
         method.trycatch(
             new BytecodeTryCatchBlock(
-                this.label("start").map(labels::label).orElse(null),
-                this.label("end").map(labels::label).orElse(null),
-                this.label("handler").map(labels::label).orElse(null),
+                this.label("start").map(this.labels::label).orElse(null),
+                this.label("end").map(this.labels::label).orElse(null),
+                this.label("handler").map(this.labels::label).orElse(null),
                 this.type().map(HexString::new).map(HexString::decode).orElse(null)
             )
         );

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
@@ -38,8 +38,15 @@ public final class XmlTryCatchEntry implements XmlBytecodeEntry {
      */
     private final XmlNode xmlnode;
 
+    /**
+     * Method Labels.
+     */
     private final AllLabels labels;
 
+    /**
+     * Constructor.
+     * @param xmlnode XML node
+     */
     public XmlTryCatchEntry(final XmlNode xmlnode) {
         this(xmlnode, new AllLabels());
     }
@@ -47,6 +54,7 @@ public final class XmlTryCatchEntry implements XmlBytecodeEntry {
     /**
      * Constructor.
      * @param node XML node
+     * @param labels Labels
      */
     public XmlTryCatchEntry(final XmlNode node, final AllLabels labels) {
         this.xmlnode = node;

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -181,13 +181,13 @@ final class BytecodeClassTest {
             IllegalStateException.class,
             () -> new BytecodeClass("Broken")
                 .withMethod("j$bar", "()I", Opcodes.ACC_PUBLIC)
-                .label("70b56006-856e-4ac2-be99-632ca25a65a0")
+                .label(new Label())
                 .opcode(Opcodes.ALOAD, 0)
                 .opcode(Opcodes.INVOKEVIRTUAL, "com/exam/BA", "foo", "()I")
                 .opcode(Opcodes.ICONST_2)
                 .opcode(Opcodes.IADD)
                 .opcode(Opcodes.IRETURN)
-                .label("f3d973ab-c502-4134-8d6f-d7fe89defc6e")
+                .label(new Label())
                 .up()
                 .bytecode(),
             "We expect an exception here because the bytecode is broken"


### PR DESCRIPTION
It is the first attempt to localize AllLabels usage. In order to do so, I removed unnecessary `new AllLabels()` statements and passed all the required objects through constructors. This doesn't solve the original problem, but it is the first step in this direction. 

Related to #244
History:
- **feat(#244): remove unnecessary AllLabels usage**
- **feat(#244): reuse labels between classes**
- **feat(#244): reuse labels between classes**
- **feat(#244): fix all qulice suggestions**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to refactor the codebase by introducing a centralized `AllLabels` class to manage method labels efficiently.

### Detailed summary
- Introduces `AllLabels` class to manage method labels centrally
- Updates constructors in multiple classes to accept `AllLabels`
- Refactors code to use `AllLabels` for generating and managing method labels efficiently

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->