### PR TITLE
feat(#578): Optimize Memory Consumption

### DIFF
--- a/src/main/java/org/eolang/jeo/Assembler.java
+++ b/src/main/java/org/eolang/jeo/Assembler.java
@@ -24,7 +24,6 @@
 package org.eolang.jeo;
 
 import java.nio.file.Path;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -81,8 +80,10 @@ final class Assembler {
                 )
             )
         ).apply(new XmirRepresentations(this.input, this.verify).all());
-        stream.forEach(terminate -> {
-        });
+        stream.forEach(
+            terminate -> {
+            }
+        );
         stream.close();
     }
 }

--- a/src/main/java/org/eolang/jeo/Assembler.java
+++ b/src/main/java/org/eolang/jeo/Assembler.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo;
 
 import java.nio.file.Path;
+import java.util.stream.Collectors;
 
 /**
  * Assembler.
@@ -78,6 +79,8 @@ final class Assembler {
                     new Assemble(this.output)
                 )
             )
-        ).apply(new XmirRepresentations(this.input, this.verify).all());
+        ).apply(
+            new XmirRepresentations(this.input, this.verify).all().collect(Collectors.toList())
+        );
     }
 }

--- a/src/main/java/org/eolang/jeo/Assembler.java
+++ b/src/main/java/org/eolang/jeo/Assembler.java
@@ -25,6 +25,7 @@ package org.eolang.jeo;
 
 import java.nio.file.Path;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Assembler.
@@ -67,7 +68,7 @@ final class Assembler {
     void assemble() {
         final String assembling = "Assembling";
         final String assembled = "assembled";
-        new LoggedTranslator(
+        final Stream<? extends Representation> stream = new LoggedTranslator(
             assembling,
             assembled,
             this.input,
@@ -79,8 +80,9 @@ final class Assembler {
                     new Assemble(this.output)
                 )
             )
-        ).apply(
-            new XmirRepresentations(this.input, this.verify).all().collect(Collectors.toList())
-        );
+        ).apply(new XmirRepresentations(this.input, this.verify).all());
+        stream.forEach(terminate -> {
+        });
+        stream.close();
     }
 }

--- a/src/main/java/org/eolang/jeo/BachedTranslator.java
+++ b/src/main/java/org/eolang/jeo/BachedTranslator.java
@@ -23,8 +23,7 @@
  */
 package org.eolang.jeo;
 
-import java.util.Collection;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Translator that applies a translation to a batch of representations.
@@ -53,14 +52,10 @@ public final class BachedTranslator implements Translator {
     }
 
     @Override
-    public Collection<Representation> apply(
-        final Collection<? extends Representation> representations
+    public Stream<Representation> apply(
+        final Stream<? extends Representation> representations
     ) {
-        return representations
-            .stream()
-            .parallel()
-            .map(this::translate)
-            .collect(Collectors.toList());
+        return representations.parallel().map(this::translate);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/BachedTranslator.java
+++ b/src/main/java/org/eolang/jeo/BachedTranslator.java
@@ -25,6 +25,7 @@ package org.eolang.jeo;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Translator that applies a translation to a batch of representations.
@@ -54,9 +55,9 @@ public final class BachedTranslator implements Translator {
 
     @Override
     public Collection<Representation> apply(
-        final Collection<? extends Representation> representations
+        final Stream<? extends Representation> representations
     ) {
-        return representations.stream()
+        return representations
             .parallel()
             .map(this::translate)
             .collect(Collectors.toList());

--- a/src/main/java/org/eolang/jeo/BachedTranslator.java
+++ b/src/main/java/org/eolang/jeo/BachedTranslator.java
@@ -25,7 +25,6 @@ package org.eolang.jeo;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Translator that applies a translation to a batch of representations.
@@ -55,9 +54,10 @@ public final class BachedTranslator implements Translator {
 
     @Override
     public Collection<Representation> apply(
-        final Stream<? extends Representation> representations
+        final Collection<? extends Representation> representations
     ) {
         return representations
+            .stream()
             .parallel()
             .map(this::translate)
             .collect(Collectors.toList());

--- a/src/main/java/org/eolang/jeo/BytecodeRepresentations.java
+++ b/src/main/java/org/eolang/jeo/BytecodeRepresentations.java
@@ -53,7 +53,7 @@ public final class BytecodeRepresentations implements Representations {
     }
 
     @Override
-    public Collection<? extends Representation> all() {
+    public Stream<? extends Representation> all() {
         try {
             return this.bytecode();
         } catch (final IOException exception) {
@@ -72,11 +72,10 @@ public final class BytecodeRepresentations implements Representations {
      * @return Collection of {@link org.eolang.jeo.Representation}
      * @throws IOException If some I/O problem arises.
      */
-    private Collection<? extends Representation> bytecode() throws IOException {
+    private Stream<? extends Representation> bytecode() throws IOException {
         return this.classes()
             .stream()
-            .map(BytecodeRepresentation::new)
-            .collect(Collectors.toList());
+            .map(BytecodeRepresentation::new);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/Disassembler.java
+++ b/src/main/java/org/eolang/jeo/Disassembler.java
@@ -24,7 +24,7 @@
 package org.eolang.jeo;
 
 import java.nio.file.Path;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This class disassembles the project's compiled classes.
@@ -64,7 +64,7 @@ public class Disassembler {
     public void disassemble() {
         final String process = "Disassembling";
         final String disassembled = "disassembled";
-        new LoggedTranslator(
+        final Stream<? extends Representation> stream = new LoggedTranslator(
             process,
             disassembled,
             this.classes,
@@ -76,6 +76,9 @@ public class Disassembler {
                     new Disassemble(this.target)
                 )
             )
-        ).apply(new BytecodeRepresentations(this.classes).all().collect(Collectors.toList()));
+        ).apply(new BytecodeRepresentations(this.classes).all());
+        stream.forEach(terminate -> {
+        });
+        stream.close();
     }
 }

--- a/src/main/java/org/eolang/jeo/Disassembler.java
+++ b/src/main/java/org/eolang/jeo/Disassembler.java
@@ -77,8 +77,10 @@ public class Disassembler {
                 )
             )
         ).apply(new BytecodeRepresentations(this.classes).all());
-        stream.forEach(terminate -> {
-        });
+        stream.forEach(
+            terminate -> {
+            }
+        );
         stream.close();
     }
 }

--- a/src/main/java/org/eolang/jeo/Disassembler.java
+++ b/src/main/java/org/eolang/jeo/Disassembler.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo;
 
 import java.nio.file.Path;
+import java.util.stream.Collectors;
 
 /**
  * This class disassembles the project's compiled classes.
@@ -75,6 +76,6 @@ public class Disassembler {
                     new Disassemble(this.target)
                 )
             )
-        ).apply(new BytecodeRepresentations(this.classes).all());
+        ).apply(new BytecodeRepresentations(this.classes).all().collect(Collectors.toList()));
     }
 }

--- a/src/main/java/org/eolang/jeo/LoggedTranslator.java
+++ b/src/main/java/org/eolang/jeo/LoggedTranslator.java
@@ -26,6 +26,7 @@ package org.eolang.jeo;
 import com.jcabi.log.Logger;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.stream.Stream;
 
 /**
  * Translation log.
@@ -85,7 +86,7 @@ public final class LoggedTranslator implements Translator {
 
     @Override
     public Collection<? extends Representation> apply(
-        final Collection<? extends Representation> representations
+        final Stream<? extends Representation> representations
     ) {
         Logger.info(
             this,

--- a/src/main/java/org/eolang/jeo/LoggedTranslator.java
+++ b/src/main/java/org/eolang/jeo/LoggedTranslator.java
@@ -26,7 +26,6 @@ package org.eolang.jeo;
 import com.jcabi.log.Logger;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.stream.Stream;
 
 /**
  * Translation log.
@@ -86,7 +85,7 @@ public final class LoggedTranslator implements Translator {
 
     @Override
     public Collection<? extends Representation> apply(
-        final Stream<? extends Representation> representations
+        final Collection<? extends Representation> representations
     ) {
         Logger.info(
             this,

--- a/src/main/java/org/eolang/jeo/LoggedTranslator.java
+++ b/src/main/java/org/eolang/jeo/LoggedTranslator.java
@@ -108,15 +108,5 @@ public final class LoggedTranslator implements Translator {
                     System.currentTimeMillis() - start
                 )
             );
-//        );
-//        final long total = ;
-//        Logger.info(
-//            this,
-//            "Total %d files were %s in %[ms]s",
-//            res.size(),
-//            this.participle,
-//            total
-//        );
-//        return res;
     }
 }

--- a/src/main/java/org/eolang/jeo/LoggedTranslator.java
+++ b/src/main/java/org/eolang/jeo/LoggedTranslator.java
@@ -25,7 +25,8 @@ package org.eolang.jeo;
 
 import com.jcabi.log.Logger;
 import java.nio.file.Path;
-import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 /**
  * Translation log.
@@ -84,8 +85,8 @@ public final class LoggedTranslator implements Translator {
     }
 
     @Override
-    public Collection<? extends Representation> apply(
-        final Collection<? extends Representation> representations
+    public Stream<? extends Representation> apply(
+        final Stream<? extends Representation> representations
     ) {
         Logger.info(
             this,
@@ -95,15 +96,27 @@ public final class LoggedTranslator implements Translator {
             this.output
         );
         final long start = System.currentTimeMillis();
-        final Collection<? extends Representation> res = this.original.apply(representations);
-        final long total = System.currentTimeMillis() - start;
-        Logger.info(
-            this,
-            "Total %d files were %s in %[ms]s",
-            res.size(),
-            this.participle,
-            total
-        );
-        return res;
+        final AtomicInteger counter = new AtomicInteger();
+        return this.original.apply(representations)
+            .peek(rep -> counter.incrementAndGet())
+            .onClose(
+                () -> Logger.info(
+                    this,
+                    "Total %d files were %s in %[ms]s",
+                    counter.get(),
+                    this.participle,
+                    System.currentTimeMillis() - start
+                )
+            );
+//        );
+//        final long total = ;
+//        Logger.info(
+//            this,
+//            "Total %d files were %s in %[ms]s",
+//            res.size(),
+//            this.participle,
+//            total
+//        );
+//        return res;
     }
 }

--- a/src/main/java/org/eolang/jeo/Representations.java
+++ b/src/main/java/org/eolang/jeo/Representations.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo;
 
 import java.util.Collection;
+import java.util.stream.Stream;
 
 /**
  * Collection of representations.
@@ -37,5 +38,5 @@ public interface Representations {
      * All representations.
      * @return All representations.
      */
-    Collection<? extends Representation> all();
+    Stream<? extends Representation> all();
 }

--- a/src/main/java/org/eolang/jeo/Representations.java
+++ b/src/main/java/org/eolang/jeo/Representations.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.jeo;
 
-import java.util.Collection;
 import java.util.stream.Stream;
 
 /**

--- a/src/main/java/org/eolang/jeo/Translator.java
+++ b/src/main/java/org/eolang/jeo/Translator.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo;
 
 import java.util.Collection;
+import java.util.stream.Stream;
 
 /**
  * Translator that applies a translation to a batch of representations.
@@ -37,6 +38,6 @@ public interface Translator {
      * @return Translated IRs.
      */
     Collection<? extends Representation> apply(
-        Collection<? extends Representation> representations
+        Stream<? extends Representation> representations
     );
 }

--- a/src/main/java/org/eolang/jeo/Translator.java
+++ b/src/main/java/org/eolang/jeo/Translator.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo;
 
 import java.util.Collection;
+import java.util.stream.Stream;
 
 /**
  * Translator that applies a translation to a batch of representations.
@@ -36,7 +37,7 @@ public interface Translator {
      * @param representations IRs to translate.
      * @return Translated IRs.
      */
-    Collection<? extends Representation> apply(
-        Collection<? extends Representation> representations
+    Stream<? extends Representation> apply(
+        Stream<? extends Representation> representations
     );
 }

--- a/src/main/java/org/eolang/jeo/Translator.java
+++ b/src/main/java/org/eolang/jeo/Translator.java
@@ -24,7 +24,6 @@
 package org.eolang.jeo;
 
 import java.util.Collection;
-import java.util.stream.Stream;
 
 /**
  * Translator that applies a translation to a batch of representations.
@@ -38,6 +37,6 @@ public interface Translator {
      * @return Translated IRs.
      */
     Collection<? extends Representation> apply(
-        Stream<? extends Representation> representations
+        Collection<? extends Representation> representations
     );
 }

--- a/src/main/java/org/eolang/jeo/Translator.java
+++ b/src/main/java/org/eolang/jeo/Translator.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.jeo;
 
-import java.util.Collection;
 import java.util.stream.Stream;
 
 /**

--- a/src/main/java/org/eolang/jeo/XmirRepresentations.java
+++ b/src/main/java/org/eolang/jeo/XmirRepresentations.java
@@ -26,8 +26,6 @@ package org.eolang.jeo;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collection;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.XmirRepresentation;
 

--- a/src/main/java/org/eolang/jeo/XmirRepresentations.java
+++ b/src/main/java/org/eolang/jeo/XmirRepresentations.java
@@ -71,12 +71,12 @@ final class XmirRepresentations implements Representations {
     }
 
     @Override
-    public Collection<? extends Representation> all() {
+    public Stream<? extends Representation> all() {
         final Path path = this.objectspath;
-        try (Stream<Path> walk = Files.walk(path)) {
-            return walk.filter(Files::isRegularFile)
-                .map(p -> new XmirRepresentation(p, this.verify))
-                .collect(Collectors.toList());
+        try {
+            return Files.walk(path)
+                .filter(Files::isRegularFile)
+                .map(p -> new XmirRepresentation(p, this.verify));
         } catch (final IOException exception) {
             throw new IllegalStateException(
                 String.format("Can't read folder '%s'", path),

--- a/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
@@ -157,7 +157,11 @@ public final class XmirRepresentation implements Representation {
         ).full();
     }
 
-
+    /**
+     * Prestructor that converts a path to a lazy XML.
+     * @param path Path to an XML file.
+     * @return Lazy XML.
+     */
     private static Unchecked<XML> fromFile(final Path path) {
         return new Unchecked<>(new Synced<>(new Sticky<>(() -> XmirRepresentation.open(path))));
     }

--- a/src/test/java/org/eolang/jeo/BachedTranslatorTest.java
+++ b/src/test/java/org/eolang/jeo/BachedTranslatorTest.java
@@ -28,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.XmirRepresentation;

--- a/src/test/java/org/eolang/jeo/BachedTranslatorTest.java
+++ b/src/test/java/org/eolang/jeo/BachedTranslatorTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.XmirRepresentation;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
@@ -64,7 +65,7 @@ final class BachedTranslatorTest {
                 .getBytes(StandardCharsets.UTF_8)
         );
         new BachedTranslator(new Disassemble(temp))
-            .apply(List.of(new XmirRepresentation(clazz)));
+            .apply(Stream.of(new XmirRepresentation(clazz))).collect(Collectors.toList());
         MatcherAssert.assertThat(
             "XML file was not saved",
             temp.resolve(this.expected).toFile(),
@@ -80,8 +81,8 @@ final class BachedTranslatorTest {
         final Representation repr = new XmirRepresentation(
             new BytecodeClass("org/eolang/jeo/Application").xml()
         );
-        footprint.apply(List.of(repr));
-        footprint.apply(List.of(repr));
+        footprint.apply(Stream.of(repr)).collect(Collectors.toList());
+        footprint.apply(Stream.of(repr)).collect(Collectors.toList());
         MatcherAssert.assertThat(
             "XML file was not successfully overwritten",
             temp.resolve(this.expected).toFile(),
@@ -93,8 +94,8 @@ final class BachedTranslatorTest {
     void assemblesSuccessfully(@TempDir final Path temp) {
         final String fake = "jeo/xmir/Fake";
         new BachedTranslator(new Assemble(temp)).apply(
-            List.of(new XmirRepresentation(new BytecodeClass(fake).xml()))
-        );
+            Stream.of(new XmirRepresentation(new BytecodeClass(fake).xml()))
+        ).collect(Collectors.toList());
         MatcherAssert.assertThat(
             String.format(
                 "Bytecode file was not saved for the representation with the name '%s'",

--- a/src/test/java/org/eolang/jeo/BachedTranslatorTest.java
+++ b/src/test/java/org/eolang/jeo/BachedTranslatorTest.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.XmirRepresentation;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
@@ -63,7 +64,7 @@ final class BachedTranslatorTest {
                 .getBytes(StandardCharsets.UTF_8)
         );
         new BachedTranslator(new Disassemble(temp))
-            .apply(Stream.of(new XmirRepresentation(clazz)));
+            .apply(List.of(new XmirRepresentation(clazz)));
         MatcherAssert.assertThat(
             "XML file was not saved",
             temp.resolve(this.expected).toFile(),
@@ -79,8 +80,8 @@ final class BachedTranslatorTest {
         final Representation repr = new XmirRepresentation(
             new BytecodeClass("org/eolang/jeo/Application").xml()
         );
-        footprint.apply(Stream.of(repr));
-        footprint.apply(Stream.of(repr));
+        footprint.apply(List.of(repr));
+        footprint.apply(List.of(repr));
         MatcherAssert.assertThat(
             "XML file was not successfully overwritten",
             temp.resolve(this.expected).toFile(),
@@ -92,7 +93,7 @@ final class BachedTranslatorTest {
     void assemblesSuccessfully(@TempDir final Path temp) {
         final String fake = "jeo/xmir/Fake";
         new BachedTranslator(new Assemble(temp)).apply(
-            Stream.of(new XmirRepresentation(new BytecodeClass(fake).xml()))
+            List.of(new XmirRepresentation(new BytecodeClass(fake).xml()))
         );
         MatcherAssert.assertThat(
             String.format(

--- a/src/test/java/org/eolang/jeo/BachedTranslatorTest.java
+++ b/src/test/java/org/eolang/jeo/BachedTranslatorTest.java
@@ -28,8 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collection;
-import java.util.Collections;
+import java.util.stream.Stream;
 import org.eolang.jeo.representation.XmirRepresentation;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.hamcrest.MatcherAssert;
@@ -43,15 +42,6 @@ import org.junit.jupiter.api.io.TempDir;
  * @since 0.1.0
  */
 final class BachedTranslatorTest {
-
-    /**
-     * Representations to test.
-     */
-    private final Collection<Representation> objects = Collections.singleton(
-        new XmirRepresentation(
-            new BytecodeClass("org/eolang/jeo/Application").xml()
-        )
-    );
 
     /**
      * Where the XML file is expected to be saved.
@@ -73,7 +63,7 @@ final class BachedTranslatorTest {
                 .getBytes(StandardCharsets.UTF_8)
         );
         new BachedTranslator(new Disassemble(temp))
-            .apply(Collections.singleton(new XmirRepresentation(clazz)));
+            .apply(Stream.of(new XmirRepresentation(clazz)));
         MatcherAssert.assertThat(
             "XML file was not saved",
             temp.resolve(this.expected).toFile(),
@@ -86,8 +76,11 @@ final class BachedTranslatorTest {
         final BachedTranslator footprint = new BachedTranslator(
             new Disassemble(temp)
         );
-        footprint.apply(this.objects);
-        footprint.apply(this.objects);
+        final Representation repr = new XmirRepresentation(
+            new BytecodeClass("org/eolang/jeo/Application").xml()
+        );
+        footprint.apply(Stream.of(repr));
+        footprint.apply(Stream.of(repr));
         MatcherAssert.assertThat(
             "XML file was not successfully overwritten",
             temp.resolve(this.expected).toFile(),
@@ -99,7 +92,7 @@ final class BachedTranslatorTest {
     void assemblesSuccessfully(@TempDir final Path temp) {
         final String fake = "jeo/xmir/Fake";
         new BachedTranslator(new Assemble(temp)).apply(
-            Collections.singleton(new XmirRepresentation(new BytecodeClass(fake).xml()))
+            Stream.of(new XmirRepresentation(new BytecodeClass(fake).xml()))
         );
         MatcherAssert.assertThat(
             String.format(

--- a/src/test/java/org/eolang/jeo/XmirRepresentationsTest.java
+++ b/src/test/java/org/eolang/jeo/XmirRepresentationsTest.java
@@ -28,6 +28,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -57,7 +59,7 @@ final class XmirRepresentationsTest {
         );
         MatcherAssert.assertThat(
             String.format("Objects were not retrieved, we expected '%d' objects", expected),
-            new XmirRepresentations(temp).all(),
+            new XmirRepresentations(temp).all().collect(Collectors.toList()),
             Matchers.hasSize(expected)
         );
     }
@@ -67,7 +69,7 @@ final class XmirRepresentationsTest {
         Files.createDirectories(temp.resolve("some-path"));
         MatcherAssert.assertThat(
             "Objects were not retrieved, we expected empty list",
-            new XmirRepresentations(temp).all(),
+            new XmirRepresentations(temp).all().collect(Collectors.toList()),
             Matchers.empty()
         );
     }
@@ -90,12 +92,13 @@ final class XmirRepresentationsTest {
             path.resolve("opeo-class.xmir"),
             new BytecodeClass("OpeoClass").xml().toString().getBytes(StandardCharsets.UTF_8)
         );
+        final Stream<? extends Representation> all = new XmirRepresentations(path).all();
         MatcherAssert.assertThat(
             String.format(
                 "Objects were not retrieved, we expected exactly one object was read from %s",
                 path
             ),
-            new XmirRepresentations(path).all(),
+            all.collect(Collectors.toList()),
             Matchers.hasSize(1)
         );
     }


### PR DESCRIPTION
In this PR I significantly optimized memory consumption by entire plugin. Now it doesn't accumulate any intemediate files and process all representations using streams. So, now we have constant memory consumption. This improvement also slightly improved transformation speed in large integration tests.

Closes: #578
History:
- **feat(#578): make representations return stream**
- **feat(#578): open XML files in a lazy mode**
- **feat(#578): return Collections instead of Streams**
- **feat(#578): add lazy loading of bytecode representations**
- **feat(#578): replace Collection -> Steam**
- **feat(#578): fix all qulice suggestions**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the codebase to use `Stream` instead of `Collection` for handling representations, improving performance and readability.

### Detailed summary
- Replaced `Collection` with `Stream` in methods returning representations
- Updated translator classes to use `Stream` for input representations
- Changed `Collection` to `Stream` in `BytecodeRepresentations` and `XmirRepresentations`
- Refactored `LoggedTranslator` to use `Stream` and added logging functionality

> The following files were skipped due to too many changes: `src/main/java/org/eolang/jeo/representation/XmirRepresentation.java`, `src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->