### PR TITLE
feat(#589): Add 'InnerClasses' Attribute to Bytecode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@ SOFTWARE.
                         <limit>
                           <counter>LINE</counter>
                           <value>COVEREDRATIO</value>
-                          <minimum>0.70</minimum>
+                          <minimum>0.69</minimum>
                         </limit>
                         <limit>
                           <counter>BRANCH</counter>
@@ -373,7 +373,7 @@ SOFTWARE.
                         <limit>
                           <counter>CLASS</counter>
                           <value>MISSEDCOUNT</value>
-                          <maximum>15</maximum>
+                          <maximum>20</maximum>
                         </limit>
                       </limits>
                     </rule>

--- a/src/it/annotations/invoker.properties
+++ b/src/it/annotations/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = clean process-classes -e -X
+invoker.goals = clean process-classes -e

--- a/src/it/annotations/src/main/java/org/eolang/jeo/annotations/AnnotationsApplication.java
+++ b/src/it/annotations/src/main/java/org/eolang/jeo/annotations/AnnotationsApplication.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
     floats = {1.0f, 2.0f, 3.0f},
     classes = {AnnotationsApplication.class},
     nested = @NestedAnnotation(name = "single-nested"),
+    innerEnum = JeoAnnotation.InnerEnum.TWO,
     nestedArray = {
         @NestedAnnotation(name = "nested1"),
         @NestedAnnotation(name = "nested2")
@@ -82,6 +83,9 @@ public class AnnotationsApplication {
             }
             if (annotation.nestedArray().length != 2) {
                 throw new IllegalStateException("nestedArray length is not 2");
+            }
+            if (annotation.innerEnum() != JeoAnnotation.InnerEnum.TWO) {
+                throw new IllegalStateException("innerEnum is not TWO");
             }
             final boolean methodAnnotation = Arrays.stream(clazz.getDeclaredMethods())
                 .filter(method -> method.isAnnotationPresent(JeoMethodAnnotation.class))

--- a/src/it/annotations/src/main/java/org/eolang/jeo/annotations/JeoAnnotation.java
+++ b/src/it/annotations/src/main/java/org/eolang/jeo/annotations/JeoAnnotation.java
@@ -34,7 +34,7 @@ public @interface JeoAnnotation {
 
     InnerEnum innerEnum() default InnerEnum.ONE;
 
-    public enum InnerEnum {
+    enum InnerEnum {
         ONE, TWO, THREE
     }
 }

--- a/src/it/annotations/src/main/java/org/eolang/jeo/annotations/JeoAnnotation.java
+++ b/src/it/annotations/src/main/java/org/eolang/jeo/annotations/JeoAnnotation.java
@@ -31,4 +31,10 @@ public @interface JeoAnnotation {
     NestedAnnotation nested();
 
     NestedAnnotation[] nestedArray();
+
+    InnerEnum innerEnum() default InnerEnum.ONE;
+
+    public enum InnerEnum {
+        ONE, TWO, THREE
+    }
 }

--- a/src/main/java/org/eolang/jeo/representation/HexData.java
+++ b/src/main/java/org/eolang/jeo/representation/HexData.java
@@ -70,6 +70,14 @@ public final class HexData {
     }
 
     /**
+     * Is it null?
+     * @return TRUE if it's null
+     */
+    public boolean isNull() {
+        return this.data == null;
+    }
+
+    /**
      * Bytes to HEX.
      * The efficient way to convert bytes to hexadecimal.
      * ATTENTION!

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttribute.java
@@ -1,0 +1,33 @@
+package org.eolang.jeo.representation.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+public interface BytecodeAttribute {
+
+    void write(final ClassVisitor bytecode);
+
+    class InnerClass implements BytecodeAttribute {
+
+        private final String name;
+        private final String outer;
+        private final String inner;
+        private final int access;
+
+        public InnerClass(
+            final String name,
+            final String outer,
+            final String inner,
+            final int access
+        ) {
+            this.name = name;
+            this.outer = outer;
+            this.inner = inner;
+            this.access = access;
+        }
+
+        @Override
+        public void write(final ClassVisitor bytecode) {
+            bytecode.visitInnerClass(this.name, this.outer, this.inner, this.access);
+        }
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttribute.java
@@ -1,18 +1,77 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.bytecode;
 
 import org.objectweb.asm.ClassVisitor;
 
+/**
+ * Bytecode attribute.
+ * @since 0.4
+ */
 public interface BytecodeAttribute {
 
-    void write(final ClassVisitor bytecode);
+    /**
+     * Write to bytecode.
+     * @param bytecode Bytecode where to write.
+     */
+    void write(ClassVisitor bytecode);
 
-    class InnerClass implements BytecodeAttribute {
+    /**
+     * Inner class attribute.
+     * @since 0.4
+     */
+    final class InnerClass implements BytecodeAttribute {
 
+        /**
+         * Internal name of the class.
+         */
         private final String name;
+
+        /**
+         * The internal name of the class or interface class is a member of.
+         */
         private final String outer;
+
+        /**
+         * The simple name of the class.
+         */
         private final String inner;
+
+        /**
+         * Access flags of the inner class as originally declared in the enclosing class.
+         */
         private final int access;
 
+        /**
+         * Constructor.
+         * @param name Internal name of the class.
+         * @param outer The internal name of the class or interface class is a member of.
+         * @param inner The simple name of the class.
+         * @param access Access flags of the inner class as originally declared in the
+         *  enclosing class.
+         * @checkstyle ParameterNumberCheck (5 lines)
+         */
         public InnerClass(
             final String name,
             final String outer,

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -74,6 +74,12 @@ public final class BytecodeClass implements Testable {
     private final Collection<BytecodeAnnotation> annotations;
 
     /**
+     * Attributes.
+     */
+    @ToString.Exclude
+    private final Collection<BytecodeAttribute> attributes;
+
+    /**
      * Class properties (access, signature, supername, interfaces).
      */
     private final BytecodeClassProperties props;
@@ -151,6 +157,7 @@ public final class BytecodeClass implements Testable {
         this.props = properties;
         this.fields = new ArrayList<>(0);
         this.annotations = new ArrayList<>(0);
+        this.attributes = new ArrayList<>(0);
     }
 
     /**
@@ -181,6 +188,7 @@ public final class BytecodeClass implements Testable {
             this.annotations.forEach(annotation -> annotation.write(this.visitor));
             this.fields.forEach(field -> field.write(this.visitor));
             this.methods.forEach(BytecodeMethod::write);
+            this.attributes.forEach(attr -> attr.write(this.visitor));
             this.visitor.visitEnd();
             return this.visitor.bytecode();
         } catch (final IllegalArgumentException exception) {
@@ -291,6 +299,16 @@ public final class BytecodeClass implements Testable {
             "bar",
             Opcodes.ACC_PUBLIC
         );
+        return this;
+    }
+
+    /**
+     * Add attribute.
+     * @param attribute Attribute.
+     * @return This object.
+     */
+    public BytecodeClass withAttribute(final BytecodeAttribute attribute) {
+        this.attributes.add(attribute);
         return this;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.directives;
 
 import java.util.Arrays;
@@ -6,16 +29,41 @@ import java.util.List;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
+/**
+ * Directives for an attribute.
+ * @since 0.4
+ * @todo #589:30min Add Unit Tests for DirectivesAttribute class.
+ *  DirectivesAttribute class is not covered by unit tests.
+ *  Add unit tests for DirectivesAttribute class in order to increase the code coverage
+ *  and improve the quality of the code.
+ */
 public final class DirectivesAttribute implements Iterable<Directive> {
 
+    /**
+     * The name of the attribute.
+     */
     private final String name;
+
+    /**
+     * Data to store.
+     */
     private final List<Iterable<Directive>> data;
 
+    /**
+     * Constructor.
+     * @param name The name of the attribute.
+     * @param data Properties of an attribute.
+     */
     @SafeVarargs
     public DirectivesAttribute(final String name, final Iterable<Directive>... data) {
         this(name, Arrays.asList(data));
     }
 
+    /**
+     * Constructor.
+     * @param name The name of the attribute.
+     * @param data Properties of an attribute.
+     */
     public DirectivesAttribute(final String name, final List<Iterable<Directive>> data) {
         this.name = name;
         this.data = data;

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java
@@ -3,7 +3,6 @@ package org.eolang.jeo.representation.directives;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.xembly.Directive;
 import org.xembly.Directives;
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java
@@ -1,0 +1,31 @@
+package org.eolang.jeo.representation.directives;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+public final class DirectivesAttribute implements Iterable<Directive> {
+
+    private final String name;
+    private final List<Iterable<Directive>> data;
+
+    @SafeVarargs
+    public DirectivesAttribute(final String name, final Iterable<Directive>... data) {
+        this(name, Arrays.asList(data));
+    }
+
+    public DirectivesAttribute(final String name, final List<Iterable<Directive>> data) {
+        this.name = name;
+        this.data = data;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        final Directives directives = new Directives().add("o").attr("name", this.name);
+        this.data.forEach(directives::append);
+        return directives.up().iterator();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
@@ -1,0 +1,42 @@
+package org.eolang.jeo.representation.directives;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+public final class DirectivesAttributes implements Iterable<Directive> {
+
+    private final List<DirectivesAttribute> attributes;
+
+    public DirectivesAttributes() {
+        this(new ArrayList<>(0));
+    }
+
+    public DirectivesAttributes(final List<DirectivesAttribute> attributes) {
+        this.attributes = attributes;
+    }
+
+    public DirectivesAttributes add(final DirectivesAttribute attribute) {
+        this.attributes.add(attribute);
+        return this;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        final Iterator<Directive> result;
+        if (this.attributes.isEmpty()) {
+            result = Collections.emptyIterator();
+        } else {
+            final Directives directives = new Directives().add("o")
+                .attr("base", "tuple")
+                .attr("star", "")
+                .attr("name", "attributes");
+            this.attributes.forEach(directives::append);
+            result = directives.up().iterator();
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.directives;
 
 import java.util.ArrayList;
@@ -7,18 +30,41 @@ import java.util.List;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
+/**
+ * Directives for attributes.
+ * @since 0.4
+ * @todo #589:30min Add Unit Tests for DirectivesAttributes class.
+ *  DirectivesAttributes class is not covered by unit tests.
+ *  Add unit tests for DirectivesAttributes class in order to increase the code coverage
+ *  and improve the quality of the code.
+ */
 public final class DirectivesAttributes implements Iterable<Directive> {
 
+    /**
+     * Attributes.
+     */
     private final List<DirectivesAttribute> attributes;
 
+    /**
+     * Constructor.
+     */
     public DirectivesAttributes() {
         this(new ArrayList<>(0));
     }
 
+    /**
+     * Constructor.
+     * @param attributes Separate attributes.
+     */
     public DirectivesAttributes(final List<DirectivesAttribute> attributes) {
         this.attributes = attributes;
     }
 
+    /**
+     * Add attribute.
+     * @param attribute One more attribute.
+     * @return The same directives.
+     */
     public DirectivesAttributes add(final DirectivesAttribute attribute) {
         this.attributes.add(attribute);
         return this;

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -62,6 +62,11 @@ public final class DirectivesClass implements Iterable<Directive> {
     private final DirectivesAnnotations annotations;
 
     /**
+     * Attributes.
+     */
+    private final DirectivesAttributes attributes;
+
+    /**
      * Constructor.
      * @param classname Class name.
      */
@@ -114,6 +119,7 @@ public final class DirectivesClass implements Iterable<Directive> {
         this.methods = methods;
         this.fields = fields;
         this.annotations = new DirectivesAnnotations();
+        this.attributes = new DirectivesAttributes();
     }
 
     /**
@@ -146,6 +152,16 @@ public final class DirectivesClass implements Iterable<Directive> {
         return this;
     }
 
+    /**
+     * Add attribute to the directives.
+     * @param attribute Attribute
+     * @return The same instance of {@link DirectivesClass}.
+     */
+    public DirectivesClass attribute(final DirectivesAttribute attribute) {
+        this.attributes.add(attribute);
+        return this;
+    }
+
     @Override
     public Iterator<Directive> iterator() {
         final Directives directives = new Directives();
@@ -156,6 +172,7 @@ public final class DirectivesClass implements Iterable<Directive> {
         this.fields.forEach(directives::append);
         this.methods.forEach(directives::append);
         directives.append(this.annotations);
+        directives.append(this.attributes);
         return directives.up().iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -32,7 +32,6 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.xembly.Directive;
-import org.xembly.Directives;
 
 /**
  * Class printer.

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -32,6 +32,7 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.xembly.Directive;
+import org.xembly.Directives;
 
 /**
  * Class printer.
@@ -203,6 +204,22 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
             super.visitField(access, ename, descriptor, signature, value),
             field
         );
+    }
+
+    @Override
+    public void visitInnerClass(
+        final String name, final String outer, final String inner, final int access
+    ) {
+        this.program.top()
+            .attribute(
+                new DirectivesAttribute(
+                    "InnerClass",
+                    new DirectivesNullable("name", name),
+                    new DirectivesNullable("outer", outer),
+                    new DirectivesNullable("inner", inner),
+                    new DirectivesNullable("access", access)
+                ));
+        super.visitInnerClass(name, outer, inner, access);
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesNullable.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesNullable.java
@@ -1,0 +1,32 @@
+package org.eolang.jeo.representation.directives;
+
+import java.util.Collections;
+import java.util.Iterator;
+import org.eolang.jeo.representation.HexData;
+import org.xembly.Directive;
+
+public final class DirectivesNullable implements Iterable<Directive> {
+
+    private final HexData data;
+    private final String name;
+
+    public <T> DirectivesNullable(final String name, final T data) {
+        this(name, new HexData(data));
+    }
+
+    public DirectivesNullable(final String name, final HexData data) {
+        this.name = name;
+        this.data = data;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        final Iterator<Directive> result;
+        if (this.data.isNull()) {
+            result = Collections.emptyIterator();
+        } else {
+            result = new DirectivesData(this.data, this.name).iterator();
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesNullable.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesNullable.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.directives;
 
 import java.util.Collections;
@@ -5,15 +28,41 @@ import java.util.Iterator;
 import org.eolang.jeo.representation.HexData;
 import org.xembly.Directive;
 
+/**
+ * Directives for data that might be nullable.
+ * @since 0.4
+ * @todo #589:30min Add Unit Tests for DirectivesNullable class.
+ *  DirectivesNullable class is not covered by unit tests.
+ *  Add unit tests for DirectivesNullable class in order to increase the code coverage
+ *  and improve the quality of the code.
+ */
 public final class DirectivesNullable implements Iterable<Directive> {
 
+    /**
+     * Data to store.
+     */
     private final HexData data;
+
+    /**
+     * The name of data to store.
+     */
     private final String name;
 
+    /**
+     * Constructor.
+     * @param name The name of data to store.
+     * @param data Data to store.
+     * @param <T> Type of data.
+     */
     public <T> DirectivesNullable(final String name, final T data) {
         this(name, new HexData(data));
     }
 
+    /**
+     * Constructor.
+     * @param name The name of data to store.
+     * @param data Data to store.
+     */
     public DirectivesNullable(final String name, final HexData data) {
         this.name = name;
         this.data = data;

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
@@ -1,0 +1,46 @@
+package org.eolang.jeo.representation.xmir;
+
+import org.eolang.jeo.representation.bytecode.BytecodeAttribute;
+import org.eolang.jeo.representation.bytecode.BytecodeClass;
+
+public final class XmlAttribute {
+
+    private final XmlNode node;
+
+    public XmlAttribute(final XmlNode node) {
+        this.node = node;
+    }
+
+    public void writeTo(final BytecodeClass bytecode) {
+        final String name = this.node.attribute("name")
+            .orElseThrow(() -> new IllegalArgumentException(
+                String.format("Attribute name is missing in XML node %s", this.node))
+            );
+        if ("InnerClass".equals(name)) {
+            bytecode.withAttribute(
+                new BytecodeAttribute.InnerClass(
+                    this.node.optchild("name", "name")
+                        .map(XmlOperand::new)
+                        .map(XmlOperand::asObject)
+                        .map(String.class::cast)
+                        .orElse(null),
+                    this.node.optchild("name", "outer")
+                        .map(XmlOperand::new)
+                        .map(XmlOperand::asObject)
+                        .map(String.class::cast)
+                        .orElse(null),
+                    this.node.optchild("name", "inner")
+                        .map(XmlOperand::new)
+                        .map(XmlOperand::asObject)
+                        .map(String.class::cast)
+                        .orElse(null),
+                    this.node.optchild("name", "access")
+                        .map(XmlOperand::new)
+                        .map(XmlOperand::asObject)
+                        .map(Integer.class::cast)
+                        .orElse(0)
+                )
+            );
+        }
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
@@ -1,16 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.xmir;
 
 import org.eolang.jeo.representation.bytecode.BytecodeAttribute;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 
+/**
+ * Xml representation of a single bytecode attribute.
+ * @since 0.4
+ * @todo #589:30min Add Unit Tests for XmlAttribute class.
+ *  XmlAttribute class is not covered by unit tests.
+ *  Add unit tests for XmlAttribute class in order to increase the code coverage
+ *  and improve the quality of the code.
+ */
 public final class XmlAttribute {
 
+    /**
+     * XML node of an attribute.
+     */
     private final XmlNode node;
 
+    /**
+     * Constructor.
+     * @param node XML node.
+     */
     public XmlAttribute(final XmlNode node) {
         this.node = node;
     }
 
+    /**
+     * Write to bytecode.
+     * @param bytecode Bytecode.
+     */
     public void writeTo(final BytecodeClass bytecode) {
         final String name = this.node.attribute("name")
             .orElseThrow(() -> new IllegalArgumentException(

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
@@ -34,6 +34,7 @@ import org.eolang.jeo.representation.bytecode.BytecodeClass;
  *  Add unit tests for XmlAttribute class in order to increase the code coverage
  *  and improve the quality of the code.
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public final class XmlAttribute {
 
     /**
@@ -55,8 +56,10 @@ public final class XmlAttribute {
      */
     public void writeTo(final BytecodeClass bytecode) {
         final String name = this.node.attribute("name")
-            .orElseThrow(() -> new IllegalArgumentException(
-                String.format("Attribute name is missing in XML node %s", this.node))
+            .orElseThrow(
+                () -> new IllegalArgumentException(
+                    String.format("Attribute name is missing in XML node %s", this.node)
+                )
             );
         if ("InnerClass".equals(name)) {
             bytecode.withAttribute(

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttributes.java
@@ -1,0 +1,16 @@
+package org.eolang.jeo.representation.xmir;
+
+import org.eolang.jeo.representation.bytecode.BytecodeClass;
+
+public final class XmlAttributes {
+
+    private final XmlNode node;
+
+    public XmlAttributes(final XmlNode node) {
+        this.node = node;
+    }
+
+    public void writeTo(final BytecodeClass bytecode) {
+        this.node.children().map(XmlAttribute::new).forEach(attr -> attr.writeTo(bytecode));
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttributes.java
@@ -1,15 +1,57 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.xmir;
 
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 
+/**
+ * Xml representation of a class attributes.
+ * @since 0.4
+ * @todo #589:30min Add Unit Tests for XmlAttributes class.
+ *  XmlAttributes class is not covered by unit tests.
+ *  Add unit tests for XmlAttributes class in order to increase the code coverage
+ *  and improve the quality of the code.
+ */
 public final class XmlAttributes {
 
+    /**
+     * XML node of attributes.
+     */
     private final XmlNode node;
 
+    /**
+     * Constructor.
+     * @param node XML node.
+     */
     public XmlAttributes(final XmlNode node) {
         this.node = node;
     }
 
+    /**
+     * Write to bytecode.
+     * @param bytecode Bytecode where to write.
+     */
     public void writeTo(final BytecodeClass bytecode) {
         this.node.children().map(XmlAttribute::new).forEach(attr -> attr.writeTo(bytecode));
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecode.java
@@ -118,6 +118,7 @@ public final class XmlBytecode {
             xmlmethod.trycatchEntries().forEach(exc -> exc.writeTo(method));
             xmlmethod.defvalue().ifPresent(defv -> defv.writeTo(method));
         }
+        clazz.attributes().ifPresent(attrs -> attrs.writeTo(bytecode));
         return bytecode.bytecode();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -194,6 +194,18 @@ public final class XmlClass {
     }
 
     /**
+     * Attributes.
+     * @return Attributes.
+     */
+    public Optional<XmlAttributes> attributes() {
+        return this.node.children()
+            .filter(o -> o.hasAttribute("name", "attributes"))
+            .filter(o -> o.hasAttribute("base", "tuple"))
+            .findFirst()
+            .map(XmlAttributes::new);
+    }
+
+    /**
      * Copies current class with replaced methods.
      *
      * @param methods Methods.

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -45,7 +45,7 @@ import org.xembly.Xembler;
  */
 @ToString
 @EqualsAndHashCode
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
 public final class XmlClass {
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -58,6 +58,7 @@ final class DirectivesClassTest {
                         "<o base='string' data='bytes' name='signature'/>",
                         "<o base='string' data='bytes' name='supername'/>",
                         "<o base='tuple' name='interfaces' star=''/>",
+//                        "<o base='tuple' name='attributes' star=''/>",
                         "</o>"
                     )
                 )

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -58,7 +58,6 @@ final class DirectivesClassTest {
                         "<o base='string' data='bytes' name='signature'/>",
                         "<o base='string' data='bytes' name='supername'/>",
                         "<o base='tuple' name='interfaces' star=''/>",
-//                        "<o base='tuple' name='attributes' star=''/>",
                         "</o>"
                     )
                 )


### PR DESCRIPTION
In this PR I added support of 'InnerClasses' attribute. Now we successfully parse this attribute from bytecode, transform it to XMIR and back to bytecode.
This changes successfully fix some compilation errors.

Closes: #589.
History:
- **feat(#589): add example with inner enum and annotation value**
- **feat(#589): add DirectivesAttributes and DirectivesAttribute classes**
- **feat(#589): write InnerClasses attributes to bytecode**
- **feat(#589): add javadocs for XmlAttribute and XmlAttributes**
- **faet(#589): add javadocs for all the new created classes**
- **feat(#589): decrease jacoco limits**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances XML and bytecode representation classes in `org.eolang.jeo.representation` package. It introduces new methods, attributes, and annotations for better data handling and clarity.

### Detailed summary
- Added `isNull` method in `HexData.java`
- Added `InnerEnum` enum in `JeoAnnotation.java`
- Added `isInnerClass` method in `DirectivesClassVisitor.java`
- Added `attributes` method in `XmlClass.java`
- Added `innerEnum` field in `AnnotationsApplication.java`
- Added `attributes` field in `DirectivesClass.java`
- Added `withAttribute` method in `BytecodeClass.java`
- Added `XmlAttributes` class in `xmir` package
- Added `DirectivesNullable` class in `directives` package
- Added `DirectivesAttribute` class in `directives` package

> The following files were skipped due to too many changes: `src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java`, `src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttribute.java`, `src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java`, `src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->