### PR TITLE
feat(#596): Add Support of Prameters Annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@ SOFTWARE.
                         <limit>
                           <counter>INSTRUCTION</counter>
                           <value>COVEREDRATIO</value>
-                          <minimum>0.68</minimum>
+                          <minimum>0.66</minimum>
                         </limit>
                         <limit>
                           <counter>LINE</counter>
@@ -358,17 +358,17 @@ SOFTWARE.
                         <limit>
                           <counter>BRANCH</counter>
                           <value>COVEREDRATIO</value>
-                          <minimum>0.43</minimum>
+                          <minimum>0.39</minimum>
                         </limit>
                         <limit>
                           <counter>COMPLEXITY</counter>
                           <value>COVEREDRATIO</value>
-                          <minimum>0.55</minimum>
+                          <minimum>0.53</minimum>
                         </limit>
                         <limit>
                           <counter>METHOD</counter>
                           <value>COVEREDRATIO</value>
-                          <minimum>0.63</minimum>
+                          <minimum>0.62</minimum>
                         </limit>
                         <limit>
                           <counter>CLASS</counter>

--- a/src/it/annotations/src/main/java/org/eolang/jeo/annotations/AnnotationsApplication.java
+++ b/src/it/annotations/src/main/java/org/eolang/jeo/annotations/AnnotationsApplication.java
@@ -94,6 +94,23 @@ public class AnnotationsApplication {
             if (!methodAnnotation) {
                 throw new IllegalStateException("Method annotation is not present");
             }
+            String def = Arrays.stream(AnnotationsApplication.class.getDeclaredMethods())
+                .filter(method -> "annotatedMethodWithDefaultValue".equals(method.getName()))
+                .findFirst().orElseThrow().getParameters()[0]
+                .getAnnotation(ParamAnnotation.class)
+                .value();
+            if (!def.equals(
+                "We can parse annotations from method parameters")) {
+                throw new IllegalStateException("Default annotation param value is not correct");
+            }
+            String custom = Arrays.stream(AnnotationsApplication.class.getDeclaredMethods())
+                .filter(method -> "annotatedMethod".equals(method.getName()))
+                .findFirst().orElseThrow().getParameters()[0]
+                .getAnnotation(ParamAnnotation.class)
+                .value();
+            if (!custom.equals("custom")) {
+                throw new IllegalStateException("Custom annotation param value is not correct");
+            }
             System.out.println("Annotations test passed successfully!");
         } else {
             throw new IllegalStateException(
@@ -103,12 +120,12 @@ public class AnnotationsApplication {
     }
 
     @JeoMethodAnnotation(required = true)
-    public static void annotatedMethod() {
+    public static void annotatedMethod(@ParamAnnotation("custom") final String param) {
         // This method is annotated with JeoMethodAnnotation
     }
 
     @JeoMethodAnnotation
-    public static void annotatedMethodWithDefaultValue() {
+    public static void annotatedMethodWithDefaultValue(@ParamAnnotation final String param) {
         // This method is annotated with JeoMethodAnnotation
     }
 }

--- a/src/it/annotations/src/main/java/org/eolang/jeo/annotations/ParamAnnotation.java
+++ b/src/it/annotations/src/main/java/org/eolang/jeo/annotations/ParamAnnotation.java
@@ -1,0 +1,14 @@
+package org.eolang.jeo.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ParamAnnotation {
+
+    String value() default "We can parse annotations from method parameters";
+
+}

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
@@ -25,6 +25,8 @@ package org.eolang.jeo.representation.bytecode;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
@@ -39,6 +41,8 @@ import org.objectweb.asm.MethodVisitor;
  *  that are used to represent annotations in different formats. We should
  *  refactor this implementation to make it simpler and more readable.
  */
+@ToString
+@EqualsAndHashCode
 public final class BytecodeAnnotation implements BytecodeAnnotationValue {
 
     /**
@@ -99,6 +103,14 @@ public final class BytecodeAnnotation implements BytecodeAnnotationValue {
      */
     public BytecodeAnnotation write(final MethodVisitor visitor) {
         final AnnotationVisitor avisitor = visitor.visitAnnotation(this.descriptor, this.visible);
+        this.properties.forEach(property -> property.writeTo(avisitor));
+        return this;
+    }
+
+    public BytecodeAnnotation write(final int index, MethodVisitor visitor) {
+        final AnnotationVisitor avisitor = visitor.visitParameterAnnotation(
+            index, this.descriptor, this.visible
+        );
         this.properties.forEach(property -> property.writeTo(avisitor));
         return this;
     }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
@@ -107,7 +107,13 @@ public final class BytecodeAnnotation implements BytecodeAnnotationValue {
         return this;
     }
 
-    public BytecodeAnnotation write(final int index, MethodVisitor visitor) {
+    /**
+     * Write parameter annotation.
+     * @param index Index of a parameter.
+     * @param visitor Method visitor.
+     * @return This.
+     */
+    public BytecodeAnnotation write(final int index, final MethodVisitor visitor) {
         final AnnotationVisitor avisitor = visitor.visitParameterAnnotation(
             index, this.descriptor, this.visible
         );

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotationProperty.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotationProperty.java
@@ -26,12 +26,16 @@ package org.eolang.jeo.representation.bytecode;
 import com.jcabi.log.Logger;
 import java.util.List;
 import java.util.Optional;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.objectweb.asm.AnnotationVisitor;
 
 /**
  * Bytecode annotation property.
  * @since 0.3
  */
+@ToString
+@EqualsAndHashCode
 public final class BytecodeAnnotationProperty implements BytecodeAnnotationValue {
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import lombok.ToString;
 import org.eolang.jeo.PluginStartup;
 import org.eolang.jeo.representation.BytecodeRepresentation;
+import org.eolang.jeo.representation.xmir.XmlAnnotation;
 import org.eolang.jeo.representation.xmir.XmlAnnotations;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Opcodes;
@@ -348,7 +349,7 @@ public final class BytecodeClass implements Testable {
     public BytecodeClass withAnnotations(final XmlAnnotations all) {
         all.all()
             .stream()
-            .map(ann -> new BytecodeAnnotation(ann.descriptor(), ann.visible(), ann.props()))
+            .map(XmlAnnotation::toBytecode)
             .forEach(this.annotations::add);
         return this;
     }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
@@ -59,6 +59,8 @@ public final class BytecodeMethodProperties implements Testable {
      */
     private final String signature;
 
+    private final BytecodeParameters parameters;
+
     /**
      * Method exceptions.
      */
@@ -112,11 +114,23 @@ public final class BytecodeMethodProperties implements Testable {
         final String signature,
         final String... exceptions
     ) {
+        this(access, name, descriptor, signature, new BytecodeParameters(), exceptions);
+    }
+
+    public BytecodeMethodProperties(
+        final int access,
+        final String name,
+        final String descriptor,
+        final String signature,
+        final BytecodeParameters parameters,
+        final String[] exceptions
+    ) {
         this.access = access;
         this.name = name;
         this.descriptor = descriptor;
         this.signature = signature;
-        this.exceptions = exceptions.clone();
+        this.parameters = parameters;
+        this.exceptions = exceptions;
     }
 
     @Override
@@ -143,7 +157,7 @@ public final class BytecodeMethodProperties implements Testable {
             this,
             String.format("Creating method visitor with the following properties %s", this)
         );
-        return writer.visitMethod(
+        final MethodVisitor visitor = writer.visitMethod(
             this.access,
             new JavaName(this.name).decode(),
             this.descriptor,
@@ -151,5 +165,7 @@ public final class BytecodeMethodProperties implements Testable {
             this.exceptions,
             compute
         );
+        this.parameters.write(visitor);
+        return visitor;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
@@ -59,6 +59,9 @@ public final class BytecodeMethodProperties implements Testable {
      */
     private final String signature;
 
+    /**
+     * Method parameters.
+     */
     private final BytecodeParameters parameters;
 
     /**
@@ -117,20 +120,30 @@ public final class BytecodeMethodProperties implements Testable {
         this(access, name, descriptor, signature, new BytecodeParameters(), exceptions);
     }
 
+    /**
+     * Constructor.
+     * @param access Access modifiers.
+     * @param name Method name.
+     * @param descriptor Method descriptor.
+     * @param signature Method signature.
+     * @param parameters Method parameters.
+     * @param exceptions Method exceptions.
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
     public BytecodeMethodProperties(
         final int access,
         final String name,
         final String descriptor,
         final String signature,
         final BytecodeParameters parameters,
-        final String[] exceptions
+        final String... exceptions
     ) {
         this.access = access;
         this.name = name;
         this.descriptor = descriptor;
         this.signature = signature;
         this.parameters = parameters;
-        this.exceptions = exceptions;
+        this.exceptions = exceptions.clone();
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeParameters.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeParameters.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.bytecode;
 
 import java.util.HashMap;
@@ -7,20 +30,38 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.objectweb.asm.MethodVisitor;
 
+/**
+ * Bytecode parameters.
+ * @since 0.4
+ */
 @ToString
 @EqualsAndHashCode
 public final class BytecodeParameters {
 
+    /**
+     * Annotations with a parameter position (as a key).
+     */
     private final Map<Integer, List<BytecodeAnnotation>> annotations;
 
+    /**
+     * Default constructor.
+     */
     public BytecodeParameters() {
         this(new HashMap<>(0));
     }
 
+    /**
+     * Constructor.
+     * @param annotations Annotations.
+     */
     public BytecodeParameters(final Map<Integer, List<BytecodeAnnotation>> annotations) {
         this.annotations = annotations;
     }
 
+    /**
+     * Add annotation.
+     * @param visitor Method visitor.
+     */
     public void write(final MethodVisitor visitor) {
         this.annotations.forEach(
             (key, value) -> value.forEach(annotation -> annotation.write(key, visitor))

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeParameters.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeParameters.java
@@ -1,0 +1,29 @@
+package org.eolang.jeo.representation.bytecode;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.objectweb.asm.MethodVisitor;
+
+@ToString
+@EqualsAndHashCode
+public final class BytecodeParameters {
+
+    private final Map<Integer, List<BytecodeAnnotation>> annotations;
+
+    public BytecodeParameters() {
+        this(new HashMap<>(0));
+    }
+
+    public BytecodeParameters(final Map<Integer, List<BytecodeAnnotation>> annotations) {
+        this.annotations = annotations;
+    }
+
+    public void write(final MethodVisitor visitor) {
+        this.annotations.forEach(
+            (key, value) -> value.forEach(annotation -> annotation.write(key, visitor))
+        );
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -212,4 +212,16 @@ public final class DirectivesMethod implements Iterable<Directive> {
     void defvalue(final DirectivesDefaultValue value) {
         this.dvalue.set(value);
     }
+
+    /**
+     * Set parameter annotation.
+     * @param parameter Parameter index
+     * @param descriptor Annotation descriptor
+     * @param visible True if annotation is visible at runtime
+     */
+    void paramAnnotation(
+        final int parameter, final String descriptor, final boolean visible
+    ) {
+        this.properties.paramAnnotation(parameter, descriptor, visible);
+    }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -216,12 +216,9 @@ public final class DirectivesMethod implements Iterable<Directive> {
     /**
      * Set parameter annotation.
      * @param parameter Parameter index
-     * @param descriptor Annotation descriptor
-     * @param visible True if annotation is visible at runtime
+     * @param annotation Annotation
      */
-    void paramAnnotation(
-        final int parameter, final String descriptor, final boolean visible
-    ) {
-        this.properties.paramAnnotation(parameter, descriptor, visible);
+    void paramAnnotation(final int parameter, final DirectivesAnnotation annotation) {
+        this.properties.paramAnnotation(parameter, annotation);
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
@@ -23,8 +23,11 @@
  */
 package org.eolang.jeo.representation.directives;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import org.objectweb.asm.Type;
 import org.xembly.Directive;
@@ -41,7 +44,7 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
      */
     private final String descriptor;
 
-    private final Map<Integer, DirectivesAnnotation> annotations;
+    private final Map<Integer, List<DirectivesAnnotation>> annotations;
 
     /**
      * Constructor.
@@ -59,7 +62,16 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
      * @param visible Is the annotation visible at runtime?
      */
     public void annotation(final int index, final String annotation, final boolean visible) {
-        this.annotations.put(index, new DirectivesAnnotation(annotation, visible));
+        this.annotations.compute(index, (key, value) -> {
+                final DirectivesAnnotation ann = new DirectivesAnnotation(annotation, visible);
+                if (value == null) {
+                    value = new ArrayList<>(Collections.singletonList(ann));
+                } else {
+                    value.add(ann);
+                }
+                return value;
+            }
+        );
     }
 
     @Override
@@ -71,7 +83,7 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
                 .attr("abstract", "")
                 .attr("name", String.format("arg__%s__%d", arguments[index], index));
             if (this.annotations.containsKey(index)) {
-                param.append(this.annotations.get(index));
+                this.annotations.get(index).forEach(param::append);
             }
             param.up();
         }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
@@ -58,16 +58,14 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
     /**
      * Add a parameter annotation
      * @param index Index of the parameter
-     * @param annotation Annotation descriptor
-     * @param visible Is the annotation visible at runtime?
+     * @param annotation Annotation.
      */
-    public void annotation(final int index, final String annotation, final boolean visible) {
+    public void annotation(final int index, final  DirectivesAnnotation annotation) {
         this.annotations.compute(index, (key, value) -> {
-                final DirectivesAnnotation ann = new DirectivesAnnotation(annotation, visible);
                 if (value == null) {
-                    value = new ArrayList<>(Collections.singletonList(ann));
+                    value = new ArrayList<>(Collections.singletonList(annotation));
                 } else {
-                    value.add(ann);
+                    value.add(annotation);
                 }
                 return value;
             }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
@@ -23,7 +23,9 @@
  */
 package org.eolang.jeo.representation.directives;
 
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import org.objectweb.asm.Type;
 import org.xembly.Directive;
 import org.xembly.Directives;
@@ -39,12 +41,25 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
      */
     private final String descriptor;
 
+    private final Map<Integer, DirectivesAnnotation> annotations;
+
     /**
      * Constructor.
      * @param descriptor Method descriptor.
      */
     public DirectivesMethodParams(final String descriptor) {
         this.descriptor = descriptor;
+        this.annotations = new HashMap<>(0);
+    }
+
+    /**
+     * Add a parameter annotation
+     * @param index Index of the parameter
+     * @param annotation Annotation descriptor
+     * @param visible Is the annotation visible at runtime?
+     */
+    public void annotation(final int index, final String annotation, final boolean visible) {
+        this.annotations.put(index, new DirectivesAnnotation(annotation, visible));
     }
 
     @Override
@@ -52,10 +67,13 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
         final Directives directives = new Directives();
         final Type[] arguments = Type.getArgumentTypes(this.descriptor);
         for (int index = 0; index < arguments.length; ++index) {
-            directives.add("o")
+            final Directives param = directives.add("o")
                 .attr("abstract", "")
-                .attr("name", String.format("arg__%s__%d", arguments[index], index))
-                .up();
+                .attr("name", String.format("arg__%s__%d", arguments[index], index));
+            if (this.annotations.containsKey(index)) {
+                param.append(this.annotations.get(index));
+            }
+            param.up();
         }
         return directives.iterator();
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.objectweb.asm.Type;
 import org.xembly.Directive;
 import org.xembly.Directives;
@@ -44,6 +45,9 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
      */
     private final String descriptor;
 
+    /**
+     * Parameter annotations.
+     */
     private final Map<Integer, List<DirectivesAnnotation>> annotations;
 
     /**
@@ -56,18 +60,22 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
     }
 
     /**
-     * Add a parameter annotation
-     * @param index Index of the parameter
+     * Add a parameter annotation.
+     * @param index Index of the parameter.
      * @param annotation Annotation.
      */
-    public void annotation(final int index, final  DirectivesAnnotation annotation) {
-        this.annotations.compute(index, (key, value) -> {
-                if (value == null) {
-                    value = new ArrayList<>(Collections.singletonList(annotation));
+    public void annotation(final int index, final DirectivesAnnotation annotation) {
+        this.annotations.compute(
+            index,
+            (key, initial) -> {
+                final List<DirectivesAnnotation> res;
+                if (Objects.isNull(initial)) {
+                    res = new ArrayList<>(Collections.singletonList(annotation));
                 } else {
-                    value.add(annotation);
+                    initial.add(annotation);
+                    res = initial;
                 }
-                return value;
+                return res;
             }
         );
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
@@ -102,11 +102,10 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
     /**
      * Set parameter annotation.
      * @param index Parameter index.
-     * @param annotation Annotation descriptor.
-     * @param visible True if annotation is visible at runtime.
+     * @param annotation Annotation.
      */
-    public void paramAnnotation(final int index, final String annotation, final boolean visible) {
-        this.params.annotation(index, annotation, visible);
+    public void paramAnnotation(final int index, final DirectivesAnnotation annotation) {
+        this.params.annotation(index, annotation);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
@@ -66,6 +66,11 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
     private final AtomicReference<DirectivesMaxs> max;
 
     /**
+     * Method parameters.
+     */
+    private final DirectivesMethodParams params;
+
+    /**
      * Constructor.
      */
     public DirectivesMethodProperties() {
@@ -91,6 +96,17 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
         this.signature = Optional.ofNullable(signature).orElse("");
         this.exceptions = Optional.ofNullable(exceptions).orElse(new String[0]).clone();
         this.max = new AtomicReference<>(new DirectivesMaxs());
+        this.params = new DirectivesMethodParams(this.descriptor);
+    }
+
+    /**
+     * Set parameter annotation.
+     * @param index Parameter index.
+     * @param annotation Annotation descriptor.
+     * @param visible True if annotation is visible at runtime.
+     */
+    public void paramAnnotation(final int index, final String annotation, final boolean visible) {
+        this.params.annotation(index, annotation, visible);
     }
 
     /**
@@ -110,7 +126,7 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
             .append(new DirectivesData("signature", this.signature))
             .append(new DirectivesTuple("exceptions", this.exceptions))
             .append(this.max.get())
-            .append(new DirectivesMethodParams(this.descriptor))
+            .append(this.params)
             .iterator();
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitor.java
@@ -211,7 +211,7 @@ public final class DirectivesMethodVisitor extends MethodVisitor implements Iter
     public AnnotationVisitor visitParameterAnnotation(
         final int parameter, final String descriptor, final boolean visible
     ) {
-        DirectivesAnnotation annotation = new DirectivesAnnotation(descriptor, visible);
+        final DirectivesAnnotation annotation = new DirectivesAnnotation(descriptor, visible);
         this.method.paramAnnotation(parameter, annotation);
         return new DirectivesAnnotationVisitor(
             this.api, super.visitParameterAnnotation(parameter, descriptor, visible), annotation

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitor.java
@@ -211,8 +211,11 @@ public final class DirectivesMethodVisitor extends MethodVisitor implements Iter
     public AnnotationVisitor visitParameterAnnotation(
         final int parameter, final String descriptor, final boolean visible
     ) {
-        this.method.paramAnnotation(parameter, descriptor, visible);
-        return super.visitParameterAnnotation(parameter, descriptor, visible);
+        DirectivesAnnotation annotation = new DirectivesAnnotation(descriptor, visible);
+        this.method.paramAnnotation(parameter, annotation);
+        return new DirectivesAnnotationVisitor(
+            this.api, super.visitParameterAnnotation(parameter, descriptor, visible), annotation
+        );
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitor.java
@@ -208,6 +208,14 @@ public final class DirectivesMethodVisitor extends MethodVisitor implements Iter
     }
 
     @Override
+    public AnnotationVisitor visitParameterAnnotation(
+        final int parameter, final String descriptor, final boolean visible
+    ) {
+        this.method.paramAnnotation(parameter, descriptor, visible);
+        return super.visitParameterAnnotation(parameter, descriptor, visible);
+    }
+
+    @Override
     public AnnotationVisitor visitAnnotation(final String descriptor, final boolean visible) {
         final DirectivesAnnotation annotation = new DirectivesAnnotation(descriptor, visible);
         this.method.annotation(annotation);

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
@@ -76,6 +76,10 @@ public class XmlAnnotation {
             .collect(Collectors.toList());
     }
 
+    /**
+     * Convert to bytecode.
+     * @return Bytecode annotation.
+     */
     public BytecodeAnnotation toBytecode() {
         return new BytecodeAnnotation(
             this.descriptor(),

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.xmir;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotationProperty;
 
 /**
@@ -73,5 +74,13 @@ public class XmlAnnotation {
             .map(XmlAnnotationProperty::new)
             .map(XmlAnnotationProperty::toBytecode)
             .collect(Collectors.toList());
+    }
+
+    public BytecodeAnnotation toBytecode() {
+        return new BytecodeAnnotation(
+            this.descriptor(),
+            this.visible(),
+            this.props()
+        );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
@@ -34,6 +35,7 @@ import lombok.ToString;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotationProperty;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodProperties;
+import org.eolang.jeo.representation.bytecode.BytecodeParameters;
 import org.eolang.jeo.representation.directives.DirectivesMethod;
 import org.eolang.jeo.representation.directives.DirectivesMethodProperties;
 import org.objectweb.asm.Opcodes;
@@ -190,6 +192,7 @@ public final class XmlMethod {
             this.name(),
             this.descriptor(),
             this.signature(),
+            this.params(),
             this.exceptions()
         );
     }
@@ -377,6 +380,16 @@ public final class XmlMethod {
             .map(HexString::new)
             .map(HexString::decode)
             .toArray(String[]::new);
+    }
+
+    private BytecodeParameters params() {
+        final AtomicInteger index = new AtomicInteger(0);
+        return new BytecodeParameters(
+            this.node.children()
+                .filter(element -> element.hasAttribute("abstract", ""))
+                .map(element -> new XmlParam(index.getAndIncrement(), element))
+                .collect(Collectors.toMap(XmlParam::index, XmlParam::annotations))
+        );
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java
@@ -1,0 +1,28 @@
+package org.eolang.jeo.representation.xmir;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
+
+public final class XmlParam {
+
+    private final int position;
+    private final XmlNode root;
+
+    public XmlParam(final int position, final XmlNode root) {
+        this.position = position;
+        this.root = root;
+    }
+
+    public int index() {
+        return this.position;
+    }
+
+    public List<BytecodeAnnotation> annotations() {
+        return this.root.children().filter(node -> node.hasAttribute("base", "annotation"))
+            .map(XmlAnnotation::new)
+            .map(XmlAnnotation::toBytecode)
+            .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java
@@ -1,23 +1,74 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package org.eolang.jeo.representation.xmir;
 
 import java.util.List;
 import java.util.stream.Collectors;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
 
+/**
+ * Xmir representation of a method parameter.
+ * @since 0.4
+ * @todo #596:30min Add unit tests for the XmlParam class.
+ *  We should add unit tests for the XmlParam class. The tests should cover
+ *  the following methods: {@link #index()} and {@link #annotations()}.
+ *  This will help us to ensure that the class is working as expected.
+ */
 public final class XmlParam {
 
+    /**
+     * Index of the parameter in the method.
+     */
     private final int position;
+
+    /**
+     * Root node from which we will get all required data.
+     */
     private final XmlNode root;
 
+    /**
+     * Constructor.
+     * @param position Index of the parameter in the method.
+     * @param root Root node.
+     */
     public XmlParam(final int position, final XmlNode root) {
         this.position = position;
         this.root = root;
     }
 
+    /**
+     * Index of the parameter in the method.
+     * @return Index.
+     */
     public int index() {
         return this.position;
     }
 
+    /**
+     * Annotations of the parameter.
+     * @return Annotations.
+     */
     public List<BytecodeAnnotation> annotations() {
         return this.root.children().filter(node -> node.hasAttribute("base", "annotation"))
             .map(XmlAnnotation::new)


### PR DESCRIPTION
In this PR I added support of method parameters annotations. It should fix some parts of the 'spring-fat' integration test in `opeo-maven-plugin`.

Risk 1: In the last PRs we added too much code that wasn't covered by tests. We definetly should cover all the new code by tests. Otherwise we will have hardly-supported unmaintainable code in the repository. I have created several issues dedicated to this problem.

Risk 2: High code complexity and number of classes. Since we need to implement many features, we don't care much about acrhitecture. But we should. It's become hard to add new features. To be precise - all new features require lots of boilerplate code. I belive we have to simplify the solution somehow.

Closes: #596.
History:
- **feat(#596): add integration test that reveal the problem with method parameters annotations**
- **feat(#596): add param annotations to XMIR**
- **feat(#596): write param annotations to bytecode**
- **feat(#596): repair 'annotations' integration test**
- **feat(#596): fix all qulice suggestions**
- **feat(#596): decrease jacoco limits**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance annotation handling in Java code. 

### Detailed summary
- Added `BytecodeAnnotationProperty` to handle bytecode annotations
- Introduced `ParamAnnotation` for method parameter annotations
- Implemented methods for setting and retrieving parameter annotations

> The following files were skipped due to too many changes: `src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java`, `src/main/java/org/eolang/jeo/representation/bytecode/BytecodeParameters.java`, `src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->