### PR TITLE
feat(#602): Use 'base' Instead of 'name'

### DIFF
--- a/src/it/annotations/pom.xml
+++ b/src/it/annotations/pom.xml
@@ -61,24 +61,24 @@ SOFTWARE.
         </executions>
       </plugin>
       <plugin>
-              <groupId>org.eolang</groupId>
-              <artifactId>eo-maven-plugin</artifactId>
-              <version>0.38.1</version>
-              <executions>
-                <execution>
-                  <id>convert-xmir-to-eo</id>
-                  <phase>process-classes</phase>
-                  <goals>
-                    <goal>xmir-to-phi</goal>
-                  </goals>
-                  <configuration>
-                    <phiOptimize>false</phiOptimize>
-                    <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
-                    <phiOutputDir>${project.build.directory}/generated-sources/jeo-eo</phiOutputDir>
-                  </configuration>
-                </execution>
-              </executions>
-            </plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>eo-maven-plugin</artifactId>
+        <version>0.38.1</version>
+        <executions>
+          <execution>
+            <id>convert-xmir-to-eo</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>xmir-to-phi</goal>
+            </goals>
+            <configuration>
+              <phiOptimize>false</phiOptimize>
+              <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
+              <phiOutputDir>${project.build.directory}/generated-sources/jeo-eo</phiOutputDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/src/it/annotations/pom.xml
+++ b/src/it/annotations/pom.xml
@@ -60,25 +60,25 @@ SOFTWARE.
           </execution>
         </executions>
       </plugin>
-      <plugin>
-              <groupId>org.eolang</groupId>
-              <artifactId>eo-maven-plugin</artifactId>
-              <version>0.38.1</version>
-              <executions>
-                <execution>
-                  <id>convert-xmir-to-eo</id>
-                  <phase>process-classes</phase>
-                  <goals>
-                    <goal>xmir-to-phi</goal>
-                  </goals>
-                  <configuration>
-                    <phiOptimize>false</phiOptimize>
-                    <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
-                    <phiOutputDir>${project.build.directory}/generated-sources/jeo-eo</phiOutputDir>
-                  </configuration>
-                </execution>
-              </executions>
-            </plugin>
+<!--      <plugin>-->
+<!--              <groupId>org.eolang</groupId>-->
+<!--              <artifactId>eo-maven-plugin</artifactId>-->
+<!--              <version>0.38.1</version>-->
+<!--              <executions>-->
+<!--                <execution>-->
+<!--                  <id>convert-xmir-to-eo</id>-->
+<!--                  <phase>process-classes</phase>-->
+<!--                  <goals>-->
+<!--                    <goal>xmir-to-phi</goal>-->
+<!--                  </goals>-->
+<!--                  <configuration>-->
+<!--                    <phiOptimize>false</phiOptimize>-->
+<!--                    <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>-->
+<!--                    <phiOutputDir>${project.build.directory}/generated-sources/jeo-eo</phiOutputDir>-->
+<!--                  </configuration>-->
+<!--                </execution>-->
+<!--              </executions>-->
+<!--            </plugin>-->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/src/it/annotations/pom.xml
+++ b/src/it/annotations/pom.xml
@@ -61,6 +61,25 @@ SOFTWARE.
         </executions>
       </plugin>
       <plugin>
+              <groupId>org.eolang</groupId>
+              <artifactId>eo-maven-plugin</artifactId>
+              <version>0.38.1</version>
+              <executions>
+                <execution>
+                  <id>convert-xmir-to-eo</id>
+                  <phase>process-classes</phase>
+                  <goals>
+                    <goal>xmir-to-phi</goal>
+                  </goals>
+                  <configuration>
+                    <phiOptimize>false</phiOptimize>
+                    <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
+                    <phiOutputDir>${project.build.directory}/generated-sources/jeo-eo</phiOutputDir>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.3.0</version>

--- a/src/it/annotations/pom.xml
+++ b/src/it/annotations/pom.xml
@@ -60,25 +60,25 @@ SOFTWARE.
           </execution>
         </executions>
       </plugin>
-<!--      <plugin>-->
-<!--              <groupId>org.eolang</groupId>-->
-<!--              <artifactId>eo-maven-plugin</artifactId>-->
-<!--              <version>0.38.1</version>-->
-<!--              <executions>-->
-<!--                <execution>-->
-<!--                  <id>convert-xmir-to-eo</id>-->
-<!--                  <phase>process-classes</phase>-->
-<!--                  <goals>-->
-<!--                    <goal>xmir-to-phi</goal>-->
-<!--                  </goals>-->
-<!--                  <configuration>-->
-<!--                    <phiOptimize>false</phiOptimize>-->
-<!--                    <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>-->
-<!--                    <phiOutputDir>${project.build.directory}/generated-sources/jeo-eo</phiOutputDir>-->
-<!--                  </configuration>-->
-<!--                </execution>-->
-<!--              </executions>-->
-<!--            </plugin>-->
+      <plugin>
+              <groupId>org.eolang</groupId>
+              <artifactId>eo-maven-plugin</artifactId>
+              <version>0.38.1</version>
+              <executions>
+                <execution>
+                  <id>convert-xmir-to-eo</id>
+                  <phase>process-classes</phase>
+                  <goals>
+                    <goal>xmir-to-phi</goal>
+                  </goals>
+                  <configuration>
+                    <phiOptimize>false</phiOptimize>
+                    <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
+                    <phiOutputDir>${project.build.directory}/generated-sources/jeo-eo</phiOutputDir>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java
@@ -40,9 +40,9 @@ import org.xembly.Directives;
 public final class DirectivesAttribute implements Iterable<Directive> {
 
     /**
-     * The name of the attribute.
+     * The base of the attribute.
      */
-    private final String name;
+    private final String base;
 
     /**
      * Data to store.
@@ -51,27 +51,29 @@ public final class DirectivesAttribute implements Iterable<Directive> {
 
     /**
      * Constructor.
-     * @param name The name of the attribute.
+     * @param base The name of the attribute.
      * @param data Properties of an attribute.
      */
     @SafeVarargs
-    public DirectivesAttribute(final String name, final Iterable<Directive>... data) {
-        this(name, Arrays.asList(data));
+    public DirectivesAttribute(final String base, final Iterable<Directive>... data) {
+        this(base, Arrays.asList(data));
     }
 
     /**
      * Constructor.
-     * @param name The name of the attribute.
+     * @param base The base of the attribute.
      * @param data Properties of an attribute.
      */
-    public DirectivesAttribute(final String name, final List<Iterable<Directive>> data) {
-        this.name = name;
+    public DirectivesAttribute(final String base, final List<Iterable<Directive>> data) {
+        this.base = base;
         this.data = data;
     }
 
     @Override
     public Iterator<Directive> iterator() {
-        final Directives directives = new Directives().add("o").attr("name", this.name);
+        final Directives directives = new Directives()
+            .add("o")
+            .attr("base", this.base);
         this.data.forEach(directives::append);
         return directives.up().iterator();
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesDefaultValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesDefaultValue.java
@@ -67,11 +67,12 @@ public final class DirectivesDefaultValue implements Iterable<Directive>, Compos
     public Iterator<Directive> iterator() {
         final Iterator<Directive> result;
         if (this.value.get() != null) {
-            final String label = "annotation-default-value";
+            final String caption = "annotation-default-value";
             final Directives directives = new Directives()
                 .add("o")
-                .attr("base", label)
-                .attr("name", label);
+                .attr("base", caption)
+                .attr("name", caption)
+                .attr("line", "999");
             directives.append(this.value.get());
             result = directives.up().iterator();
         } else {

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMaxs.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMaxs.java
@@ -64,7 +64,8 @@ public final class DirectivesMaxs implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        return new Directives().add("o").attr("name", "maxs")
+        return new Directives().add("o")
+            .attr("base", "maxs")
             .append(new DirectivesData("stack", this.stack))
             .append(new DirectivesData("locals", this.locals))
             .up()

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
@@ -55,13 +55,13 @@ public final class XmlAttribute {
      * @param bytecode Bytecode.
      */
     public void writeTo(final BytecodeClass bytecode) {
-        final String name = this.node.attribute("name")
+        final String base = this.node.attribute("base")
             .orElseThrow(
                 () -> new IllegalArgumentException(
-                    String.format("Attribute name is missing in XML node %s", this.node)
+                    String.format("Attribute base is missing in XML node %s", this.node)
                 )
             );
-        if ("InnerClass".equals(name)) {
+        if ("InnerClass".equals(base)) {
             bytecode.withAttribute(
                 new BytecodeAttribute.InnerClass(
                     this.node.optchild("name", "name")

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -203,7 +203,7 @@ public final class XmlMethod {
      * @return Maxs.
      */
     public Optional<XmlMaxs> maxs() {
-        return this.node.optchild("name", "maxs").map(XmlMaxs::new);
+        return this.node.optchild("base", "maxs").map(XmlMaxs::new);
     }
 
     /**
@@ -279,7 +279,7 @@ public final class XmlMethod {
                 new XmlNode(
                     new Xembler(
                         new Directives()
-                            .xpath("./o[@name='maxs']")
+                            .xpath("./o[@base='maxs']")
                             .remove()
                     ).apply(this.node.node())
                 )


### PR DESCRIPTION
In this PR I changed attributes for 'maxs' and 'InnerClasses' They used 'name' attribute in EO representation and didn't have 'abstract' attribute.
So I just used 'base' attribute instead of 'name'. Now this classes can be treatened as a normal EO objects.
Closes: #602.
History:
- **feat(#602): add phi printing for annotations integration test**
- **feat(#602): make maxs as base**
- **feat(#602): use base for InnerClass**
- **feat(#602): enable PHI printing for 'annotations' integration test**
- **feat(#602): fix all quality issues**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update attribute names from "name" to "base" for consistency across various classes.

### Detailed summary
- Updated attribute names from "name" to "base" in multiple classes for consistency.
- Updated XML node attribute checks and manipulations.
- Updated Maven plugin configuration.
- Renamed variables and constructors for clarity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->