### PR TITLE
feat(#605): Prove That PHI Printing Workds Well For Inner Classes

### DIFF
--- a/src/it/takes/README.md
+++ b/src/it/takes/README.md
@@ -1,0 +1,10 @@
+# Takes Integration Test
+
+Integration test that checks correct transformation simple Java application
+written with using Takes Framework. This application starts HTTP server,
+ sends a single HTTP request and prints response to the console.
+If you need to run only this test, use the following command:
+
+```shell
+mvn clean integration-test invoker:run -Dinvoker.test=takes -DskipTests
+```

--- a/src/it/takes/pom.xml
+++ b/src/it/takes/pom.xml
@@ -77,6 +77,25 @@ SOFTWARE.
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>eo-maven-plugin</artifactId>
+        <version>0.38.1</version>
+        <executions>
+          <execution>
+            <id>convert-xmir-to-eo</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>xmir-to-phi</goal>
+            </goals>
+            <configuration>
+              <phiOptimize>false</phiOptimize>
+              <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
+              <phiOutputDir>${project.build.directory}/generated-sources/jeo-eo</phiOutputDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.3.0</version>


### PR DESCRIPTION
In this PR I prove that printing PHI expressions for Inner classes works as expected and without errors.
The original problem with Inner classes was solved in a separate PR:
https://github.com/objectionary/jeo-maven-plugin/pull/612

Closes: #605.


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add an integration test for a Java application using Takes Framework and to include a plugin for converting Xmir to Eo language.

### Detailed summary
- Added integration test for Takes Framework
- Included `eo-maven-plugin` for converting Xmir to Eo language
- Configuration set to process Xmir files during `process-classes` phase

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->