### PR TITLE
chore(#648): Update Libraries Version 

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Upload coverage reports to Codecov
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'

--- a/.github/workflows/up.yaml
+++ b/.github/workflows/up.yaml
@@ -13,7 +13,7 @@ jobs:
   up:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - run: |-
           git fetch --tags --force && \
           latest=$(git tag --sort=creatordate | tail -1) && \

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
-      <version>0.38.4</version>
+      <version>0.39.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.volodya-lombrozo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@ SOFTWARE.
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.22.1</version>
+            <version>0.23.0</version>
             <configuration>
               <license>file:${basedir}/LICENSE.txt</license>
               <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -153,10 +153,16 @@ SOFTWARE.
       <artifactId>slf4j-api</artifactId>
       <version>2.0.13</version>
     </dependency>
+    <!--
+      Warning!
+      We use the 1.3.14 version of logback intentionally.
+      Recent versions of the dependency are incompatible with Java 8.
+      So, don't change this version without a necessity.
+    -->
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.5.6</version>
+      <version>1.3.14</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ SOFTWARE.
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.67.0</version>
+    <version>0.68.0</version>
   </parent>
   <groupId>org.eolang</groupId>
   <artifactId>jeo-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@ SOFTWARE.
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.3.14</version>
+      <version>1.5.6</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,13 @@ SOFTWARE.
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.23.0</version>
+            <!--
+              @todo #648:30min Upgrade qulice-maven-plugin version.
+               Currently we can't do it because qulice fails on ubuntu 20.04 and Java 8.
+               We should find the original reason why this happens and upgrade the version.
+               Up to 0.23.0, or latest.
+            -->
+            <version>0.22.1</version>
             <configuration>
               <license>file:${basedir}/LICENSE.txt</license>
               <excludes>

--- a/src/it/bytecode-to-eo/pom.xml
+++ b/src/it/bytecode-to-eo/pom.xml
@@ -78,7 +78,7 @@ SOFTWARE.
       <!--      <plugin>-->
       <!--        <groupId>org.eolang</groupId>-->
       <!--        <artifactId>eo-maven-plugin</artifactId>-->
-      <!--        <version>0.38.1</version>-->
+      <!--        <version>0.39.0</version>-->
       <!--        <executions>-->
       <!--          <execution>-->
       <!--            <id>convert-xmir-to-eo</id>-->

--- a/src/it/custom-transformations/pom.xml
+++ b/src/it/custom-transformations/pom.xml
@@ -63,7 +63,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.38.1</version>
+        <version>0.39.0</version>
         <executions>
           <!--
             @todo #610:30min Enable EO Printing in 'custom-transformations' it.


### PR DESCRIPTION
In this PR I upgrade all the possible libraries version.

Closes: #648
History:
- **chore(#648): update eo dependency 0.39.0**
- **chore(#648): update jcabi.parent version 0.68.0**
- **chore(#648): update logback dependency 1.5.6**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates versions of various dependencies, including `eo-maven-plugin`, `parent`, `logback-classic`, `eo-parser`, and `qulice-maven-plugin`. It also includes instructions to enable EO Printing and upgrade the `qulice-maven-plugin` version in the future.

### Detailed summary
- Updated `eo-maven-plugin` version to `0.39.0`
- Updated `parent` version to `0.68.0`
- Updated `logback-classic` version to `1.3.14`
- Updated `eo-parser` version to `0.39.0`
- Added instructions to enable EO Printing in `custom-transformations`
- Added instructions to upgrade `qulice-maven-plugin` to version `0.22.1` or latest

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->