### PR TITLE
feat(#650): qulice upgraded to 0.23, quliceJava8, check profiles

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -20,7 +20,7 @@ jobs:
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-
-      - run: mvn clean install -Pqulice --errors --batch-mode
+      - run: mvn clean install -Pcheck -Dqulice --errors --batch-mode
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -20,7 +20,7 @@ jobs:
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-
-      - run: mvn clean install -Pcheck -Dqulice --errors --batch-mode
+      - run: mvn clean install -Pqulice --errors --batch-mode
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/maven.test.yaml
+++ b/.github/workflows/maven.test.yaml
@@ -32,7 +32,7 @@ jobs:
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
-      - run: mvn clean install -P"check,long" --errors --batch-mode
+      - run: mvn clean install -P"check,long" -Dqulice --errors --batch-mode
       - name: Archive failure logs
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/maven.test.yaml
+++ b/.github/workflows/maven.test.yaml
@@ -18,7 +18,7 @@ jobs:
         #  https://github.com/objectionary/eo/issues/3307
         #  After the problem is resolved, we can enable Windows OS.
         os: [ ubuntu-20.04, macos-12 ]
-        java: [ 8, 11, 20 ]
+        java: [ 8, 11, 21 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/maven.test.yaml
+++ b/.github/workflows/maven.test.yaml
@@ -32,7 +32,7 @@ jobs:
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
-      - run: mvn clean install -P"check,long" -Dqulice --errors --batch-mode
+      - run: mvn clean install -P"qulice,long" --errors --batch-mode
       - name: Archive failure logs
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/maven.test.yaml
+++ b/.github/workflows/maven.test.yaml
@@ -32,7 +32,7 @@ jobs:
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
-      - run: mvn clean install -P"long" --errors --batch-mode
+      - run: mvn clean install -P"check,long" --errors --batch-mode
       - name: Archive failure logs
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/maven.test.yaml
+++ b/.github/workflows/maven.test.yaml
@@ -32,7 +32,7 @@ jobs:
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
-      - run: mvn clean install -P"qulice,long" --errors --batch-mode
+      - run: mvn clean install -P"long" --errors --batch-mode
       - name: Archive failure logs
         uses: actions/upload-artifact@v4
         if: failure()

--- a/pom.xml
+++ b/pom.xml
@@ -369,6 +369,9 @@ SOFTWARE.
       <id>quliceJava8</id>
       <activation>
         <jdk>1.8</jdk>
+        <property>
+          <name>qulice</name>
+        </property>
       </activation>
       <build>
         <plugins>
@@ -405,6 +408,9 @@ SOFTWARE.
       <id>qulice</id>
       <activation>
         <jdk>[11,)</jdk>
+        <property>
+          <name>qulice</name>
+        </property>
       </activation>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -270,82 +270,9 @@ SOFTWARE.
   </build>
   <profiles>
     <profile>
-      <id>quliceJava8</id>
-      <activation>
-        <jdk>1.8</jdk>
-      </activation>
+      <id>check</id>
       <build>
         <plugins>
-          <plugin>
-            <groupId>com.qulice</groupId>
-            <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.22.1</version>
-            <configuration>
-              <license>file:${basedir}/LICENSE.txt</license>
-              <excludes>
-                <exclude>checkstyle:.*/BytecodeInstructionEntry.java</exclude>
-                <exclude>pmd:/src/test/resources/.*</exclude>
-                <exclude>pmd:/src/it/.*</exclude>
-                <exclude>checkstyle:/src/site/.*</exclude>
-                <exclude>checkstyle:/src/test/resources/.*</exclude>
-                <exclude>checkstyle:/src/main/resources/.*</exclude>
-                <exclude>checkstyle:/src/it/.*</exclude>
-                <exclude>duplicatefinder:.*</exclude>
-                <exclude>dependencies:.*</exclude>
-              </excludes>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>qulice</id>
-      <activation>
-        <jdk>[11,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.qulice</groupId>
-            <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.23.0</version>
-            <configuration>
-              <license>file:${basedir}/LICENSE.txt</license>
-              <excludes>
-                <exclude>checkstyle:.*/BytecodeInstructionEntry.java</exclude>
-                <exclude>pmd:/src/test/resources/.*</exclude>
-                <exclude>pmd:/src/it/.*</exclude>
-                <exclude>checkstyle:/src/site/.*</exclude>
-                <exclude>checkstyle:/src/test/resources/.*</exclude>
-                <exclude>checkstyle:/src/main/resources/.*</exclude>
-                <exclude>checkstyle:/src/it/.*</exclude>
-                <exclude>duplicatefinder:.*</exclude>
-                <!--
-                  @todo #30:30min Enable dependency check.
-                    The qulice library has an issue related to dependency check.
-                    You can find more details here:
-                    - https://github.com/yegor256/qulice/issues/1145
-                    When this issue is fixed, we should enable dependency check.
-                    Don't forget to remove the exclude below and this puzzle.
-                -->
-                <exclude>dependencies:.*</exclude>
-              </excludes>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
@@ -431,6 +358,86 @@ SOFTWARE.
                 <phase>prepare-package</phase>
                 <goals>
                   <goal>report</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>quliceJava8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.qulice</groupId>
+            <artifactId>qulice-maven-plugin</artifactId>
+            <version>0.22.1</version>
+            <configuration>
+              <license>file:${basedir}/LICENSE.txt</license>
+              <excludes>
+                <exclude>checkstyle:.*/BytecodeInstructionEntry.java</exclude>
+                <exclude>pmd:/src/test/resources/.*</exclude>
+                <exclude>pmd:/src/it/.*</exclude>
+                <exclude>checkstyle:/src/site/.*</exclude>
+                <exclude>checkstyle:/src/test/resources/.*</exclude>
+                <exclude>checkstyle:/src/main/resources/.*</exclude>
+                <exclude>checkstyle:/src/it/.*</exclude>
+                <exclude>duplicatefinder:.*</exclude>
+                <exclude>dependencies:.*</exclude>
+              </excludes>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>qulice</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.qulice</groupId>
+            <artifactId>qulice-maven-plugin</artifactId>
+            <version>0.23.0</version>
+            <configuration>
+              <license>file:${basedir}/LICENSE.txt</license>
+              <excludes>
+                <exclude>checkstyle:.*/BytecodeInstructionEntry.java</exclude>
+                <exclude>pmd:/src/test/resources/.*</exclude>
+                <exclude>pmd:/src/it/.*</exclude>
+                <exclude>checkstyle:/src/site/.*</exclude>
+                <exclude>checkstyle:/src/test/resources/.*</exclude>
+                <exclude>checkstyle:/src/main/resources/.*</exclude>
+                <exclude>checkstyle:/src/it/.*</exclude>
+                <exclude>duplicatefinder:.*</exclude>
+                <!--
+                  @todo #30:30min Enable dependency check.
+                    The qulice library has an issue related to dependency check.
+                    You can find more details here:
+                    - https://github.com/yegor256/qulice/issues/1145
+                    When this issue is fixed, we should enable dependency check.
+                    Don't forget to remove the exclude below and this puzzle.
+                -->
+                <exclude>dependencies:.*</exclude>
+              </excludes>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>check</goal>
                 </goals>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -270,9 +270,35 @@ SOFTWARE.
   </build>
   <profiles>
     <profile>
-      <id>check</id>
+      <id>qulice</id>
       <build>
         <plugins>
+          <plugin>
+            <groupId>com.qulice</groupId>
+            <artifactId>qulice-maven-plugin</artifactId>
+            <version>${qulice.version}</version>
+            <configuration>
+              <license>file:${basedir}/LICENSE.txt</license>
+              <excludes>
+                <exclude>checkstyle:.*/BytecodeInstructionEntry.java</exclude>
+                <exclude>pmd:/src/test/resources/.*</exclude>
+                <exclude>pmd:/src/it/.*</exclude>
+                <exclude>checkstyle:/src/site/.*</exclude>
+                <exclude>checkstyle:/src/test/resources/.*</exclude>
+                <exclude>checkstyle:/src/main/resources/.*</exclude>
+                <exclude>checkstyle:/src/it/.*</exclude>
+                <exclude>duplicatefinder:.*</exclude>
+                <exclude>dependencies:.*</exclude>
+              </excludes>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
@@ -366,90 +392,22 @@ SOFTWARE.
       </build>
     </profile>
     <profile>
+      <id>quliceJava11</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <properties>
+        <qulice.version>0.23.0</qulice.version>
+      </properties>
+    </profile>
+    <profile>
       <id>quliceJava8</id>
       <activation>
         <jdk>1.8</jdk>
-        <property>
-          <name>qulice</name>
-        </property>
       </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.qulice</groupId>
-            <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.22.1</version>
-            <configuration>
-              <license>file:${basedir}/LICENSE.txt</license>
-              <excludes>
-                <exclude>checkstyle:.*/BytecodeInstructionEntry.java</exclude>
-                <exclude>pmd:/src/test/resources/.*</exclude>
-                <exclude>pmd:/src/it/.*</exclude>
-                <exclude>checkstyle:/src/site/.*</exclude>
-                <exclude>checkstyle:/src/test/resources/.*</exclude>
-                <exclude>checkstyle:/src/main/resources/.*</exclude>
-                <exclude>checkstyle:/src/it/.*</exclude>
-                <exclude>duplicatefinder:.*</exclude>
-                <exclude>dependencies:.*</exclude>
-              </excludes>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>qulice</id>
-      <activation>
-        <jdk>[11,)</jdk>
-        <property>
-          <name>qulice</name>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.qulice</groupId>
-            <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.23.0</version>
-            <configuration>
-              <license>file:${basedir}/LICENSE.txt</license>
-              <excludes>
-                <exclude>checkstyle:.*/BytecodeInstructionEntry.java</exclude>
-                <exclude>pmd:/src/test/resources/.*</exclude>
-                <exclude>pmd:/src/it/.*</exclude>
-                <exclude>checkstyle:/src/site/.*</exclude>
-                <exclude>checkstyle:/src/test/resources/.*</exclude>
-                <exclude>checkstyle:/src/main/resources/.*</exclude>
-                <exclude>checkstyle:/src/it/.*</exclude>
-                <exclude>duplicatefinder:.*</exclude>
-                <!--
-                  @todo #30:30min Enable dependency check.
-                    The qulice library has an issue related to dependency check.
-                    You can find more details here:
-                    - https://github.com/yegor256/qulice/issues/1145
-                    When this issue is fixed, we should enable dependency check.
-                    Don't forget to remove the exclude below and this puzzle.
-                -->
-                <exclude>dependencies:.*</exclude>
-              </excludes>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
+      <properties>
+        <qulice.version>0.22.1</qulice.version>
+      </properties>
     </profile>
     <profile>
       <id>long</id>

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@ SOFTWARE.
   </build>
   <profiles>
     <profile>
-      <id>java8</id>
+      <id>quliceJava8</id>
       <activation>
         <jdk>1.8</jdk>
       </activation>
@@ -307,6 +307,9 @@ SOFTWARE.
     </profile>
     <profile>
       <id>qulice</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -312,12 +312,6 @@ SOFTWARE.
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <!--
-              @todo #648:30min Upgrade qulice-maven-plugin version.
-               Currently we can't do it because qulice fails on ubuntu 20.04 and Java 8.
-               We should find the original reason why this happens and upgrade the version.
-               Up to 0.23.0, or latest.
-            -->
             <version>0.23.0</version>
             <configuration>
               <license>file:${basedir}/LICENSE.txt</license>

--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,14 @@ SOFTWARE.
                 <exclude>checkstyle:/src/main/resources/.*</exclude>
                 <exclude>checkstyle:/src/it/.*</exclude>
                 <exclude>duplicatefinder:.*</exclude>
+                <!--
+                  @todo #30:30min Enable dependency check.
+                    The qulice library has an issue related to dependency check.
+                    You can find more details here:
+                    - https://github.com/yegor256/qulice/issues/1145
+                    When this issue is fixed, we should enable dependency check.
+                    Don't forget to remove the exclude below and this puzzle.
+                -->
                 <exclude>dependencies:.*</exclude>
               </excludes>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,42 @@ SOFTWARE.
   </build>
   <profiles>
     <profile>
+      <id>java8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.qulice</groupId>
+            <artifactId>qulice-maven-plugin</artifactId>
+            <version>0.22.1</version>
+            <configuration>
+              <license>file:${basedir}/LICENSE.txt</license>
+              <excludes>
+                <exclude>checkstyle:.*/BytecodeInstructionEntry.java</exclude>
+                <exclude>pmd:/src/test/resources/.*</exclude>
+                <exclude>pmd:/src/it/.*</exclude>
+                <exclude>checkstyle:/src/site/.*</exclude>
+                <exclude>checkstyle:/src/test/resources/.*</exclude>
+                <exclude>checkstyle:/src/main/resources/.*</exclude>
+                <exclude>checkstyle:/src/it/.*</exclude>
+                <exclude>duplicatefinder:.*</exclude>
+                <exclude>dependencies:.*</exclude>
+              </excludes>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>qulice</id>
       <build>
         <plugins>
@@ -282,7 +318,7 @@ SOFTWARE.
                We should find the original reason why this happens and upgrade the version.
                Up to 0.23.0, or latest.
             -->
-            <version>0.22.1</version>
+            <version>0.23.0</version>
             <configuration>
               <license>file:${basedir}/LICENSE.txt</license>
               <excludes>


### PR DESCRIPTION
In this pull I've upgraded `qulice` to 0.23 version. The following profiles were added: `qulice` (triggers qulice 0.23 on Java 11+), `qulice8` (triggers qulice 0.22.1 on Java 8), and `check` that activates `jtcop` and `jacoco`. Now, in order to run full build we can run this:

```bash
mvn clean install -Pcheck
```

Qulice will be automatically enabled on either Java 8 (0.22.1) or Java 11+ (0.23).

Also, Java 20 was upgraded to Java 21 (LTS)

@volodya-lombrozo take a look, please
closes #650

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates Java version to 21, adds profiles for Java 8 and 11 in `pom.xml`, and switches to using a property for `qulice-maven-plugin` version.

### Detailed summary
- Updated Java version to 21 in `.github/workflows/maven.test.yaml`
- Added profiles for Java 8 and 11 with corresponding `qulice-maven-plugin` versions in `pom.xml`
- Switched to using a property for `qulice-maven-plugin` version in `pom.xml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->