### PR TITLE
feat(#656): Fix Method Params Decompilation Format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,6 @@ SOFTWARE.
           <pomExcludes>
             <exclude>spring-fat/pom.xml</exclude>
           </pomExcludes>
-          <streamLogs>true</streamLogs>
         </configuration>
       </plugin>
       <plugin>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -115,24 +115,24 @@ SOFTWARE.
          You can check the progress of the issue by the link:
          https://github.com/objectionary/eo/issues/3257
       -->
-      <!--            <plugin>-->
-      <!--              <groupId>org.eolang</groupId>-->
-      <!--              <artifactId>eo-maven-plugin</artifactId>-->
-      <!--              <version>0.39.0</version>-->
-      <!--              <executions>-->
-      <!--                <execution>-->
-      <!--                  <id>convert-xmir-to-phi</id>-->
-      <!--                  <phase>process-classes</phase>-->
-      <!--                  <goals>-->
-      <!--                    <goal>xmir-to-phi</goal>-->
-      <!--                  </goals>-->
-      <!--                  <configuration>-->
-      <!--                    <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>-->
-      <!--                    <phiOutputDir>${project.build.directory}/generated-sources/jeo-phi</phiOutputDir>-->
-      <!--                  </configuration>-->
-      <!--                </execution>-->
-      <!--              </executions>-->
-      <!--            </plugin>-->
+                  <plugin>
+                    <groupId>org.eolang</groupId>
+                    <artifactId>eo-maven-plugin</artifactId>
+                    <version>0.39.0</version>
+                    <executions>
+                      <execution>
+                        <id>convert-xmir-to-phi</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                          <goal>xmir-to-phi</goal>
+                        </goals>
+                        <configuration>
+                          <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
+                          <phiOutputDir>${project.build.directory}/generated-sources/jeo-phi</phiOutputDir>
+                        </configuration>
+                      </execution>
+                    </executions>
+                  </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -115,24 +115,24 @@ SOFTWARE.
          You can check the progress of the issue by the link:
          https://github.com/objectionary/eo/issues/3257
       -->
-                  <plugin>
-                    <groupId>org.eolang</groupId>
-                    <artifactId>eo-maven-plugin</artifactId>
-                    <version>0.39.0</version>
-                    <executions>
-                      <execution>
-                        <id>convert-xmir-to-phi</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                          <goal>xmir-to-phi</goal>
-                        </goals>
-                        <configuration>
-                          <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
-                          <phiOutputDir>${project.build.directory}/generated-sources/jeo-phi</phiOutputDir>
-                        </configuration>
-                      </execution>
-                    </executions>
-                  </plugin>
+      <!--            <plugin>-->
+      <!--              <groupId>org.eolang</groupId>-->
+      <!--              <artifactId>eo-maven-plugin</artifactId>-->
+      <!--              <version>0.39.0</version>-->
+      <!--              <executions>-->
+      <!--                <execution>-->
+      <!--                  <id>convert-xmir-to-phi</id>-->
+      <!--                  <phase>process-classes</phase>-->
+      <!--                  <goals>-->
+      <!--                    <goal>xmir-to-phi</goal>-->
+      <!--                  </goals>-->
+      <!--                  <configuration>-->
+      <!--                    <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>-->
+      <!--                    <phiOutputDir>${project.build.directory}/generated-sources/jeo-phi</phiOutputDir>-->
+      <!--                  </configuration>-->
+      <!--                </execution>-->
+      <!--              </executions>-->
+      <!--            </plugin>-->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -39,14 +39,8 @@ import org.xembly.Directive;
  * You can read more about Xembly right here:
  * - https://github.com/yegor256/xembly
  * - https://www.xembly.org
- * Firther all this directives will be used to build XML representation of the class.
+ * Further, all these directives will be used to build XML representation of the class.
  * @since 0.1
- * @todo #107:30min Change method argument naming strategy.
- *  Right now we use method argument type and index to generate method argument name.
- *  For example for method with signature `void foo(int a, String b)` we generate
- *  method argument names `arg__I__0` and `arg__Ljava/lang/String__1`. This is not a good way
- *  to do it. At least it leads to errors when argument type is an array or class.
- *  So we have to test this cases and maybe create a better strategy for arguments naming.
  */
 @SuppressWarnings({"PMD.UseObjectForClearerAPI", "PMD.AvoidDuplicateLiterals"})
 public final class DirectivesClassVisitor extends ClassVisitor implements Iterable<Directive> {

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
@@ -86,7 +86,7 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
         final Type[] arguments = Type.getArgumentTypes(this.descriptor);
         for (int index = 0; index < arguments.length; ++index) {
             final Directives param = directives.add("o")
-                .attr("abstract", "")
+                .attr("base", "param")
                 .attr("name", String.format("arg__%s__%d", arguments[index], index));
             if (this.annotations.containsKey(index)) {
                 this.annotations.get(index).forEach(param::append);

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
@@ -87,7 +87,7 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
         for (int index = 0; index < arguments.length; ++index) {
             final Directives param = directives.add("o")
                 .attr("base", "param")
-                .attr("name", String.format("arg__%s__%d", arguments[index], index));
+                .attr("name", String.valueOf(arguments[index]));
             if (this.annotations.containsKey(index)) {
                 this.annotations.get(index).forEach(param::append);
             }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -390,7 +390,7 @@ public final class XmlMethod {
         return new BytecodeParameters(
             this.node.children()
                 .filter(
-                    element -> element.hasAttribute("abstract", "")
+                    element -> element.hasAttribute("base", "param")
                         && !element.hasAttribute("name", "maxs")
                 )
                 .map(element -> new XmlParam(index.getAndIncrement(), element))

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
@@ -139,8 +139,8 @@ final class DirectivesMethodVisitorTest {
             xml,
             new HasMethod(method)
                 .inside(clazz)
-                .withParameter("arg__I__0")
-                .withParameter("arg__I__1")
+                .withParameter("I")
+                .withParameter("I")
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
@@ -203,7 +203,7 @@ final class HasMethod extends TypeSafeMatcher<String> {
     private Stream<String> parameters() {
         final String root = this.root();
         return this.params.stream()
-            .map(param -> String.format("%s/o[@name='%s']/@name", root, param));
+            .map(param -> String.format("%s/o[@name='%s' and @base='param']/@name", root, param));
     }
 
     /**


### PR DESCRIPTION
In this PR I modified method params disassembled format. This format allows PHI printing without errors.


Closes: #656.
History:
- **feat(#656): add base for params**
- **feat(#656): disable 'spring-fat' PHI printing again - slow invocation**
- **feat(#656): don't stream logs from integration tests**
- **feat(#656): fix unit tests**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates method parameter naming, improves XML representation, and refactors directive comments.

### Detailed summary
- Updated method parameter naming strategy in tests and classes
- Enhanced XML representation by adding base attribute to elements
- Improved directive comments for clarity and consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->