### PR TITLE
feat(#658): Fix Ambiguity in Method Pram Names

### DIFF
--- a/src/it/custom-transformations/src/main/java/org/eolang/jeo/Bar.java
+++ b/src/it/custom-transformations/src/main/java/org/eolang/jeo/Bar.java
@@ -12,4 +12,12 @@ public class Bar {
         short s = 256;
         System.out.println(s);
     }
+
+    public int sum(int a, int b) {
+        return a + b;
+    }
+
+    public int sub(int a, int b) {
+        return a - b;
+    }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
@@ -87,7 +87,9 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
         for (int index = 0; index < arguments.length; ++index) {
             final Directives param = directives.add("o")
                 .attr("base", "param")
-                .attr("name", String.valueOf(arguments[index]));
+                .attr("name", String.format("%s-%d", arguments[index], index))
+//                .attr("name", String.format("%s", arguments[index]))
+                ;
             if (this.annotations.containsKey(index)) {
                 this.annotations.get(index).forEach(param::append);
             }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
@@ -87,9 +87,7 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
         for (int index = 0; index < arguments.length; ++index) {
             final Directives param = directives.add("o")
                 .attr("base", "param")
-                .attr("name", String.format("%s-%d", arguments[index], index))
-//                .attr("name", String.format("%s", arguments[index]))
-                ;
+                .attr("name", String.format("%s-%d", arguments[index], index));
             if (this.annotations.containsKey(index)) {
                 this.annotations.get(index).forEach(param::append);
             }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
@@ -139,8 +139,8 @@ final class DirectivesMethodVisitorTest {
             xml,
             new HasMethod(method)
                 .inside(clazz)
-                .withParameter("I")
-                .withParameter("I")
+                .withParameter("I-0")
+                .withParameter("I-1")
         );
     }
 


### PR DESCRIPTION
Fix the problem with duplicated names of method parameters. This changes allow PHI printing.

Closes: #658.
History:
- **feat(#658): identify and fix the problem with duplicated param names**
- **feat(#658): fix all qulice offences**
- **feat(#658): fix all unit tests**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update method parameters in `DirectivesMethodVisitorTest`, add `sum` and `sub` methods in `Bar.java`, and modify parameter names in `DirectivesMethodParams`.

### Detailed summary
- Updated method parameters in `DirectivesMethodVisitorTest`
- Added `sum` and `sub` methods in `Bar.java`
- Modified parameter names in `DirectivesMethodParams`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->