### PR TITLE
feat(#661): Fix Method Param Names

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
@@ -84,7 +84,10 @@ public final class DirectivesAnnotation implements Iterable<Directive>, Composit
     public Iterator<Directive> iterator() {
         final Directives directives = new Directives().add("o")
             .attr("base", "annotation")
-            .attr("name", new MethodName("annotation", this.descriptor).encoded())
+            .attr("name", new MethodName(
+                String.format("annotation-%d", new Random().nextInt(Integer.MAX_VALUE)),
+                this.descriptor
+            ).encoded())
             .attr("line", new Random().nextInt(Integer.MAX_VALUE))
             .append(new DirectivesData(this.descriptor))
             .append(new DirectivesData(this.visible));

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
@@ -84,7 +84,7 @@ public final class DirectivesAnnotation implements Iterable<Directive>, Composit
     public Iterator<Directive> iterator() {
         final Directives directives = new Directives().add("o")
             .attr("base", "annotation")
-            .attr("name", new MethodName("annotation", this.descriptor))
+            .attr("name", new MethodName("annotation", this.descriptor).encoded())
             .attr("line", new Random().nextInt(Integer.MAX_VALUE))
             .append(new DirectivesData(this.descriptor))
             .append(new DirectivesData(this.visible));

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
@@ -84,10 +84,13 @@ public final class DirectivesAnnotation implements Iterable<Directive>, Composit
     public Iterator<Directive> iterator() {
         final Directives directives = new Directives().add("o")
             .attr("base", "annotation")
-            .attr("name", new MethodName(
-                String.format("annotation-%d", new Random().nextInt(Integer.MAX_VALUE)),
-                this.descriptor
-            ).encoded())
+            .attr(
+                "name",
+                new MethodName(
+                    String.format("annotation-%d", new Random().nextInt(Integer.MAX_VALUE)),
+                    this.descriptor
+                ).encoded()
+            )
             .attr("line", new Random().nextInt(Integer.MAX_VALUE))
             .append(new DirectivesData(this.descriptor))
             .append(new DirectivesData(this.visible));

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
@@ -87,7 +87,7 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
         for (int index = 0; index < arguments.length; ++index) {
             final Directives param = directives.add("o")
                 .attr("base", "param")
-                .attr("name", String.format("%s-%d", arguments[index], index));
+                .attr("name", String.format("param-%s-%d", arguments[index], index));
             if (this.annotations.containsKey(index)) {
                 this.annotations.get(index).forEach(param::append);
             }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
@@ -47,7 +47,6 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
      */
     private static final Base64.Encoder ENCODER = Base64.getEncoder();
 
-
     /**
      * Method descriptor.
      */

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
@@ -23,7 +23,9 @@
  */
 package org.eolang.jeo.representation.directives;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -39,6 +41,12 @@ import org.xembly.Directives;
  * @since 0.1
  */
 public final class DirectivesMethodParams implements Iterable<Directive> {
+
+    /**
+     * Base64 decoder.
+     */
+    private static final Base64.Encoder ENCODER = Base64.getEncoder();
+
 
     /**
      * Method descriptor.
@@ -87,7 +95,16 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
         for (int index = 0; index < arguments.length; ++index) {
             final Directives param = directives.add("o")
                 .attr("base", "param")
-                .attr("name", String.format("param-%s-%d", arguments[index], index));
+                .attr(
+                    "name",
+                    String.format(
+                        "param-%s-%d",
+                        DirectivesMethodParams.ENCODER.encodeToString(
+                            arguments[index].toString().getBytes(StandardCharsets.UTF_8)
+                        ),
+                        index
+                    )
+                );
             if (this.annotations.containsKey(index)) {
                 this.annotations.get(index).forEach(param::append);
             }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
@@ -139,8 +139,8 @@ final class DirectivesMethodVisitorTest {
             xml,
             new HasMethod(method)
                 .inside(clazz)
-                .withParameter("param-I-0")
-                .withParameter("param-I-1")
+                .withParameter("param-SQ==-0")
+                .withParameter("param-SQ==-1")
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
@@ -139,8 +139,8 @@ final class DirectivesMethodVisitorTest {
             xml,
             new HasMethod(method)
                 .inside(clazz)
-                .withParameter("I-0")
-                .withParameter("I-1")
+                .withParameter("param-I-0")
+                .withParameter("param-I-1")
         );
     }
 


### PR DESCRIPTION
In this PR I added prefix for method params in EO representation and encoded their types using base64 encoding.
This changes allow to run `normalizer` without errors. 

Closes: #661.
History:
- **feat(#661): fix small bag with annotation names**
- **feat(#661): add 'param' suffix for param name**
- **feat(#661): fix unit tests**
- **feat(#661): fix annotation names**
- **feat(#661): encode param types using base64**
- **feat(#661): fix all qulice offences**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance method parameter handling and annotation naming in Java code.

### Detailed summary
- Updated method parameter names to use Base64 encoding
- Improved annotation naming with random numbers
- Added Base64 encoder for method parameter encoding

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->