### PR TITLE
feat(#678): Use Lowercase For Opcode Names

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -206,7 +206,7 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
         this.program.top()
             .attribute(
                 new DirectivesAttribute(
-                    "InnerClass",
+                    "inner-class",
                     new DirectivesNullable("", name),
                     new DirectivesNullable("", outer),
                     new DirectivesNullable("", inner),

--- a/src/main/java/org/eolang/jeo/representation/directives/OpcodeName.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/OpcodeName.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.directives;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.objectweb.asm.Opcodes;
@@ -46,6 +47,11 @@ public final class OpcodeName {
      * Default counter.
      */
     private static final AtomicInteger DEFAULT = new AtomicInteger(0);
+
+    /**
+     * Unknown opcode name.
+     */
+    private static final String UNKNOWN = "unknown";
 
     /**
      * Bytecode operation code.
@@ -80,7 +86,7 @@ public final class OpcodeName {
      * @return Simplified opcode name.
      */
     public String simplified() {
-        return OpcodeName.NAMES.getOrDefault(this.opcode, "UNKNOWN");
+        return OpcodeName.NAMES.getOrDefault(this.opcode, OpcodeName.UNKNOWN);
     }
 
     /**
@@ -88,7 +94,7 @@ public final class OpcodeName {
      * @return String representation of a bytecode.
      */
     public String asString() {
-        final String opc = OpcodeName.NAMES.getOrDefault(this.opcode, "UNKNOWN");
+        final String opc = OpcodeName.NAMES.getOrDefault(this.opcode, OpcodeName.UNKNOWN);
         return String.format("%s-%X", opc, this.counter.incrementAndGet());
     }
 
@@ -101,7 +107,7 @@ public final class OpcodeName {
             final Map<Integer, String> res = new HashMap<>();
             for (final Field field : Opcodes.class.getFields()) {
                 if (field.getType() == int.class) {
-                    res.put(field.getInt(Opcodes.class), field.getName());
+                    res.put(field.getInt(Opcodes.class), field.getName().toLowerCase(Locale.ROOT));
                 }
             }
             return res;

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
@@ -63,7 +63,7 @@ public final class XmlAttribute {
                     String.format("Attribute base is missing in XML node %s", this.node)
                 )
             );
-        if ("InnerClass".equals(base)) {
+        if ("inner-class".equals(base)) {
             bytecode.withAttribute(
                 new BytecodeAttribute.InnerClass(
                     Optional.ofNullable(this.node.children().collect(Collectors.toList()).get(0))

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -120,10 +120,10 @@ final class BytecodeClassTest {
             ),
             xmir.toString(),
             XhtmlMatchers.hasXPaths(
-                "//o[@base='opcode' and @name='GETSTATIC']",
-                "//o[@base='opcode' and @name='LDC']",
-                "//o[@base='opcode' and @name='INVOKEVIRTUAL']",
-                "//o[@base='opcode' and @name='RETURN']"
+                "//o[@base='opcode' and @name='getstatic']",
+                "//o[@base='opcode' and @name='ldc']",
+                "//o[@base='opcode' and @name='invokevirtual']",
+                "//o[@base='opcode' and @name='return']"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
@@ -378,7 +378,7 @@ final class DirectivesMethodVisitorTest {
             "MultiArray instruction wasn't visited successfully.",
             new Xembler(method).xml(),
             Matchers.allOf(
-                Matchers.containsString("MULTIANEWARRAY"),
+                Matchers.containsString("multianewarray"),
                 Matchers.containsString("2")
             )
         );
@@ -409,7 +409,7 @@ final class DirectivesMethodVisitorTest {
             "LookupSwitch instruction wasn't visited successfully.",
             new Xembler(method).xml(),
             Matchers.allOf(
-                Matchers.containsString("LOOKUPSWITCH"),
+                Matchers.containsString("lookupswitch"),
                 Matchers.containsString("1"),
                 Matchers.containsString("2"),
                 Matchers.containsString("3"),
@@ -428,7 +428,7 @@ final class DirectivesMethodVisitorTest {
             "TableSwitch instruction wasn't visited successfully.",
             new Xembler(method).xml(),
             Matchers.allOf(
-                Matchers.containsString("TABLESWITCH"),
+                Matchers.containsString("tableswitch"),
                 Matchers.containsString("1"),
                 Matchers.containsString("3"),
                 Matchers.containsString("label")

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodVisitorTest.java
@@ -392,7 +392,7 @@ final class DirectivesMethodVisitorTest {
             "Iinc instruction wasn't visited successfully.",
             new Xembler(method).xml(),
             Matchers.allOf(
-                Matchers.containsString("IINC"),
+                Matchers.containsString("iinc"),
                 Matchers.containsString("1"),
                 Matchers.containsString("2")
             )

--- a/src/test/java/org/eolang/jeo/representation/directives/OpcodeNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/OpcodeNameTest.java
@@ -62,17 +62,17 @@ final class OpcodeNameTest {
     @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static Stream<Arguments> opcodes() {
         return Stream.of(
-            Arguments.of(Opcodes.INVOKESPECIAL, "INVOKESPECIAL-1"),
-            Arguments.of(Opcodes.INVOKEVIRTUAL, "INVOKEVIRTUAL-2"),
-            Arguments.of(Opcodes.INVOKESTATIC, "INVOKESTATIC-3"),
-            Arguments.of(Opcodes.INVOKEINTERFACE, "INVOKEINTERFACE-4"),
-            Arguments.of(Opcodes.INVOKEDYNAMIC, "INVOKEDYNAMIC-5"),
-            Arguments.of(Opcodes.DUP, "DUP-6"),
-            Arguments.of(Opcodes.LDC, "LDC-7"),
-            Arguments.of(Opcodes.ALOAD, "ALOAD-8"),
-            Arguments.of(Opcodes.ASTORE, "ASTORE-9"),
-            Arguments.of(Opcodes.ILOAD, "ILOAD-A"),
-            Arguments.of(Opcodes.ISTORE, "ISTORE-B")
+            Arguments.of(Opcodes.INVOKESPECIAL, "invokespecial-1"),
+            Arguments.of(Opcodes.INVOKEVIRTUAL, "invokevirtual-2"),
+            Arguments.of(Opcodes.INVOKESTATIC, "invokestatic-3"),
+            Arguments.of(Opcodes.INVOKEINTERFACE, "invokeinterface-4"),
+            Arguments.of(Opcodes.INVOKEDYNAMIC, "invokedynamic-5"),
+            Arguments.of(Opcodes.DUP, "dup-6"),
+            Arguments.of(Opcodes.LDC, "ldc-7"),
+            Arguments.of(Opcodes.ALOAD, "aload-8"),
+            Arguments.of(Opcodes.ASTORE, "astore-9"),
+            Arguments.of(Opcodes.ILOAD, "iload-A"),
+            Arguments.of(Opcodes.ISTORE, "istore-B")
         );
     }
 }


### PR DESCRIPTION
In this PR I renamed all opcode names from Uppercase to Lowercase.
In other words now opcode names look like the following:
```
"LDC" -> "ldc",
"LOAD" -> "load", 
"ADD" -> "add",
"SUB" -> "sub"
```

Closes: #678.
History:
- **feat(#678): use lowercase in opcode names**
- **feat(#678): fix all the unit tests**


<!-- start pr-codex -->

---

## PR-Codex overview
The PR focuses on standardizing and updating opcode names, attribute names, and method names to follow a consistent naming convention.

### Detailed summary
- Standardized attribute names to lowercase
- Updated opcode names to lowercase
- Renamed methods to lowercase
- Added a new constant for unknown opcode name

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->