### PR TITLE
feat(#672): Can't Find Proves of Flaky Test

### DIFF
--- a/.github/workflows/maven.test.yaml
+++ b/.github/workflows/maven.test.yaml
@@ -34,4 +34,4 @@ jobs:
         with:
           name: build-log-files
           path: |
-            target/**/build.log
+            target/

--- a/integration_tests.sh
+++ b/integration_tests.sh
@@ -1,0 +1,9 @@
+# This script is used to run the integration tests for the project until they fail.
+# This is us useful to find flaky bugs in the project.
+while [ true  ]; do
+    echo "Running integration tests"
+    mvn clean install -DskipTests
+    if [[ "$?" -ne 0 ]]; then
+      break
+    fi
+done

--- a/integration_tests.sh
+++ b/integration_tests.sh
@@ -2,6 +2,7 @@
 # This is us useful to find flaky bugs in the project.
 while [ true  ]; do
     echo "Running integration tests"
+    java --version
     mvn clean install -DskipTests
     if [[ "$?" -ne 0 ]]; then
       break

--- a/pom.xml
+++ b/pom.xml
@@ -364,7 +364,7 @@ SOFTWARE.
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
-            <version>1.2.4</version>
+            <version>1.3.1</version>
             <executions>
               <execution>
                 <phase>verify</phase>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -66,7 +66,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.7.1</version>
+        <version>3.8.0</version>
         <executions>
           <execution>
             <id>unpack-dependencies</id>

--- a/src/it/spring/verify.groovy
+++ b/src/it/spring/verify.groovy
@@ -28,5 +28,8 @@ assert log.contains("Glad to see you, Spring...")
 //Check that we have generated EO object files.
 assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/spring/Application.xmir').exists()
 assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/spring/Receptionist.xmir').exists()
-assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/spring/App.xmir').exists()
+def app = new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/spring/App.xmir')
+assert app.exists()
+assert app.text.contains("metas")
+assert app.text.contains("<head>package</head>")
 true


### PR DESCRIPTION
In this PR I added one more shell script that runs integration tests until failure.
I run this tests around 20 times (~200 integration tests) and all of them were successful.
Also I updated the dependencies that we didn't update because of this flaky test.
Now if fail happens we save the entire archive of `target` directory.

Some other clues I have found:
1. The problem usually happens on ubuntu-20.04 system
2. Also might happen on windows - https://github.com/objectionary/jeo-maven-plugin/actions/runs/10435189705/job/28898897097
3. The problem happened on `Java 21` only.
4. Usually it is either `takes` or `generics` integration test.
5. Problem happens on `Assemble` phase during bytecode verification.

Related to: #672.

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update versions and improve integration testing for the project.

### Detailed summary
- Updated `jtcop-maven-plugin` version to `1.3.1`
- Updated `maven-dependency-plugin` version to `3.8.0`
- Added a script for running integration tests continuously
- Improved verification in `verify.groovy` for `App.xmir` file

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->