### PR TITLE
feat(#647): Add Imports Only When It Is Needed

### DIFF
--- a/src/it/spring/src/main/java/org/eolang/jeo/spring/WithoutInstructions.java
+++ b/src/it/spring/src/main/java/org/eolang/jeo/spring/WithoutInstructions.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.spring;
+
+/**
+ * App.
+ * @since 0.1
+ */
+public interface WithoutInstructions {
+}

--- a/src/it/spring/verify.groovy
+++ b/src/it/spring/verify.groovy
@@ -32,4 +32,12 @@ def app = new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/sp
 assert app.exists()
 assert app.text.contains("metas")
 assert app.text.contains("<head>package</head>")
+// Check that we have "opcode" and "label" imports where they are needed
+assert app.text.contains("<tail>org.eolang.jeo.opcode</tail>")
+assert app.text.contains("<tail>org.eolang.jeo.label</tail>")
+//Check that if class doesn't have instructions, it doesn't have "opcode" imports.
+def empty = new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/spring/WithoutInstructions.xmir')
+assert empty.exists()
+assert !empty.text.contains("<tail>org.eolang.jeo.opcode</tail>")
+assert !empty.text.contains("<tail>org.eolang.jeo.label</tail>")
 true

--- a/src/main/java/org/eolang/jeo/representation/VerifiedEo.java
+++ b/src/main/java/org/eolang/jeo/representation/VerifiedEo.java
@@ -27,7 +27,6 @@ import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.directives.DirectivesClassVisitor;
 import org.eolang.parser.Schema;
-import org.xembly.Directives;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
@@ -58,47 +57,9 @@ final class VerifiedEo {
      * @throws ImpossibleModificationException If something goes wrong.
      */
     XML asXml() throws ImpossibleModificationException {
-        final XML res = VerifiedEo.cleanAliases(
-            new XMLDocument(new Xembler(this.directives).xml())
-        );
+        final XML res = new XMLDocument(new Xembler(this.directives).xml());
         new Schema(res).check();
         return res;
     }
 
-    /**
-     * Clean aliases from the EO if they are not needed.
-     * @param original Original EO with aliases.
-     * @return Clean EO.
-     * @throws ImpossibleModificationException If something goes wrong.
-     * @todo #640:60min Remove {@link #cleanAliases(XML)} method.
-     *  This method is some sort of crutch to remove aliases from the EO.
-     *  Actually, it's better just not to add them if they are not needed.
-     *  So, we need to remove this method and refactor the code to not add aliases.
-     */
-    private static XML cleanAliases(final XML original) throws ImpossibleModificationException {
-        final XML result;
-        if (VerifiedEo.dontHaveInstructions(original)) {
-            result = new XMLDocument(
-                new Xembler(
-                    new Directives()
-                        .xpath("./program/metas/meta[head[text()='alias']]")
-                        .remove()
-                ).apply(original.node())
-            );
-        } else {
-            result = original;
-        }
-        return result;
-    }
-
-    /**
-     * Check if EO has methods with instructions.
-     * @param original Original EO.
-     * @return True if EO has instructions.
-     */
-    private static boolean dontHaveInstructions(final XML original) {
-        return original.xpath(
-            ".//o[@base='seq']/o[@base='tuple']/o[@base='opcode' or @base='label']/text()"
-        ).isEmpty();
-    }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -68,14 +68,6 @@ public final class DirectivesClass implements Iterable<Directive> {
 
     /**
      * Constructor.
-     * @param classname Class name.
-     */
-    public DirectivesClass(final String classname) {
-        this(new ClassName(classname));
-    }
-
-    /**
-     * Constructor.
      * @param name Class name
      */
     public DirectivesClass(final ClassName name) {

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -154,6 +154,22 @@ public final class DirectivesClass implements Iterable<Directive> {
         return this;
     }
 
+    /**
+     * Check if class has opcodes.
+     * @return True if class has opcodes, false otherwise.
+     */
+    public boolean hasOpcodes() {
+        return this.methods.stream().anyMatch(DirectivesMethod::hasOpcodes);
+    }
+
+    /**
+     * Check if class has labels.
+     * @return True if class has labels, false otherwise.
+     */
+    public boolean hasLabels() {
+        return this.methods.stream().anyMatch(DirectivesMethod::hasLabels);
+    }
+
     @Override
     public Iterator<Directive> iterator() {
         final Directives directives = new Directives();

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -137,7 +137,7 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
         final ClassName classname = new ClassName(new JavaName(name).encode());
         this.metas.set(new DirectivesMetas(classname));
         this.program.withClass(
-            classname,
+            this.metas.get(),
             new DirectivesClass(
                 classname,
                 new DirectivesClassProperties(
@@ -221,6 +221,19 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
                     new DirectivesNullable("", access)
                 ));
         super.visitInnerClass(name, outer, inner, access);
+    }
+
+    @Override
+    public void visitEnd() {
+        final DirectivesClass clazz = this.program.top();
+        final DirectivesMetas aliases = this.metas.get();
+        if (clazz.hasOpcodes()) {
+            aliases.withOpcodes();
+        }
+        if (clazz.hasLabels()) {
+            aliases.withLabels();
+        }
+        super.visitEnd();
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassVisitor.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
 import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.DefaultVersion;
 import org.eolang.jeo.representation.JavaName;
@@ -49,6 +50,11 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
      * Program directives.
      */
     private final DirectivesProgram program;
+
+    /**
+     * Metas.
+     */
+    private final AtomicReference<DirectivesMetas> metas;
 
     /**
      * Opcodes counting.
@@ -116,6 +122,7 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
         super(api);
         this.program = program;
         this.counting = counting;
+        this.metas = new AtomicReference<>();
     }
 
     @Override
@@ -128,6 +135,7 @@ public final class DirectivesClassVisitor extends ClassVisitor implements Iterab
         final String[] interfaces
     ) {
         final ClassName classname = new ClassName(new JavaName(name).encode());
+        this.metas.set(new DirectivesMetas(classname));
         this.program.withClass(
             classname,
             new DirectivesClass(

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -79,7 +79,7 @@ public final class DirectivesMetas implements Iterable<Directive> {
      * Class name.
      * @return The class name.
      */
-    public ClassName name() {
+    public ClassName className() {
         return this.name;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -24,12 +24,13 @@
 package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.eolang.jeo.representation.ClassName;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
 /**
- * Directives for meta information of a class.
+ * Directives for meta-information of a class.
  * @since 0.1
  */
 public final class DirectivesMetas implements Iterable<Directive> {
@@ -38,6 +39,10 @@ public final class DirectivesMetas implements Iterable<Directive> {
      * Class name.
      */
     private final ClassName name;
+
+    private final AtomicBoolean opcodes;
+
+    private final AtomicBoolean labels;
 
     /**
      * Constructor.
@@ -51,7 +56,35 @@ public final class DirectivesMetas implements Iterable<Directive> {
      * @param classname Class name.
      */
     public DirectivesMetas(final ClassName classname) {
+        this(classname, false, false);
+    }
+
+    public DirectivesMetas(
+        final ClassName classname,
+        final boolean opcodes,
+        final boolean labels
+    ) {
         this.name = classname;
+        this.opcodes = new AtomicBoolean(opcodes);
+        this.labels = new AtomicBoolean(labels);
+    }
+
+    /**
+     * With opcodes.
+     * @return The same instance with opcodes.
+     */
+    public DirectivesMetas withOpcodes() {
+        this.opcodes.set(true);
+        return this;
+    }
+
+    /**
+     * With labels.
+     * @return The same instance with labels.
+     */
+    public DirectivesMetas withLabels() {
+        this.labels.set(true);
+        return this;
     }
 
     @Override
@@ -59,6 +92,26 @@ public final class DirectivesMetas implements Iterable<Directive> {
         final String opcode = "org.eolang.jeo.opcode";
         final String label = "org.eolang.jeo.label";
         final String alias = "alias";
+
+        final Directives opdirs;
+        if (this.opcodes.get()) {
+            opdirs = new Directives()
+                .add("meta")
+                .add("head").set(alias).up()
+                .add("tail").set(opcode).up()
+                .add("part").set(opcode).up()
+                .up();
+        } else {
+            opdirs = new Directives();
+        }
+        final Directives labeldirs = new Directives();
+        if (this.labels.get()) {
+            labeldirs.add("meta")
+                .add("head").set(alias).up()
+                .add("tail").set(label).up()
+                .add("part").set(label).up()
+                .up();
+        }
         return new Directives()
             .add("metas")
             .add("meta")
@@ -66,16 +119,8 @@ public final class DirectivesMetas implements Iterable<Directive> {
             .add("tail").set(this.name.pckg()).up()
             .add("part").set(this.name.pckg()).up()
             .up()
-            .add("meta")
-            .add("head").set(alias).up()
-            .add("tail").set(opcode).up()
-            .add("part").set(opcode).up()
-            .up()
-            .add("meta")
-            .add("head").set(alias).up()
-            .add("tail").set(label).up()
-            .add("part").set(label).up()
-            .up()
+            .append(opdirs)
+            .append(labeldirs)
             .up()
             .iterator();
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -40,8 +40,14 @@ public final class DirectivesMetas implements Iterable<Directive> {
      */
     private final ClassName name;
 
+    /**
+     * Whether to include "opcodes" import.
+     */
     private final AtomicBoolean opcodes;
 
+    /**
+     * Whether to include "labels" import.
+     */
     private final AtomicBoolean labels;
 
     /**
@@ -70,6 +76,14 @@ public final class DirectivesMetas implements Iterable<Directive> {
     }
 
     /**
+     * Class name.
+     * @return The class name.
+     */
+    public ClassName name() {
+        return this.name;
+    }
+
+    /**
      * With opcodes.
      * @return The same instance with opcodes.
      */
@@ -92,17 +106,13 @@ public final class DirectivesMetas implements Iterable<Directive> {
         final String opcode = "org.eolang.jeo.opcode";
         final String label = "org.eolang.jeo.label";
         final String alias = "alias";
-
-        final Directives opdirs;
+        final Directives opdirs = new Directives();
         if (this.opcodes.get()) {
-            opdirs = new Directives()
-                .add("meta")
+            opdirs.add("meta")
                 .add("head").set(alias).up()
                 .add("tail").set(opcode).up()
                 .add("part").set(opcode).up()
                 .up();
-        } else {
-            opdirs = new Directives();
         }
         final Directives labeldirs = new Directives();
         if (this.labels.get()) {

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -226,7 +226,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
      * True if method has opcodes.
      * @return True if method has opcodes.
      */
-    public boolean hasOpcodes() {
+    boolean hasOpcodes() {
         return this.instructions.stream().anyMatch(DirectivesInstruction.class::isInstance);
     }
 
@@ -234,7 +234,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
      * True if method has labels.
      * @return True if method has labels.
      */
-    public boolean hasLabels() {
+    boolean hasLabels() {
         return this.instructions.stream()
             .filter(DirectivesOperand.class::isInstance)
             .map(DirectivesOperand.class::cast)

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -222,11 +222,22 @@ public final class DirectivesMethod implements Iterable<Directive> {
         this.properties.paramAnnotation(parameter, annotation);
     }
 
+    /**
+     * True if method has opcodes.
+     * @return True if method has opcodes.
+     */
     public boolean hasOpcodes() {
         return this.instructions.stream().anyMatch(DirectivesInstruction.class::isInstance);
     }
 
+    /**
+     * True if method has labels.
+     * @return True if method has labels.
+     */
     public boolean hasLabels() {
-        return this.instructions.stream().anyMatch(DirectivesLabel.class::isInstance);
+        return this.instructions.stream()
+            .filter(DirectivesOperand.class::isInstance)
+            .map(DirectivesOperand.class::cast)
+            .anyMatch(DirectivesOperand::isLabel);
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -221,4 +221,12 @@ public final class DirectivesMethod implements Iterable<Directive> {
     void paramAnnotation(final int parameter, final DirectivesAnnotation annotation) {
         this.properties.paramAnnotation(parameter, annotation);
     }
+
+    public boolean hasOpcodes() {
+        return this.instructions.stream().anyMatch(DirectivesInstruction.class::isInstance);
+    }
+
+    public boolean hasLabels() {
+        return this.instructions.stream().anyMatch(DirectivesLabel.class::isInstance);
+    }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesOperand.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesOperand.java
@@ -50,7 +50,7 @@ public final class DirectivesOperand implements Iterable<Directive> {
     @Override
     public Iterator<Directive> iterator() {
         final Iterator<Directive> result;
-        if (this.raw instanceof Label) {
+        if (this.isLabel()) {
             result = new DirectivesLabel((Label) this.raw).iterator();
         } else if (this.raw instanceof Handle) {
             result = new DirectivesHandle((Handle) this.raw).iterator();
@@ -58,5 +58,13 @@ public final class DirectivesOperand implements Iterable<Directive> {
             result = new DirectivesData(this.raw).iterator();
         }
         return result;
+    }
+
+    /**
+     * Is it a label?
+     * @return True if it is a label.
+     */
+    public boolean isLabel() {
+        return this.raw instanceof Label;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesProgram.java
@@ -104,7 +104,7 @@ public final class DirectivesProgram implements Iterable<Directive> {
             .format(DateTimeFormatter.ISO_INSTANT);
         final Directives directives = new Directives();
         directives.add("program")
-            .attr("name", this.metas.get().name())
+            .attr("name", this.metas.get().name().name())
             .attr("version", "0.0.0")
             .attr("revision", "0.0.0")
             .attr("dob", now)

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesProgram.java
@@ -52,11 +52,9 @@ public final class DirectivesProgram implements Iterable<Directive> {
     private final AtomicReference<DirectivesClass> klass;
 
     /**
-     * Top-level class name.
-     * This field uses atomic reference because the field can't be initialized in the constructor.
-     * It is ASM framework limitation.
+     * Metas.
      */
-    private final AtomicReference<ClassName> classname;
+    private final AtomicReference<DirectivesMetas> metas;
 
     /**
      * Simple constructor with empty listing.
@@ -82,21 +80,20 @@ public final class DirectivesProgram implements Iterable<Directive> {
     public DirectivesProgram(
         final String code,
         final AtomicReference<DirectivesClass> clazz,
-        final AtomicReference<ClassName> name
+        final AtomicReference<DirectivesMetas> name
     ) {
         this.listing = code;
         this.klass = clazz;
-        this.classname = name;
+        this.metas = name;
     }
 
     /**
      * Append top-level class.
-     * @param name Class Name.
      * @param clazz Top-level class.
      * @return The same instance.
      */
-    public DirectivesProgram withClass(final ClassName name, final DirectivesClass clazz) {
-        this.classname.set(name);
+    public DirectivesProgram withClass(final DirectivesMetas metas, final DirectivesClass clazz) {
+        this.metas.set(metas);
         this.klass.set(clazz);
         return this;
     }
@@ -107,7 +104,7 @@ public final class DirectivesProgram implements Iterable<Directive> {
             .format(DateTimeFormatter.ISO_INSTANT);
         final Directives directives = new Directives();
         directives.add("program")
-            .attr("name", this.classname.get().name())
+            .attr("name", this.metas.get().name())
             .attr("version", "0.0.0")
             .attr("revision", "0.0.0")
             .attr("dob", now)
@@ -118,7 +115,7 @@ public final class DirectivesProgram implements Iterable<Directive> {
             .add("errors").up()
             .add("sheets").up()
             .add("license").up()
-            .append(new DirectivesMetas(this.classname.get()))
+            .append(this.metas.get())
             .attr("ms", System.currentTimeMillis())
             .add("objects");
         directives.append(this.klass.get());

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesProgram.java
@@ -29,7 +29,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
-import org.eolang.jeo.representation.ClassName;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -75,7 +74,7 @@ public final class DirectivesProgram implements Iterable<Directive> {
      * Constructor.
      * @param code Program listing.
      * @param clazz Class.
-     * @param name Classname.
+     * @param name Metas.
      */
     public DirectivesProgram(
         final String code,
@@ -89,11 +88,12 @@ public final class DirectivesProgram implements Iterable<Directive> {
 
     /**
      * Append top-level class.
+     * @param meta Metas.
      * @param clazz Top-level class.
      * @return The same instance.
      */
-    public DirectivesProgram withClass(final DirectivesMetas metas, final DirectivesClass clazz) {
-        this.metas.set(metas);
+    public DirectivesProgram withClass(final DirectivesMetas meta, final DirectivesClass clazz) {
+        this.metas.set(meta);
         this.klass.set(clazz);
         return this;
     }
@@ -104,7 +104,7 @@ public final class DirectivesProgram implements Iterable<Directive> {
             .format(DateTimeFormatter.ISO_INSTANT);
         final Directives directives = new Directives();
         directives.add("program")
-            .attr("name", this.metas.get().name().name())
+            .attr("name", this.metas.get().className().name())
             .attr("version", "0.0.0")
             .attr("revision", "0.0.0")
             .attr("dob", now)

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -27,6 +27,7 @@ import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.directives.DirectivesClass;
+import org.eolang.jeo.representation.directives.DirectivesMetas;
 import org.eolang.jeo.representation.directives.DirectivesProgram;
 import org.w3c.dom.Node;
 import org.xembly.Directives;
@@ -58,7 +59,10 @@ public final class XmlProgram {
         this(
             new XMLDocument(
                 new Xembler(
-                    new DirectivesProgram().withClass(name, new DirectivesClass(name))
+                    new DirectivesProgram().withClass(
+                        new DirectivesMetas(name),
+                        new DirectivesClass(name)
+                    )
                 ).xmlQuietly()
             ).node()
         );

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XML;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.hamcrest.MatcherAssert;

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -24,7 +24,6 @@
 package org.eolang.jeo.representation;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import com.jcabi.xml.XML;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.hamcrest.MatcherAssert;

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
@@ -58,7 +58,7 @@ final class DirectivesMetasTest {
         MatcherAssert.assertThat(
             "Can't create corresponding xembly directives for opcode alias",
             new Xembler(
-                new DirectivesMetas(),
+                new DirectivesMetas().withOpcodes(),
                 new Transformers.Node()
             ).xmlQuietly(),
             Matchers.allOf(
@@ -74,12 +74,34 @@ final class DirectivesMetasTest {
         MatcherAssert.assertThat(
             "Can't create corresponding xembly directives for label alias",
             new Xembler(
-                new DirectivesMetas(),
+                new DirectivesMetas().withLabels(),
                 new Transformers.Node()
             ).xmlQuietly(),
             Matchers.allOf(
                 XhtmlMatchers.hasXPath("/metas/meta/tail[text()='org.eolang.jeo.label']"),
                 XhtmlMatchers.hasXPath("/metas/meta/part[text()='org.eolang.jeo.label']")
+            )
+        );
+    }
+
+    @Test
+    void addsNothingExceptPackage() {
+        MatcherAssert.assertThat(
+            "Can't create corresponding xembly directives for metas with package only",
+            new Xembler(
+                new DirectivesMetas(new ClassName("path/to/SomeClass")),
+                new Transformers.Node()
+            ).xmlQuietly(),
+            Matchers.allOf(
+                XhtmlMatchers.hasXPath("/metas/meta/head[text()='package']"),
+                XhtmlMatchers.hasXPath("/metas/meta/tail[text()='path.to']"),
+                XhtmlMatchers.hasXPath("/metas/meta/part[text()='path.to']"),
+                Matchers.not(
+                    XhtmlMatchers.hasXPath("/metas/meta/tail[text()='org.eolang.jeo.label']")
+                ),
+                Matchers.not(
+                    XhtmlMatchers.hasXPath("/metas/meta/tail[text()='org.eolang.jeo.opcode']")
+                )
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesProgramTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesProgramTest.java
@@ -42,7 +42,7 @@ final class DirectivesProgramTest {
         final ClassName name = new ClassName("Foo");
         final String actual = new Xembler(
             new DirectivesProgram()
-                .withClass(name, new DirectivesClass(name)),
+                .withClass(new DirectivesMetas(name), new DirectivesClass(name)),
             new Transformers.Node()
         ).xmlQuietly();
         MatcherAssert.assertThat(

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlBytecodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlBytecodeTest.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.xmir;
 
 import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.directives.DirectivesClass;
+import org.eolang.jeo.representation.directives.DirectivesMetas;
 import org.eolang.jeo.representation.directives.DirectivesMethod;
 import org.eolang.jeo.representation.directives.DirectivesMethodProperties;
 import org.eolang.jeo.representation.directives.DirectivesProgram;
@@ -80,7 +81,7 @@ final class XmlBytecodeTest {
         return new Xembler(
             new DirectivesProgram()
                 .withClass(
-                    name,
+                    new DirectivesMetas(name),
                     new DirectivesClass(name).method(
                         new DirectivesMethod(
                             "printElement",
@@ -131,7 +132,7 @@ final class XmlBytecodeTest {
         return new Xembler(
             new DirectivesProgram()
                 .withClass(
-                    name,
+                    new DirectivesMetas(name),
                     new DirectivesClass(name)
                         .method(
                             new DirectivesMethod(


### PR DESCRIPTION
In this PR I added the logic that adds meta information (imports) only when they are needed.
For example, when we have a Java interface - it usually doesn't have any instructions or labels.
So, we don't need to add "opcode" and "label" imports to the generated XMIR.
Also I removed the outdated ad-hoc solution of this problem.

Closes: #647
History:
- **feat(#647): change DirectivesMetas significantly**
- **feat(#647): naive implementation of opcodes and labels checking**
- **feat(#647): fix the small bug with class names**
- **feat(#647): fix all the integration tests**
- **feat(#647): remove deprecated code and the puzzle for #647 issue**
- **feat(#647): fix all the code offences**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance the representation of classes and methods in the codebase by introducing methods to check for opcodes and labels. 

### Detailed summary
- Added `hasOpcodes` and `hasLabels` methods to `DirectivesMethod` and `DirectivesClass`.
- Introduce `DirectivesMetas` to handle metadata in class representation.
- Improved XML generation in `DirectivesClassVisitor`.
- Refactored `DirectivesProgram` to use `DirectivesMetas` instead of `ClassName`.

> The following files were skipped due to too many changes: `src/main/java/org/eolang/jeo/representation/directives/DirectivesProgram.java`, `src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->