### PR TITLE
feat(#697): Rremove Redundant Methods

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -234,6 +234,14 @@ public final class BytecodeMethod implements Testable {
         return this;
     }
 
+    /**
+     * Method name.
+     * @return Method name.
+     */
+    public String name() {
+        return this.properties.name();
+    }
+
     @Override
     @SuppressWarnings("PMD.InsufficientStringBufferDeclaration")
     public String testCode() {

--- a/src/main/java/org/eolang/jeo/representation/xmir/HexString.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/HexString.java
@@ -41,7 +41,7 @@ public final class HexString {
     /**
      * Hex string.
      * Example:
-     * - "48 65 6C 6C 6F 20 57 6F 72 6C 64 21"
+     * - "20 57 6F 72 6C 64 21" (World!)
      */
     private final String hex;
 
@@ -112,10 +112,18 @@ public final class HexString {
         return "01".equals(value);
     }
 
+    /**
+     * Convert hex string to double.
+     * @return Double.
+     */
     public double decodeAsDouble() {
         return (double) DataType.DOUBLE.decode(this.hex.replace(" ", ""));
     }
 
+    /**
+     * Convert hex string to float.
+     * @return Float.
+     */
     public float decodeAsFloat() {
         return (float) DataType.FLOAT.decode(this.hex.replace(" ", ""));
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
@@ -86,20 +86,9 @@ public class XmlAnnotation {
      */
     private List<BytecodeAnnotationValue> props() {
         return this.node.children()
-            .filter(
-                xmlnode -> xmlnode.hasAttribute("base", "annotation-property")
-                    || xmlnode.hasAttribute("base", "annotation")
-            ).map(
-                xmlnode -> {
-                    final BytecodeAnnotationValue result;
-                    if (xmlnode.hasAttribute("base", "annotation-property")) {
-                        result = new XmlAnnotationProperty(xmlnode).bytecode();
-                    } else {
-                        result = new XmlAnnotation(xmlnode).bytecode();
-                    }
-                    return result;
-                }
-            )
+            .filter(xmlnode -> xmlnode.hasAttribute("base", "annotation-property"))
+            .map(XmlAnnotationProperty::new)
+            .map(XmlAnnotationProperty::bytecode)
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotationProperty.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotationProperty.java
@@ -40,10 +40,10 @@ public final class XmlAnnotationProperty {
 
     /**
      * Constructor.
-     * @param node XML node.
+     * @param xmlnode XML node.
      */
-    public XmlAnnotationProperty(final XmlNode node) {
-        this.node = node;
+    public XmlAnnotationProperty(final XmlNode xmlnode) {
+        this.node = xmlnode;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
@@ -26,7 +26,6 @@ package org.eolang.jeo.representation.xmir;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.eolang.jeo.representation.bytecode.BytecodeAttribute;
-import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.eolang.jeo.representation.bytecode.InnerClass;
 
 /**
@@ -96,13 +95,5 @@ public final class XmlAttribute {
             result = Optional.empty();
         }
         return result;
-    }
-
-    /**
-     * Write to bytecode.
-     * @param bytecode Bytecode.
-     */
-    public void writeTo(final BytecodeClass bytecode) {
-        this.attribute().ifPresent(bytecode::withAttribute);
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttributes.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.eolang.jeo.representation.bytecode.BytecodeAttribute;
-import org.eolang.jeo.representation.bytecode.BytecodeClass;
 
 /**
  * Xml representation of a class attributes.
@@ -46,10 +45,10 @@ public final class XmlAttributes {
 
     /**
      * Constructor.
-     * @param node XML node.
+     * @param xmlnode XML node.
      */
-    XmlAttributes(final XmlNode node) {
-        this.node = node;
+    XmlAttributes(final XmlNode xmlnode) {
+        this.node = xmlnode;
     }
 
     /**
@@ -61,13 +60,5 @@ public final class XmlAttributes {
             .filter(Optional::isPresent)
             .map(Optional::get)
             .collect(Collectors.toList());
-    }
-
-    /**
-     * Write to bytecode.
-     * @param bytecode Bytecode where to write.
-     */
-    public void writeTo(final BytecodeClass bytecode) {
-        this.node.children().map(XmlAttribute::new).forEach(attr -> attr.writeTo(bytecode));
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
@@ -35,12 +35,6 @@ import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 public interface XmlBytecodeEntry {
 
     /**
-     * Write instruction to the bytecode method.
-     * @param method Bytecode Method where instruction should be written.
-     */
-    void writeTo(BytecodeMethod method);
-
-    /**
      * Convert to bytecode entry.
      * @return Bytecode entry.
      */

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
@@ -24,7 +24,6 @@
 package org.eolang.jeo.representation.xmir;
 
 import org.eolang.jeo.representation.bytecode.BytecodeEntry;
-import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 
 /**
  * XML representation of bytecode instruction or a label.

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
@@ -30,7 +30,6 @@ import org.eolang.jeo.representation.bytecode.BytecodeClassProperties;
 
 /**
  * XML representation of a class.
- *
  * @since 0.1.0
  */
 public final class XmlClassProperties {
@@ -42,18 +41,18 @@ public final class XmlClassProperties {
 
     /**
      * Constructor.
-     * @param clazz XMl representation of a class.
+     * @param xmlclass XMl representation of a class.
      */
-    XmlClassProperties(final XmlNode clazz) {
-        this(clazz.asDocument());
+    XmlClassProperties(final XmlNode xmlclass) {
+        this(xmlclass.asDocument());
     }
 
     /**
      * Constructor.
-     * @param clazz XML representation of a class.
+     * @param xmlclass XML representation of a class.
      */
-    private XmlClassProperties(final XMLDocument clazz) {
-        this.clazz = clazz;
+    private XmlClassProperties(final XMLDocument xmlclass) {
+        this.clazz = xmlclass;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlDefaultValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlDefaultValue.java
@@ -29,7 +29,6 @@ import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 
 /**
  * XMIR of annotation default value.
- *
  * @since 0.3
  */
 public final class XmlDefaultValue {
@@ -66,5 +65,4 @@ public final class XmlDefaultValue {
     public void writeTo(final BytecodeMethod method) {
         this.bytecode().ifPresent(method::defvalue);
     }
-
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -197,8 +197,8 @@ public class XmlField {
 
         /**
          * Initial field value.
-         * For example for field of type int with value 19 the value will be "13".
-         * Any data type will be represented as hex string.
+         * For example, for field of type int with value 19, the value will be "13".
+         * Any data type will be represented as a hex string.
          * May not be set.
          */
         VALUE;

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlFrame.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlFrame.java
@@ -23,9 +23,9 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.eolang.jeo.representation.bytecode.BytecodeFrame;
-import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 
 /**
  * Xmir representation of bytecode frame.
@@ -38,6 +38,14 @@ public final class XmlFrame implements XmlBytecodeEntry {
      * Xmir node.
      */
     private final XmlNode node;
+
+    /**
+     * Constructor.
+     * @param xmlnode Xmir node
+     */
+    public XmlFrame(final XmlNode xmlnode) {
+        this.node = xmlnode;
+    }
 
     /**
      * Constructor.
@@ -56,14 +64,6 @@ public final class XmlFrame implements XmlBytecodeEntry {
     }
 
     /**
-     * Constructor.
-     * @param node Xmir node
-     */
-    public XmlFrame(final XmlNode node) {
-        this.node = node;
-    }
-
-    /**
      * Convert to bytecode.
      * @return Bytecode frame.
      */
@@ -77,19 +77,12 @@ public final class XmlFrame implements XmlBytecodeEntry {
         );
     }
 
-    @Override
-    public void writeTo(final BytecodeMethod method) {
-        method.entry(this.bytecode());
-    }
-
     /**
      * Type of frame.
      * @return Type.
      */
     private int type() {
-        return (int) new XmlOperand(
-            this.node.children().collect(Collectors.toList()).get(0)
-        ).asObject();
+        return this.ichild(0);
     }
 
     /**
@@ -97,9 +90,7 @@ public final class XmlFrame implements XmlBytecodeEntry {
      * @return Number of local variables.
      */
     private int nlocal() {
-        return (int) new XmlOperand(
-            this.node.children().collect(Collectors.toList()).get(1)
-        ).asObject();
+        return this.ichild(1);
     }
 
     /**
@@ -119,9 +110,21 @@ public final class XmlFrame implements XmlBytecodeEntry {
      * @return Number of stack elements.
      */
     private int nstack() {
-        return (int) new XmlOperand(
-            this.node.children().collect(Collectors.toList()).get(3)
-        ).asObject();
+        return this.ichild(3);
+    }
+
+    /**
+     * Retrieve integer child.
+     * @param position Position.
+     * @return Integer value.
+     */
+    private int ichild(final int position) {
+        return (int) Objects.requireNonNull(
+            new XmlOperand(
+                this.node.children().collect(Collectors.toList()).get(position)
+            ).asObject(),
+            String.format("Can't find integer child at position %d in '%s'", position, this.node)
+        );
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlHandler.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlHandler.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation.xmir;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.eolang.jeo.representation.bytecode.BytecodeHandler;
 
@@ -40,10 +41,10 @@ final class XmlHandler {
 
     /**
      * Constructor.
-     * @param node Node.
+     * @param xmlnode Node.
      */
-    XmlHandler(final XmlNode node) {
-        this.node = node;
+    XmlHandler(final XmlNode xmlnode) {
+        this.node = xmlnode;
     }
 
     /**
@@ -55,11 +56,11 @@ final class XmlHandler {
             .map(XmlOperand::new)
             .collect(Collectors.toList());
         return new BytecodeHandler(
-            Integer.class.cast(operands.get(0).asObject()),
-            operands.get(1).asObject().toString(),
-            operands.get(2).asObject().toString(),
-            operands.get(3).asObject().toString(),
-            Boolean.class.cast(operands.get(4).asObject())
+            (Integer) Objects.requireNonNull(operands.get(0).asObject()),
+            Objects.requireNonNull(operands.get(1).asObject()).toString(),
+            Objects.requireNonNull(operands.get(2).asObject()).toString(),
+            Objects.requireNonNull(operands.get(3).asObject()).toString(),
+            (Boolean) Objects.requireNonNull(operands.get(4).asObject())
         );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -106,19 +106,6 @@ public final class XmlInstruction implements XmlBytecodeEntry {
     }
 
     /**
-     * Get XML node.
-     * @return XML node.
-     * @todo #636:30min Rremove {@link XmlInstruction#toNode()} method.
-     *  This method is required for inserting instructions into {@link XmlMethod}.
-     *  Actually, we should insert instructions not to the {@link XmlMethod},
-     *  but to the {@link BytecodeMethod}. When this will be implemented in
-     *  `opeo-maven-plugin`, we should remove this method.
-     */
-    public XmlNode toNode() {
-        return this.node;
-    }
-
-    /**
      * Instruction code.
      * @return Code.
      */

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.bytecode.BytecodeInstructionEntry;
-import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.eolang.jeo.representation.directives.DirectivesInstruction;
 import org.xembly.Transformers;
 import org.xembly.Xembler;
@@ -83,15 +82,10 @@ public final class XmlInstruction implements XmlBytecodeEntry {
 
     /**
      * Constructor.
-     * @param node Instruction node.
+     * @param xmlnode Instruction node.
      */
-    XmlInstruction(final XmlNode node) {
-        this.node = node;
-    }
-
-    @Override
-    public void writeTo(final BytecodeMethod method) {
-        method.entry(this.bytecode());
+    XmlInstruction(final XmlNode xmlnode) {
+        this.node = xmlnode;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation.xmir;
 
 import org.eolang.jeo.representation.DataType;
 import org.eolang.jeo.representation.bytecode.BytecodeLabel;
-import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.objectweb.asm.Label;
 
 /**
@@ -47,11 +46,6 @@ public final class XmlLabel implements XmlBytecodeEntry {
         this.node = node;
     }
 
-    @Override
-    public void writeTo(final BytecodeMethod method) {
-        method.label((Label) DataType.LABEL.decode(this.node.text()));
-    }
-
     /**
      * Converts label to bytecode.
      * @return Bytecode label.
@@ -59,5 +53,4 @@ public final class XmlLabel implements XmlBytecodeEntry {
     public BytecodeLabel bytecode() {
         return new BytecodeLabel((Label) DataType.LABEL.decode(this.node.text()), new AllLabels());
     }
-
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMaxs.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMaxs.java
@@ -23,16 +23,14 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.bytecode.BytecodeMaxs;
-import org.eolang.jeo.representation.directives.DirectivesMaxs;
-import org.xembly.Xembler;
 
 /**
  * Xmir representation of max stack and max locals of a method.
- *
  * @since 0.3
  */
 @EqualsAndHashCode
@@ -44,16 +42,6 @@ public final class XmlMaxs {
      */
     @EqualsAndHashCode.Exclude
     private final XmlNode node;
-
-    /**
-     * Constructor.
-     *
-     * @param stack Stack size.
-     * @param locals Locals size.
-     */
-    XmlMaxs(final int stack, final int locals) {
-        this(XmlMaxs.prestructor(stack, locals));
-    }
 
     /**
      * Constructor.
@@ -74,36 +62,37 @@ public final class XmlMaxs {
 
     /**
      * Stack max size.
-     *
      * @return Stack size.
      */
     @EqualsAndHashCode.Include
     private int stack() {
-        return (int) new XmlOperand(
-            this.node.children().collect(Collectors.toList()).get(0)
-        ).asObject();
+        return this.ichild(0);
     }
 
     /**
      * Locals max size.
-     *
      * @return Locals size.
      */
     @EqualsAndHashCode.Include
     private int locals() {
-        return (int) new XmlOperand(
-            this.node.children().collect(Collectors.toList()).get(1)
-        ).asObject();
+        return this.ichild(1);
     }
 
     /**
-     * Prestructor.
-     *
-     * @param stack Stack size.
-     * @param locals Locals size.
-     * @return XML node that represents Max Stack and Max Locals.
+     * Retrieve integer child.
+     * @param position Position.
+     * @return Integer value.
      */
-    private static XmlNode prestructor(final int stack, final int locals) {
-        return new XmlNode(new Xembler(new DirectivesMaxs(stack, locals)).xmlQuietly());
+    private int ichild(int position) {
+        return (int) Objects.requireNonNull(
+            new XmlOperand(
+                this.node.children().collect(Collectors.toList()).get(position)
+            ).asObject(),
+            String.format(
+                "The XML node representing Maxs '%s' doesn't contain a valid integer at '%d' position",
+                this.node,
+                position
+            )
+        );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMaxs.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMaxs.java
@@ -83,7 +83,7 @@ public final class XmlMaxs {
      * @param position Position.
      * @return Integer value.
      */
-    private int ichild(int position) {
+    private int ichild(final int position) {
         return (int) Objects.requireNonNull(
             new XmlOperand(
                 this.node.children().collect(Collectors.toList()).get(position)

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -24,12 +24,10 @@
 package org.eolang.jeo.representation.xmir;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -73,6 +71,15 @@ public final class XmlMethod {
 
     /**
      * Constructor.
+     * @param xmlnode Method node.
+     */
+    public XmlMethod(final XmlNode xmlnode) {
+        this.node = xmlnode;
+        this.labels = new AllLabels();
+    }
+
+    /**
+     * Constructor.
      *
      * @param name Method name.
      * @param access Access modifiers.
@@ -80,7 +87,7 @@ public final class XmlMethod {
      * @param exceptions Method exceptions.
      * @checkstyle ParameterNumberCheck (5 lines)
      */
-    public XmlMethod(
+    XmlMethod(
         final String name,
         final int access,
         final String descriptor,
@@ -95,17 +102,8 @@ public final class XmlMethod {
      * @param stack Max stack.
      * @param locals Max locals.
      */
-    public XmlMethod(final int stack, final int locals) {
+    XmlMethod(final int stack, final int locals) {
         this(XmlMethod.prestructor("foo", Opcodes.ACC_PUBLIC, "()V", stack, locals));
-    }
-
-    /**
-     * Constructor.
-     * @param xmlnode Method node.
-     */
-    public XmlMethod(final XmlNode xmlnode) {
-        this.node = xmlnode;
-        this.labels = new AllLabels();
     }
 
     /**
@@ -139,7 +137,7 @@ public final class XmlMethod {
      * Method name.
      * @return Name.
      */
-    public String name() {
+    private String name() {
         return new MethodName(
             new Signature(
                 this.node.attribute("name")
@@ -152,20 +150,14 @@ public final class XmlMethod {
 
     /**
      * All instructions.
-     *
-     * @param predicates Predicates to filter instructions.
      * @return Instructions.
      */
-    @SafeVarargs
-    private final List<XmlBytecodeEntry> instructions(
-        final Predicate<XmlBytecodeEntry>... predicates
-    ) {
+    private List<XmlBytecodeEntry> instructions() {
         return this.node.child("base", "seq")
             .child("base", "tuple")
             .children()
             .filter(element -> element.attribute("base").isPresent())
             .map(XmlNode::toEntry)
-            .filter(instr -> Arrays.stream(predicates).allMatch(predicate -> predicate.test(instr)))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -44,7 +44,6 @@ public final class XmlNode {
     /**
      * Parent node.
      */
-    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     private final Node node;
 
     /**
@@ -61,14 +60,6 @@ public final class XmlNode {
      */
     public XmlNode(final Node parent) {
         this.node = parent;
-    }
-
-    /**
-     * To XML node.
-     * @return Xml node
-     */
-    public Node node() {
-        return this.node;
     }
 
     @Override
@@ -90,87 +81,6 @@ public final class XmlNode {
     @Override
     public String toString() {
         return new XMLDocument(this.node).toString();
-    }
-
-    /**
-     * Get child node.
-     * @param name Child node name.
-     * @return Child node.
-     */
-    public XmlNode child(final String name) {
-        return this.optchild(name).orElseThrow(() -> this.notFound(name));
-    }
-
-    /**
-     * Find elements by xpath.
-     * @param xpath XPath.
-     * @return List of elements.
-     */
-    public List<String> xpath(final String xpath) {
-        return new XMLDocument(this.node).xpath(xpath);
-    }
-
-    /**
-     * Get optional child node.
-     * @param name Child node name.
-     * @return Child node.
-     */
-    public Optional<XmlNode> optchild(final String name) {
-        Optional<XmlNode> result = Optional.empty();
-        final NodeList children = this.node.getChildNodes();
-        for (int index = 0; index < children.getLength(); ++index) {
-            final Node current = children.item(index);
-            if (current.getNodeName().equals(name)) {
-                result = Optional.of(new XmlNode(current));
-                break;
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Get child node by attribute.
-     * @param attribute Attribute name.
-     * @param value Attribute value.
-     * @return Child node.
-     */
-    public XmlNode child(final String attribute, final String value) {
-        return this.children()
-            .filter(xmlnode -> xmlnode.hasAttribute(attribute, value))
-            .findFirst()
-            .orElseThrow(
-                () -> this.notFound(
-                    String.format("object with attribute %s='%s'", attribute, value)
-                )
-            );
-    }
-
-    /**
-     * Get optional child node by attribute.
-     * @param attribute Attribute name.
-     * @param value Attribute value.
-     * @return Child node.
-     */
-    public Optional<XmlNode> optchild(final String attribute, final String value) {
-        return this.children()
-            .filter(xmlnode -> xmlnode.hasAttribute(attribute, value))
-            .findFirst();
-    }
-
-    /**
-     * Get first child.
-     * @return First child node.
-     */
-    public XmlNode firstChild() {
-        return this.children().findFirst()
-            .orElseThrow(
-                () -> new IllegalStateException(
-                    String.format(
-                        "Can't find any child nodes in '%s'",
-                        new XMLDocument(this.node)
-                    )
-                )
-            );
     }
 
     /**
@@ -206,12 +116,75 @@ public final class XmlNode {
     }
 
     /**
-     * Check if attribute exists.
+     * Get child node.
+     * @param name Child node name.
+     * @return Child node.
+     */
+    XmlNode child(final String name) {
+        return this.optchild(name).orElseThrow(() -> this.notFound(name));
+    }
+
+    /**
+     * Find elements by xpath.
+     * @param xpath XPath.
+     * @return List of elements.
+     */
+    List<String> xpath(final String xpath) {
+        return new XMLDocument(this.node).xpath(xpath);
+    }
+
+    /**
+     * Get child node by attribute.
+     * @param attribute Attribute name.
+     * @param value Attribute value.
+     * @return Child node.
+     */
+    XmlNode child(final String attribute, final String value) {
+        return this.children()
+            .filter(xmlnode -> xmlnode.hasAttribute(attribute, value))
+            .findFirst()
+            .orElseThrow(
+                () -> this.notFound(
+                    String.format("object with attribute %s='%s'", attribute, value)
+                )
+            );
+    }
+
+    /**
+     * Get optional child node by attribute.
+     * @param attribute Attribute name.
+     * @param value Attribute value.
+     * @return Child node.
+     */
+    Optional<XmlNode> optchild(final String attribute, final String value) {
+        return this.children()
+            .filter(xmlnode -> xmlnode.hasAttribute(attribute, value))
+            .findFirst();
+    }
+
+    /**
+     * Get first child.
+     * @return First child node.
+     */
+    XmlNode firstChild() {
+        return this.children().findFirst()
+            .orElseThrow(
+                () -> new IllegalStateException(
+                    String.format(
+                        "Can't find any child nodes in '%s'",
+                        new XMLDocument(this.node)
+                    )
+                )
+            );
+    }
+
+    /**
+     * Check if an attribute exists.
      * @param name Attribute name.
      * @param value Attribute value.
-     * @return True if attribute with specified value exists.
+     * @return True if an attribute with specified value exists.
      */
-    public boolean hasAttribute(final String name, final String value) {
+    boolean hasAttribute(final String name, final String value) {
         return this.attribute(name)
             .map(String::valueOf)
             .map(val -> val.equals(value))
@@ -249,6 +222,24 @@ public final class XmlNode {
      */
     XMLDocument asDocument() {
         return new XMLDocument(this.node);
+    }
+
+    /**
+     * Get optional child node.
+     * @param name Child node name.
+     * @return Child node.
+     */
+    private Optional<XmlNode> optchild(final String name) {
+        Optional<XmlNode> result = Optional.empty();
+        final NodeList children = this.node.getChildNodes();
+        for (int index = 0; index < children.getLength(); ++index) {
+            final Node current = children.item(index);
+            if (current.getNodeName().equals(name)) {
+                result = Optional.of(new XmlNode(current));
+                break;
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlOperand.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlOperand.java
@@ -45,7 +45,7 @@ public final class XmlOperand {
      * Constructor.
      * @param node Raw XML operand node.
      */
-    public XmlOperand(final XmlNode node) {
+    XmlOperand(final XmlNode node) {
         this.raw = node;
     }
 
@@ -55,7 +55,6 @@ public final class XmlOperand {
      */
     @EqualsAndHashCode.Include
     public Object asObject() {
-        final Object result;
         final String base = this.raw.attribute("base")
             .orElseThrow(
                 () -> new IllegalStateException(
@@ -65,6 +64,7 @@ public final class XmlOperand {
                     )
                 )
             );
+        final Object result;
         if ("handle".equals(base)) {
             result = new XmlHandler(this.raw).bytecode().asHandle();
         } else if ("annotation".equals(base)) {
@@ -75,13 +75,12 @@ public final class XmlOperand {
         } else if ("tuple".equals(base)) {
             result = new XmlTuple(this.raw).asObject();
         } else {
-            final boolean nullable = this.raw.attribute("scope").map("nullable"::equals)
-                .orElse(false);
-            if (nullable) {
+            if (this.raw.attribute("scope")
+                .map("nullable"::equals)
+                .orElse(false)) {
                 result = null;
             } else {
-                final String text = this.raw.text();
-                result = DataType.find(base).decode(text);
+                result = DataType.find(base).decode(this.raw.text());
             }
         }
         return result;

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -51,24 +51,6 @@ public final class XmlProgram {
 
     /**
      * Constructor.
-     *
-     * @param name Class name.
-     */
-    public XmlProgram(final ClassName name) {
-        this(
-            new XMLDocument(
-                new Xembler(
-                    new DirectivesProgram().withClass(
-                        new DirectivesMetas(name),
-                        new DirectivesClass(name)
-                    )
-                ).xmlQuietly()
-            ).node()
-        );
-    }
-
-    /**
-     * Constructor.
      * @param lines Xmir lines.
      */
     public XmlProgram(final String... lines) {
@@ -87,9 +69,27 @@ public final class XmlProgram {
     /**
      * Constructor.
      *
+     * @param name Class name.
+     */
+    XmlProgram(final ClassName name) {
+        this(
+            new XMLDocument(
+                new Xembler(
+                    new DirectivesProgram().withClass(
+                        new DirectivesMetas(name),
+                        new DirectivesClass(name)
+                    )
+                ).xmlQuietly()
+            ).node()
+        );
+    }
+
+    /**
+     * Constructor.
+     *
      * @param root Root node.
      */
-    public XmlProgram(final Node root) {
+    private XmlProgram(final Node root) {
         this.root = root;
     }
 
@@ -103,10 +103,7 @@ public final class XmlProgram {
      * @return Bytecode program.
      */
     public BytecodeProgram bytecode() {
-        return new BytecodeProgram(
-            this.pckg(),
-            this.top().bytecode()
-        );
+        return new BytecodeProgram(this.pckg(), this.top().bytecode());
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
@@ -63,22 +63,12 @@ public final class XmlTryCatchEntry implements XmlBytecodeEntry {
         this.labels = labels;
     }
 
-    @Override
-    public void writeTo(final BytecodeMethod method) {
-        method.trycatch(this.bytecode());
-    }
-
     /**
      * Converts XML to bytecode.
      * @return Bytecode try-catch block.
      */
     public BytecodeTryCatchBlock bytecode() {
-        return new BytecodeTryCatchBlock(
-            this.start(),
-            this.end(),
-            this.handler(),
-            this.type()
-        );
+        return new BytecodeTryCatchBlock(this.start(), this.end(), this.handler(), this.type());
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation.xmir;
 
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.eolang.jeo.representation.bytecode.BytecodeTryCatchBlock;
 import org.objectweb.asm.Label;
 

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
@@ -59,7 +59,7 @@ final class XmlMethodTest {
     void createsConstructor() {
         MatcherAssert.assertThat(
             "Method name is not equal to expected, it should be <init>",
-            new XmlMethod("@init@", Opcodes.ACC_PUBLIC, "()V").name(),
+            new XmlMethod("@init@", Opcodes.ACC_PUBLIC, "()V").bytecode().name(),
             Matchers.equalTo("<init>")
         );
     }


### PR DESCRIPTION
In this PR I succesfully removed many outdated and redundant methods from `xmir` package.

Closes: #697.
History:
- **feat(#697): removed unused XmlInstruction#toNode method**
- **feat(#697): remove redundant code**
- **feat(#697): add more javadocs**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds and updates methods and constructors in various classes related to XML representation and bytecode handling.

### Detailed summary
- Added a `name` method in `BytecodeMethod`
- Renamed parameter in `XmlAnnotationProperty` constructor
- Updated method call in `XmlMethodTest`
- Removed empty comment in `XmlDefaultValue`
- Updated comments in `XmlField`
- Removed `writeTo` method in `XmlBytecodeEntry`
- Updated comments in `XmlBytecodeEntry`
- Updated comments in `XmlAttribute`
- Updated comments and examples in `HexString`
- Updated `props` method in `XmlAnnotation`
- Removed `writeTo` method in `XmlLabel`
- Updated constructor parameter name in `XmlClassProperties`
- Removed `writeTo` method in `XmlTryCatchEntry`
- Updated constructor parameter name in `XmlAttributes`
- Updated `bytecode` method in `XmlHandler`
- Updated `XmlOperand` constructor
- Updated `XmlProgram` constructors
- Removed `writeTo` method in `XmlInstruction`

> The following files were skipped due to too many changes: `src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java`, `src/main/java/org/eolang/jeo/representation/xmir/XmlMaxs.java`, `src/main/java/org/eolang/jeo/representation/xmir/XmlFrame.java`, `src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java`, `src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->