### PR TITLE
feat(#595): Add Unit Test for `XmlAttributes`

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation.directives;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -49,6 +50,14 @@ public final class DirectivesAttributes implements Iterable<Directive> {
      */
     public DirectivesAttributes() {
         this(new ArrayList<>(0));
+    }
+
+    /**
+     * Constructor.
+     * @param attributes Attributes.
+     */
+    public DirectivesAttributes(final DirectivesAttribute... attributes) {
+        this(Arrays.asList(attributes));
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttributes.java
@@ -31,10 +31,6 @@ import org.eolang.jeo.representation.bytecode.BytecodeAttribute;
 /**
  * Xml representation of a class attributes.
  * @since 0.4
- * @todo #589:30min Add Unit Tests for XmlAttributes class.
- *  XmlAttributes class is not covered by unit tests.
- *  Add unit tests for XmlAttributes class in order to increase the code coverage
- *  and improve the quality of the code.
  */
 public final class XmlAttributes {
 

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlAttributesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlAttributesTest.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.xmir;
+
+import org.eolang.jeo.representation.bytecode.InnerClass;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link XmlAttributes}.
+ * @since 0.6
+ */
+final class XmlAttributesTest {
+
+    /**
+     * Example XMIR of attributes.
+     */
+    private static final String XMIR = String.join(
+        "\n",
+        "<o base='seq1' line='637276933' name='attributes'>",
+        "   <o base='inner-class'>",
+        "      <o base='string' data='bytes' line='2024476541'>6E 61 6D 65</o>",
+        "      <o base='string' data='bytes' line='1277525674'>6F 75 74 65 72</o>",
+        "      <o base='string' data='bytes' line='1937924607'>69 6E 6E 65 72</o>",
+        "      <o base='int' data='bytes' line='1322657598'>00 00 00 00 00 00 00 00</o>",
+        "   </o>",
+        "</o>"
+    );
+
+    @Test
+    void convertsToBytecode() {
+        MatcherAssert.assertThat(
+            "We expect the attributes to be converted to a correct bytecode domain class",
+            new XmlAttributes(new XmlNode(XmlAttributesTest.XMIR)).attributes(),
+            Matchers.contains(
+                new InnerClass("name", "outer", "inner", 0)
+            )
+        );
+    }
+
+}

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlAttributesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlAttributesTest.java
@@ -39,12 +39,12 @@ final class XmlAttributesTest {
      */
     private static final String XMIR = String.join(
         "\n",
-        "<o base='seq1' line='637276933' name='attributes'>",
+        "<o base='seq1' name='attributes'>",
         "   <o base='inner-class'>",
-        "      <o base='string' data='bytes' line='2024476541'>6E 61 6D 65</o>",
-        "      <o base='string' data='bytes' line='1277525674'>6F 75 74 65 72</o>",
-        "      <o base='string' data='bytes' line='1937924607'>69 6E 6E 65 72</o>",
-        "      <o base='int' data='bytes' line='1322657598'>00 00 00 00 00 00 00 00</o>",
+        "      <o base='string' data='bytes'>6E 61 6D 65</o>",
+        "      <o base='string' data='bytes'>6F 75 74 65 72</o>",
+        "      <o base='string' data='bytes'>69 6E 6E 65 72</o>",
+        "      <o base='int' data='bytes'>00 00 00 00 00 00 00 00</o>",
         "   </o>",
         "</o>"
     );
@@ -59,5 +59,4 @@ final class XmlAttributesTest {
             )
         );
     }
-
 }


### PR DESCRIPTION
In this PR I added one more unit test for the `XmlAttribute`.

Closes: #595
History:
- **feat(#595): add unit test for XmlAttributes**
- **feat(#595): fix all the code offences**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding unit tests for the `XmlAttributes` class in the `jeo` module.

### Detailed summary
- Added unit tests for the `XmlAttributes` class.
- Added a test case in `XmlAttributesTest` to convert attributes to bytecode.
- Included MIT License in `XmlAttributesTest`.
- Imported necessary classes in `XmlAttributesTest`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->