### PR TITLE
feat(#591): Add Unit Tests for DirectivesAttribute and DirectivesAttributes

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java
@@ -32,10 +32,6 @@ import org.xembly.Directives;
 /**
  * Directives for an attribute.
  * @since 0.4
- * @todo #589:30min Add Unit Tests for DirectivesAttribute class.
- *  DirectivesAttribute class is not covered by unit tests.
- *  Add unit tests for DirectivesAttribute class in order to increase the code coverage
- *  and improve the quality of the code.
  */
 public final class DirectivesAttribute implements Iterable<Directive> {
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
@@ -33,10 +33,6 @@ import org.xembly.Directive;
 /**
  * Directives for attributes.
  * @since 0.4
- * @todo #589:30min Add Unit Tests for DirectivesAttributes class.
- *  DirectivesAttributes class is not covered by unit tests.
- *  Add unit tests for DirectivesAttributes class in order to increase the code coverage
- *  and improve the quality of the code.
  */
 public final class DirectivesAttributes implements Iterable<Directive> {
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation.directives;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.xembly.Directive;
@@ -64,24 +63,8 @@ public final class DirectivesAttributes implements Iterable<Directive> {
         this.attributes = attributes;
     }
 
-    /**
-     * Add attribute.
-     * @param attribute One more attribute.
-     * @return The same directives.
-     */
-    public DirectivesAttributes add(final DirectivesAttribute attribute) {
-        this.attributes.add(attribute);
-        return this;
-    }
-
     @Override
     public Iterator<Directive> iterator() {
-        final Iterator<Directive> result;
-        if (this.attributes.isEmpty()) {
-            result = Collections.emptyIterator();
-        } else {
-            result = new DirectivesSeq("attributes", this.attributes).iterator();
-        }
-        return result;
+        return new DirectivesSeq("attributes", this.attributes).iterator();
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAttributeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAttributeTest.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link DirectivesAttribute}.
+ * @since 0.6
+ */
+final class DirectivesAttributeTest {
+
+    @Test
+    void convertsToXmirWithoutChildren() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect that the attribute will be converted to Xmir as a simple object without children",
+            new Xembler(new DirectivesAttribute("some")).xml(),
+            XhtmlMatchers.hasXPaths("./o[contains(@base, 'some')]")
+        );
+    }
+
+    @Test
+    void convertsToXmirWithChildren() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect that the attribute will be converted to Xmir with children",
+            new Xembler(
+                new DirectivesAttribute(
+                    "children",
+                    new DirectivesData("data")
+                )
+            ).xml(),
+            XhtmlMatchers.hasXPaths(
+                "./o[contains(@base, 'children')]",
+                "./o[contains(@base, 'children')]/o[contains(@base, 'string')]"
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAttributesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAttributesTest.java
@@ -52,5 +52,4 @@ final class DirectivesAttributesTest {
             )
         );
     }
-
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAttributesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAttributesTest.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link DirectivesAttributes}.
+ * @since 0.6
+ */
+final class DirectivesAttributesTest {
+
+    @Test
+    void convertsToXmir() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect that attributes will be converted to Xmir as a sequence of two objects with the name 'attributes'",
+            new Xembler(
+                new DirectivesAttributes(
+                    new DirectivesAttribute("first"),
+                    new DirectivesAttribute("second")
+                )
+            ).xml(),
+            XhtmlMatchers.hasXPaths(
+                "./o[contains(@name, 'attributes') and contains(@base, 'seq2')]",
+                "./o[contains(@base, 'seq2')]/o[contains(@base, 'first')]",
+                "./o[contains(@base, 'seq2')]/o[contains(@base, 'second')]"
+            )
+        );
+    }
+
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -62,6 +62,7 @@ final class DirectivesClassTest {
                     "<o base='org.eolang.jeo.string' data='bytes' name='supername'/>",
                     "<o base='org.eolang.seq0' name='interfaces'/>",
                     "<o base='org.eolang.seq0' name='annotations'/>",
+                    "<o base='org.eolang.seq0' name='attributes'/>",
                     "</o>"
                 )
             )


### PR DESCRIPTION
In this PR I added unit tests for `DirectivesAttribute` and `DirectivesAttributes` classes.

Closes: #591.
History:
- **feat(#591): add tests for DirectivesAttribute**
- **feat(#591): add unit tests for DirectivesAttributes**
- **feat(#591): remove outdated puzzles**
- **feat(#591): simplify DirectivesAttributes test**
- **feat(#591): fix all the code offences**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds unit tests for the `DirectivesAttribute` and `DirectivesAttributes` classes to increase code coverage and improve code quality.

### Detailed summary
- Added unit tests for `DirectivesAttribute` and `DirectivesAttributes` classes
- Improved code coverage and quality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->