### PR TITLE
feat(#634): Remove Redundant Methods from BytecodeAnnotation

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
@@ -151,24 +151,4 @@ public final class BytecodeAnnotation implements BytecodeAnnotationValue {
                 .collect(Collectors.toList())
         );
     }
-
-    /**
-     * Descriptor.
-     * @return Descriptor.
-     */
-    public String descriptor() {
-        return this.descr;
-    }
-
-    /**
-     * Visible.
-     * @return Visible.
-     * @todo #627:30min Remove Getters From {@link BytecodeAnnotation}.
-     *  We opened {@link #descriptor()} and {@link #isVisible()} methods to simplify unit testing.
-     *  However, now we violate encapsulation idea at all.
-     *  It's better to find another way to test correct transformations.
-     */
-    public boolean isVisible() {
-        return this.visible;
-    }
 }


### PR DESCRIPTION
Remove redundant getters from `BytecodeAnnotation`. 
Related to #634.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the `descriptor()` and `isVisible()` getter methods from the `BytecodeAnnotation` class to enhance encapsulation and eliminate unnecessary exposure of internal state.

### Detailed summary
- Removed the `descriptor()` method and its associated Javadoc comment.
- Removed the `isVisible()` method and its associated Javadoc comment, including the `@todo` note.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->