### PR TITLE
feat(#723): Simplify Testing of XML Parsin

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttributes.java
@@ -40,22 +40,31 @@ public final class BytecodeAttributes {
      */
     private final List<BytecodeAttribute> all;
 
+    /**
+     * Constructor.
+     * @param all All attributes.
+     */
     public BytecodeAttributes(final BytecodeAttribute... all) {
         this(Arrays.asList(all));
     }
 
-    public BytecodeAttributes(final List<BytecodeAttribute> all) {
+    /**
+     * Constructor.
+     * @param all All attributes.
+     */
+    private BytecodeAttributes(final List<BytecodeAttribute> all) {
         this.all = all;
     }
 
+    /**
+     * Convert to directives.
+     * @param name Name of the attributes in EO representation.
+     * @return Directives.
+     */
     public Iterable<Directive> directives(final String name) {
         return new DirectivesSeq(
             name,
-            this.all.stream()
-                .map(BytecodeAttribute::directives)
-                .collect(Collectors.toList())
+            this.all.stream().map(BytecodeAttribute::directives).collect(Collectors.toList())
         );
     }
-
-
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttributes.java
@@ -21,35 +21,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.jeo.representation.xmir;
+package org.eolang.jeo.representation.bytecode;
 
-import org.eolang.jeo.representation.bytecode.BytecodeAttributes;
-import org.eolang.jeo.representation.bytecode.InnerClass;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
-import org.xembly.ImpossibleModificationException;
-import org.xembly.Xembler;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eolang.jeo.representation.directives.DirectivesSeq;
+import org.xembly.Directive;
 
 /**
- * Test case for {@link XmlAttributes}.
+ * Bytecode attributes.
  * @since 0.6
  */
-final class XmlAttributesTest {
+public final class BytecodeAttributes {
 
-    @Test
-    void convertsToBytecode() throws ImpossibleModificationException {
-        final InnerClass expected = new InnerClass("name", "outer", "inner", 0);
-        MatcherAssert.assertThat(
-            "We expect the attributes to be converted to a correct bytecode domain class",
-            new XmlAttributes(
-                new XmlNode(
-                    new Xembler(
-                        new BytecodeAttributes(expected).directives("attributes")
-                    ).xml()
-                )
-            ).attributes(),
-            Matchers.contains(expected)
+    /**
+     * All attributes.
+     */
+    private final List<BytecodeAttribute> all;
+
+    public BytecodeAttributes(final BytecodeAttribute... all) {
+        this(Arrays.asList(all));
+    }
+
+    public BytecodeAttributes(final List<BytecodeAttribute> all) {
+        this.all = all;
+    }
+
+    public Iterable<Directive> directives(final String name) {
+        return new DirectivesSeq(
+            name,
+            this.all.stream()
+                .map(BytecodeAttribute::directives)
+                .collect(Collectors.toList())
         );
     }
+
+
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameter.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameter.java
@@ -90,7 +90,7 @@ public final class BytecodeMethodParameter {
      * Convert to directives.
      * @return Directives.
      */
-    Iterable<Directive> directives() {
+    public Iterable<Directive> directives() {
         return new DirectivesMethodParam(
             this.index,
             this.type,

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlAnnotationsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlAnnotationsTest.java
@@ -28,6 +28,8 @@ import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
 
 /**
  * Test case for {@link XmlAnnotations}.
@@ -36,25 +38,15 @@ import org.junit.jupiter.api.Test;
 final class XmlAnnotationsTest {
 
     @Test
-    void parsesXmirAnnotations() {
+    void parsesXmirAnnotations() throws ImpossibleModificationException {
+        final BytecodeAnnotations expected = new BytecodeAnnotations(
+            new BytecodeAnnotation("java/lang/Override", true)
+        );
         MatcherAssert.assertThat(
             "We expect that XMIR annotations are parsed correctly",
-            new XmlAnnotations(
-                new XmlNode(
-                    String.join(
-                        "\n",
-                        "<o name='annotations'>",
-                        "  <o base='org.eolang.jeo.annotation' name='annotation-1015422024-amF2YS9sYW5nL092ZXJyaWRl'>",
-                        "    <o base='org.eolang.jeo.string'><o base='bytes' data='bytes'>6A 61 76 61 2F 6C 61 6E 67 2F 4F 76 65 72 72 69 64 65</o></o>",
-                        "    <o base='org.eolang.jeo.bool'><o base='bytes' data='bytes'>01</o></o>",
-                        "  </o>",
-                        "</o>"
-                    ))).bytecode(),
-            Matchers.equalTo(
-                new BytecodeAnnotations(
-                    new BytecodeAnnotation("java/lang/Override", true)
-                )
-            )
+            new XmlAnnotations(new XmlNode(new Xembler(expected.directives("")).xml()))
+                .bytecode(),
+            Matchers.equalTo(expected)
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlAttributeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlAttributeTest.java
@@ -23,11 +23,14 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import org.eolang.jeo.representation.bytecode.BytecodeAttribute;
 import org.eolang.jeo.representation.bytecode.InnerClass;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
 
 /**
  * Test case for {@link XmlAttribute}.
@@ -35,27 +38,13 @@ import org.junit.jupiter.api.Test;
  */
 final class XmlAttributeTest {
 
-    /**
-     * Example of an inner class in XMIR.
-     */
-    private static final String XMIR = String.join(
-        "\n",
-        "<o base='org.eolang.jeo.inner-class'>",
-        "  <o base='org.eolang.jeo.string'><o base='bytes' data='bytes'>6E 61 6D 65</o></o>",
-        "  <o base='org.eolang.jeo.string'><o base='bytes' data='bytes'>6F 75 74 65 72</o></o>",
-        "  <o base='org.eolang.jeo.string'><o base='bytes' data='bytes'>69 6E 6E 65 72</o></o>",
-        "  <o base='org.eolang.jeo.int'><o base='bytes' data='bytes'>00 00 00 00 00 00 00 00</o></o>",
-        "</o>"
-    );
-
     @Test
-    void convertsToDomainInnerClass() {
+    void convertsToDomainInnerClass() throws ImpossibleModificationException {
+        final BytecodeAttribute expected = new InnerClass("name", "outer", "inner", 0);
         MatcherAssert.assertThat(
             "We expect the attribute to be converted to a correct  domain attribute (inner class)",
-            new XmlAttribute(XmlAttributeTest.XMIR).attribute(),
-            Matchers.equalTo(
-                new InnerClass("name", "outer", "inner", 0)
-            )
+            new XmlAttribute(new Xembler(expected.directives()).xml()).attribute(),
+            Matchers.equalTo(expected)
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlFrameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlFrameTest.java
@@ -28,6 +28,8 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
 
 /**
  * Test case for {@link XmlFrame}.
@@ -37,34 +39,18 @@ import org.objectweb.asm.Opcodes;
 final class XmlFrameTest {
 
     @Test
-    void parsesRawXmirNode() {
+    void parsesRawXmirNode() throws ImpossibleModificationException {
+        final BytecodeFrame expected = new BytecodeFrame(
+            Opcodes.F_NEW,
+            2,
+            new Object[]{"java/lang/Object", Opcodes.LONG},
+            3,
+            new Object[]{"java/lang/String", Opcodes.DOUBLE}
+        );
         MatcherAssert.assertThat(
             "Parsed frame type is not correct.",
-            new XmlFrame(
-                "<?xml version='1.0' encoding='UTF-8'?>\n",
-                "<o base='org.eolang.jeo.frame'>\n",
-                " <o base='org.eolang.jeo.int'><o base='bytes' data='bytes'>FF FF FF FF FF FF FF FF</o></o>\n",
-                " <o base='org.eolang.jeo.int'><o base='bytes' data='bytes'>00 00 00 00 00 00 00 02</o></o>\n",
-                " <o base='org.eolang.jeo.tuple' star=''>\n",
-                "  <o base='org.eolang.jeo.string'><o base='bytes' data='bytes'>6A 61 76 61 2F 6C 61 6E 67 2F 4F 62 6A 65 63 74</o></o>\n",
-                "  <o base='org.eolang.jeo.int'><o base='bytes' data='bytes'>00 00 00 00 00 00 00 04</o></o>\n",
-                " </o>\n",
-                " <o base='org.eolang.jeo.int'><o base='bytes' data='bytes'>00 00 00 00 00 00 00 03</o></o>\n",
-                " <o base='org.eolang.jeo.tuple' star=''>\n",
-                "  <o base='org.eolang.jeo.string'><o base='bytes' data='bytes'>6A 61 76 61 2F 6C 61 6E 67 2F 53 74 72 69 6E 67</o></o>\n",
-                "  <o base='org.eolang.jeo.int'><o base='bytes' data='bytes'>00 00 00 00 00 00 00 03</o></o>\n",
-                " </o>\n",
-                "</o>\n"
-            ).bytecode(),
-            Matchers.equalTo(
-                new BytecodeFrame(
-                    Opcodes.F_NEW,
-                    2,
-                    new Object[]{"java/lang/Object", Opcodes.LONG},
-                    3,
-                    new Object[]{"java/lang/String", Opcodes.DOUBLE}
-                )
-            )
+            new XmlFrame(new Xembler(expected.directives(false)).xml()).bytecode(),
+            Matchers.equalTo(expected)
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import org.eolang.jeo.representation.bytecode.BytecodeInstructionEntry;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -31,44 +32,22 @@ import org.objectweb.asm.Opcodes;
 /**
  * Test case for {@link XmlInstruction}.
  * @since 0.1
- * @todo #715:60min Simplify Xml Transformation Tests
- *  Currently we compare XMLs with their String representations.
- *  It leads to significant efforts to update this XML when the structure changes.
- *  We should use domain classes from {@link org.eolang.jeo.representation.bytecode} package.
- *  We should refactor all "Xml..." tests to use these classes.
  */
 final class XmlInstructionTest {
 
     /**
      * Default instruction which we use for testing.
-     * This XML is compared with all other XMLs.
      */
-    private static final XmlInstruction INSTRUCTION =
-        new XmlInstruction(
-            new StringBuilder()
-                .append("<o base='org.eolang.jeo.opcode' line='999' name='INVOKESPECIAL'>")
-                .append(
-                    "<o base='org.eolang.jeo.int' data='bytes'><o base='bytes' data='bytes'>00 00 00 00 00 00 00 B7</o></o>"
-                )
-                .append(
-                    "<o base='org.eolang.jeo.int' data='bytes'><o base='bytes' data='bytes'>00 00 00 00 00 00 00 01</o></o>"
-                )
-                .append(
-                    "<o base='org.eolang.jeo.int' data='bytes'><o base='bytes' data='bytes'>00 00 00 00 00 00 00 02</o></o>"
-                )
-                .append(
-                    "<o base='org.eolang.jeo.int' data='bytes'><o base='bytes' data='bytes'>00 00 00 00 00 00 00 03</o></o>"
-                )
-                .append("</o>")
-                .toString()
-        );
+    private static final BytecodeInstructionEntry INST = new BytecodeInstructionEntry(
+        Opcodes.INVOKESPECIAL, 1, 2, 3
+    );
 
     @Test
     void comparesSuccessfullyWithSpaces() {
         MatcherAssert.assertThat(
             "Xml Instruction nodes with different empty spaces, but with the same content should be the same, but it wasn't",
-            new XmlInstruction(false, Opcodes.INVOKESPECIAL, 1, 2, 3),
-            Matchers.equalTo(XmlInstructionTest.INSTRUCTION)
+            new XmlInstruction(false, Opcodes.INVOKESPECIAL, 1, 2, 3).bytecode(),
+            Matchers.equalTo(XmlInstructionTest.INST)
         );
     }
 
@@ -77,7 +56,7 @@ final class XmlInstructionTest {
         MatcherAssert.assertThat(
             "Xml Instruction with different arguments should not be equal, but it was",
             new XmlInstruction(Opcodes.INVOKESPECIAL, 32, 23, 14),
-            Matchers.not(Matchers.equalTo(XmlInstructionTest.INSTRUCTION))
+            Matchers.not(Matchers.equalTo(XmlInstructionTest.INST))
         );
     }
 
@@ -86,7 +65,7 @@ final class XmlInstructionTest {
         MatcherAssert.assertThat(
             "Xml Instruction with different child content should not be equal, but it was",
             new XmlInstruction(Opcodes.INVOKESPECIAL),
-            Matchers.not(Matchers.equalTo(XmlInstructionTest.INSTRUCTION))
+            Matchers.not(Matchers.equalTo(XmlInstructionTest.INST))
         );
     }
 
@@ -95,7 +74,7 @@ final class XmlInstructionTest {
         MatcherAssert.assertThat(
             "Xml Instruction with different content should not be equal, but it was",
             new XmlInstruction(Opcodes.DUP),
-            Matchers.not(Matchers.equalTo(XmlInstructionTest.INSTRUCTION))
+            Matchers.not(Matchers.equalTo(XmlInstructionTest.INST))
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlLabelTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlLabelTest.java
@@ -27,6 +27,8 @@ import org.eolang.jeo.representation.bytecode.BytecodeLabel;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
 
 /**
  * Test case for {@link XmlLabel}.
@@ -35,15 +37,16 @@ import org.junit.jupiter.api.Test;
 final class XmlLabelTest {
 
     @Test
-    void retrievesLabelIdentifier() {
+    void retrievesLabelIdentifier() throws ImpossibleModificationException {
+        final BytecodeLabel expected = new BytecodeLabel("some");
         MatcherAssert.assertThat(
             "Can't retrieve correct label identifier",
             new XmlLabel(
                 new XmlNode(
-                    "<o base='org.eolang.jeo.label' data='bytes'>73 6F 6D 65 0A</o>"
+                    new Xembler(expected.directives(false)).xml()
                 )
             ).bytecode(),
-            Matchers.equalTo(new BytecodeLabel("some"))
+            Matchers.equalTo(expected)
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
@@ -26,9 +26,14 @@ package org.eolang.jeo.representation.xmir;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.eolang.jeo.representation.bytecode.BytecodeInstructionEntry;
+import org.eolang.jeo.representation.bytecode.BytecodeLabel;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
 
 /**
  * Test case for {@link XmlNode}.
@@ -89,27 +94,26 @@ final class XmlNodeTest {
     }
 
     @Test
-    void convertsToLabelEntry() {
+    void convertsToLabelEntry() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "Can't convert to label entry",
             new XmlNode(
-                "<o base='org.eolang.jeo.label' data='bytes'>73 6F 6D 65</o>"
+                new Xembler(
+                    new BytecodeLabel("lbl").directives(false)
+                ).xml()
             ).toEntry(),
             Matchers.instanceOf(XmlLabel.class)
         );
     }
 
     @Test
-    void convertsToInstructionEntry() {
+    void convertsToInstructionEntry() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "Can't convert to instruction entry",
             new XmlNode(
-                String.join(
-                    "\n",
-                    "<o base='opcode' line='999' name='ICONST_2-17'>",
-                    "<o base=\"int\" data=\"bytes\">00 00 00 00 00 00 00 05</o>",
-                    "</o>"
-                )
+                new Xembler(
+                    new BytecodeInstructionEntry(Opcodes.ICONST_2).directives(false)
+                ).xml()
             ).toEntry(),
             Matchers.instanceOf(XmlInstruction.class)
         );

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlParamTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlParamTest.java
@@ -28,6 +28,8 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Type;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
 
 /**
  * Test cases for {@link XmlParam}.
@@ -36,15 +38,14 @@ import org.objectweb.asm.Type;
 final class XmlParamTest {
 
     @Test
-    void convertsToBytecode() {
+    void convertsToBytecode() throws ImpossibleModificationException {
+        final BytecodeMethodParameter expected = new BytecodeMethodParameter(0, Type.INT_TYPE);
         MatcherAssert.assertThat(
             "Can't convert XML param to bytecode",
             new XmlParam(
-                new XmlNode("<o base='param' name='param-SQ==-0'/>")
+                new XmlNode(new Xembler(expected.directives()).xml())
             ).bytecode(),
-            Matchers.equalTo(
-                new BytecodeMethodParameter(0, Type.INT_TYPE)
-            )
+            Matchers.equalTo(expected)
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlProgramTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlProgramTest.java
@@ -39,7 +39,6 @@ import org.xembly.Xembler;
 
 /**
  * Test case for {@link XmlProgram}.
- *
  * @since 0.1
  */
 final class XmlProgramTest {

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntryTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntryTest.java
@@ -27,6 +27,8 @@ import org.eolang.jeo.representation.bytecode.BytecodeTryCatchBlock;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
 
 /**
  * Test case for {@link XmlTryCatchEntry}.
@@ -35,44 +37,20 @@ import org.junit.jupiter.api.Test;
 final class XmlTryCatchEntryTest {
 
     @Test
-    void transformsToBytecode() {
+    void transformsToBytecode() throws ImpossibleModificationException {
         final AllLabels labels = new AllLabels();
+        final BytecodeTryCatchBlock block = new BytecodeTryCatchBlock(
+            labels.label("a"),
+            labels.label("b"),
+            labels.label("c"),
+            "java/lang/Exception"
+        );
         MatcherAssert.assertThat(
             "Can't convert XML try-catch entry to the correct bytecode",
             new XmlTryCatchEntry(
-                new XmlNode(
-                    String.join(
-                        "\n",
-                        "<o base='trycatch'>\n",
-                        "  <o base='org.eolang.jeo.label' name='start'><o base='bytes' data='bytes'>30 65 65 66 66 62 37 37 2D 34 64 32 62 2D 34 63 31 38 2D 39 32 32 39 2D 36 32 65 39 66 61 66 39 34 61 34 34</o></o>\n",
-                        "  <o base='org.eolang.jeo.label' name='end'><o base='bytes' data='bytes'>62 31 65 65 38 61 34 32 2D 37 63 39 63 2D 34 63 66 39 2D 61 63 63 65 2D 39 35 62 39 38 36 38 34 34 65 36 35</o></o>\n",
-                        "  <o base='org.eolang.jeo.label' name='handler'><o base='bytes' data='bytes'>62 31 65 65 38 61 34 32 2D 37 63 39 63 2D 34 63 66 39 2D 61 63 63 65 2D 39 35 62 39 38 36 38 34 34 65 36 35</o></o>\n",
-                        "  <o base='org.eolang.jeo.string' name='type'><o base='bytes' data='bytes'>6A 61 76 61 2F 69 6F 2F 49 4F 45 78 63 65 70 74 69 6F 6E</o></o>\n",
-                        "</o>"
-                    )
-                ),
-                labels
+                new XmlNode(new Xembler(block.directives(false)).xml())
             ).bytecode(),
-            Matchers.equalTo(
-                new BytecodeTryCatchBlock(
-                    labels.label(
-                        new HexString(
-                            "30 65 65 66 66 62 37 37 2D 34 64 32 62 2D 34 63 31 38 2D 39 32 32 39 2D 36 32 65 39 66 61 66 39 34 61 34 34"
-                        ).decode()
-                    ),
-                    labels.label(
-                        new HexString(
-                            "62 31 65 65 38 61 34 32 2D 37 63 39 63 2D 34 63 66 39 2D 61 63 63 65 2D 39 35 62 39 38 36 38 34 34 65 36 35"
-                        ).decode()
-                    ),
-                    labels.label(
-                        new HexString(
-                            "62 31 65 65 38 61 34 32 2D 37 63 39 63 2D 34 63 66 39 2D 61 63 63 65 2D 39 35 62 39 38 36 38 34 34 65 36 35"
-                        ).decode()
-                    ),
-                    "java/io/IOException"
-                )
-            )
+            Matchers.equalTo(block)
         );
     }
 }


### PR DESCRIPTION
In this PR I significantly simplified parsing of any `xmir` part. We had to change many tests before when some changes in EO format occured.
Now I significantly simplified tests and future changes will be much easier to provide.

Closes: #723.
History:
- **feat(#723): simplify XmlInstructionTest**
- **feat(#723): simplify XmlAnnotationsTest**
- **feat(#723): simplify XmlAttributesTest**
- **feat(#723): simplify XmlAttributeTest**
- **feat(#723): simplify XmlFrameTest**
- **feat(#723): simplify XmlLabelTest**
- **feat(#723): simplify XmlNodeTest**
- **feat(#723): simplify XmlParamTest**
- **feat(#723): simplify XmlTryCatchEntryTest**
- **feat(#723): fix all the code offences**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `Xml` representation classes by introducing exception handling, improving method visibility, and utilizing the `Xembler` for XML generation. It also refines tests by incorporating expected outcomes based on new bytecode representations.

### Detailed summary
- Changed method visibility of `directives()` in `BytecodeMethodParameter`.
- Added exception handling in test methods across multiple test classes.
- Replaced hardcoded XML strings with `Xembler` generated XML in tests.
- Updated assertions in tests to compare against expected bytecode objects.
- Removed unnecessary static XML examples from `XmlAttributeTest` and `XmlAttributesTest`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->