### PR TITLE
feat(#520): Add BytecodeValue Abstraction

### DIFF
--- a/src/main/java/org/eolang/jeo/Assemble.java
+++ b/src/main/java/org/eolang/jeo/Assemble.java
@@ -56,7 +56,7 @@ public final class Assemble implements Translation {
         final Details details = representation.details();
         final String name = new PrefixedName(details.name()).decode();
         try {
-            final byte[] bytecode = representation.toBytecode().asBytes();
+            final byte[] bytecode = representation.toBytecode().bytes();
             final String[] subpath = name.split("\\.");
             subpath[subpath.length - 1] = String.format("%s.class", subpath[subpath.length - 1]);
             final Path path = Paths.get(this.classes.toString(), subpath);

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -78,7 +78,7 @@ public final class BytecodeRepresentation implements Representation {
      * @param bytecode Bytecode
      */
     public BytecodeRepresentation(final Bytecode bytecode) {
-        this(BytecodeRepresentation.fromBytes(bytecode.asBytes()), "bytecode");
+        this(BytecodeRepresentation.fromBytes(bytecode.bytes()), "bytecode");
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/Bytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/Bytecode.java
@@ -39,22 +39,22 @@ public final class Bytecode {
     /**
      * Bytecode Bytes.
      */
-    private final byte[] bytes;
+    private final byte[] codes;
 
     /**
      * Constructor.
      * @param bytes Bytecode bytes.
      */
     public Bytecode(final byte[] bytes) {
-        this.bytes = Arrays.copyOf(bytes, bytes.length);
+        this.codes = Arrays.copyOf(bytes, bytes.length);
     }
 
     /**
      * Get as bytes.
      * @return Bytecode bytes.
      */
-    public byte[] asBytes() {
-        return Arrays.copyOf(this.bytes, this.bytes.length);
+    public byte[] bytes() {
+        return Arrays.copyOf(this.codes, this.codes.length);
     }
 
     @Override
@@ -66,20 +66,20 @@ public final class Bytecode {
             result = false;
         } else {
             final Bytecode bytecode = (Bytecode) other;
-            result = Arrays.equals(this.bytes, bytecode.bytes);
+            result = Arrays.equals(this.codes, bytecode.codes);
         }
         return result;
     }
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(this.bytes);
+        return Arrays.hashCode(this.codes);
     }
 
     @Override
     public String toString() {
         final StringWriter out = new StringWriter();
-        new ClassReader(this.bytes)
+        new ClassReader(this.codes)
             .accept(new TraceClassVisitor(null, new Textifier(), new PrintWriter(out)), 0);
         return out.toString();
     }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabel.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.bytecode;
 
+import java.nio.charset.StandardCharsets;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.directives.DirectivesLabel;
@@ -48,6 +49,14 @@ public final class BytecodeLabel implements BytecodeEntry {
      * All method labels.
      */
     private final AllLabels labels;
+
+    /**
+     * Constructor.
+     * @param uid Label identifier.
+     */
+    public BytecodeLabel(final byte[] uid) {
+        this(new String(uid, StandardCharsets.UTF_8));
+    }
 
     /**
      * Constructor.

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation.bytecode;
 
 import java.util.Locale;
+import java.util.Optional;
 
 /**
  * Bytecode value.
@@ -75,7 +76,7 @@ public final class BytecodeValue {
      */
     private BytecodeValue(final DataType type, final byte[] bytes) {
         this.vtype = type;
-        this.vbytes = bytes;
+        this.vbytes = Optional.ofNullable(bytes).map(byte[]::clone).orElse(null);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
@@ -28,6 +28,10 @@ public final class BytecodeValue {
     private final DataType type;
     private final byte[] bytes;
 
+    public BytecodeValue(final String type, final byte[] bytes) {
+        this(DataType.find(type), bytes);
+    }
+
     public BytecodeValue(final DataType type, final byte[] bytes) {
         this.type = type;
         this.bytes = bytes;

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
@@ -25,32 +25,86 @@ package org.eolang.jeo.representation.bytecode;
 
 import java.util.Locale;
 
+/**
+ * Bytecode value.
+ * Represents a typed value in bytecode format.
+ * @since 0.6
+ */
 public final class BytecodeValue {
 
+    /**
+     * Data type.
+     */
     private final DataType type;
+
+    /**
+     * Bytes.
+     */
     private final byte[] bytes;
+
+    /**
+     * Constructor.
+     * @param value Value.
+     */
     public BytecodeValue(final Object value) {
-        this(DataType.type(value), DataType.toBytes(value));
+        this(DataType.findByData(value), value);
     }
 
+    /**
+     * Constructor.
+     * @param type Value type.
+     * @param bytes Value bytes.
+     */
     public BytecodeValue(final String type, final byte[] bytes) {
-        this(DataType.find(type), bytes);
+        this(DataType.findByBase(type), bytes);
     }
 
-    public BytecodeValue(final DataType type, final byte[] bytes) {
+    /**
+     * Constructor.
+     * @param type Value type.
+     * @param value Value.
+     */
+    private BytecodeValue(DataType type, Object value) {
+        this(type, type.encode(value));
+    }
+
+    /**
+     * Constructor.
+     * @param type Value type.
+     * @param bytes Value bytes.
+     */
+    private BytecodeValue(final DataType type, final byte[] bytes) {
         this.type = type;
         this.bytes = bytes;
     }
 
+    /**
+     * Represent the value as an object.
+     * @return Object.
+     */
     public Object object() {
         return this.type.decode(this.bytes);
     }
 
+    /**
+     * Retrieve the type of the value.
+     * @return Type.
+     */
     public String type() {
         return this.type.base().toLowerCase(Locale.ROOT);
     }
 
+    /**
+     * Retrieve the bytes of the value.
+     * @return Bytes.
+     */
     public byte[] bytes() {
-        return this.bytes;
+        final byte[] result;
+        if (this.bytes == null) {
+            result = null;
+        } else {
+            result = this.bytes.clone();
+        }
+        return result;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
@@ -40,7 +40,7 @@ public final class BytecodeValue {
     /**
      * Bytes.
      */
-    private final byte[] bytes;
+    private final byte[] vbytes;
 
     /**
      * Constructor.
@@ -64,7 +64,7 @@ public final class BytecodeValue {
      * @param type Value type.
      * @param value Value.
      */
-    private BytecodeValue(DataType type, Object value) {
+    private BytecodeValue(final DataType type, final Object value) {
         this(type, type.encode(value));
     }
 
@@ -75,7 +75,7 @@ public final class BytecodeValue {
      */
     private BytecodeValue(final DataType type, final byte[] bytes) {
         this.type = type;
-        this.bytes = bytes;
+        this.vbytes = bytes;
     }
 
     /**
@@ -83,7 +83,7 @@ public final class BytecodeValue {
      * @return Object.
      */
     public Object object() {
-        return this.type.decode(this.bytes);
+        return this.type.decode(this.vbytes);
     }
 
     /**
@@ -91,7 +91,7 @@ public final class BytecodeValue {
      * @return Type.
      */
     public String type() {
-        return this.type.base().toLowerCase(Locale.ROOT);
+        return this.type.caption().toLowerCase(Locale.ROOT);
     }
 
     /**
@@ -100,10 +100,10 @@ public final class BytecodeValue {
      */
     public byte[] bytes() {
         final byte[] result;
-        if (this.bytes == null) {
+        if (this.vbytes == null) {
             result = null;
         } else {
-            result = this.bytes.clone();
+            result = this.vbytes.clone();
         }
         return result;
     }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
@@ -29,7 +29,6 @@ public final class BytecodeValue {
 
     private final DataType type;
     private final byte[] bytes;
-
     public BytecodeValue(final Object value) {
         this(DataType.type(value), DataType.toBytes(value));
     }
@@ -43,7 +42,7 @@ public final class BytecodeValue {
         this.bytes = bytes;
     }
 
-    public Object asObject() {
+    public Object object() {
         return this.type.decode(this.bytes);
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
@@ -23,10 +23,16 @@
  */
 package org.eolang.jeo.representation.bytecode;
 
+import java.util.Locale;
+
 public final class BytecodeValue {
 
     private final DataType type;
     private final byte[] bytes;
+
+    public BytecodeValue(final Object value) {
+        this(DataType.type(value), DataType.toBytes(value));
+    }
 
     public BytecodeValue(final String type, final byte[] bytes) {
         this(DataType.find(type), bytes);
@@ -39,5 +45,13 @@ public final class BytecodeValue {
 
     public Object asObject() {
         return this.type.decode(this.bytes);
+    }
+
+    public String type() {
+        return this.type.base().toLowerCase(Locale.ROOT);
+    }
+
+    public byte[] bytes() {
+        return this.bytes;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
@@ -35,7 +35,7 @@ public final class BytecodeValue {
     /**
      * Data type.
      */
-    private final DataType type;
+    private final DataType vtype;
 
     /**
      * Bytes.
@@ -74,7 +74,7 @@ public final class BytecodeValue {
      * @param bytes Value bytes.
      */
     private BytecodeValue(final DataType type, final byte[] bytes) {
-        this.type = type;
+        this.vtype = type;
         this.vbytes = bytes;
     }
 
@@ -83,7 +83,7 @@ public final class BytecodeValue {
      * @return Object.
      */
     public Object object() {
-        return this.type.decode(this.vbytes);
+        return this.vtype.decode(this.vbytes);
     }
 
     /**
@@ -91,7 +91,7 @@ public final class BytecodeValue {
      * @return Type.
      */
     public String type() {
-        return this.type.caption().toLowerCase(Locale.ROOT);
+        return this.vtype.caption().toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
@@ -21,41 +21,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.jeo.representation.xmir;
+package org.eolang.jeo.representation.bytecode;
 
-import org.eolang.jeo.representation.bytecode.BytecodeLabel;
-import org.eolang.jeo.representation.bytecode.BytecodeValue;
-import org.eolang.jeo.representation.bytecode.DataType;
-import org.objectweb.asm.Label;
+public final class BytecodeValue {
 
-/**
- * XML representation of bytecode label.
- * @since 0.1
- */
-public final class XmlLabel implements XmlBytecodeEntry {
+    private final DataType type;
+    private final byte[] bytes;
 
-    /**
-     * Label node.
-     */
-    private final XmlNode node;
-
-    /**
-     * Constructor.
-     * @param node Label node.
-     */
-    XmlLabel(final XmlNode node) {
-        this.node = node;
+    public BytecodeValue(final DataType type, final byte[] bytes) {
+        this.type = type;
+        this.bytes = bytes;
     }
 
-    /**
-     * Converts label to bytecode.
-     * @return Bytecode label.
-     */
-    public BytecodeLabel bytecode() {
-        return new BytecodeLabel(
-            (Label) new BytecodeValue(DataType.LABEL, new XmlValue(this.node).bytes()).asObject(),
-            new AllLabels()
-        );
-//        return new BytecodeLabel((Label) DataType.LABEL.decode(this.node.text()), new AllLabels());
+    public Object asObject() {
+        return this.type.decode(this.bytes);
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
@@ -35,10 +35,6 @@ import org.objectweb.asm.Type;
 /**
  * All supported data types.
  * @since 0.3
- * @todo #518:90min Refactor DataType, HexData and HexString classes.
- *  This classes has some sort of intersection in their responsibilities.
- *  We should refactor them to make them more clear and separate. Maybe we can
- *  merge them into one class or split them into more classes.
  */
 public enum DataType {
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
@@ -28,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Function;
-import org.eolang.jeo.representation.directives.JeoFqn;
 import org.eolang.jeo.representation.xmir.AllLabels;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Type;
@@ -224,37 +223,6 @@ public enum DataType {
                     String.format("Unknown data type '%s'", base)
                 )
             );
-    }
-
-    /**
-     * Base fully qualified name.
-     * @return FQN.
-     */
-    public String fqn() {
-        return new JeoFqn(this.base).fqn();
-    }
-
-    /**
-     * Convert bytes to data.
-     * @param raw Bytes.
-     * @return Data.
-     */
-    public Object decode(final String raw) {
-        final Object result;
-        if (raw == null) {
-            result = null;
-        } else {
-            final char[] chars = raw.trim().replace(" ", "").toCharArray();
-            final int length = chars.length;
-            final byte[] res = new byte[length / 2];
-            for (int index = 0; index < length; index += 2) {
-                res[index / 2] = (byte) Integer.parseInt(
-                    String.copyValueOf(new char[]{chars[index], chars[index + 1]}), 16
-                );
-            }
-            result = this.decode(res);
-        }
-        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
@@ -213,8 +213,7 @@ public enum DataType {
      * @param base Base type.
      * @return Type.
      */
-    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
-    public static DataType find(final String base) {
+    static DataType findByBase(final String base) {
         return Arrays.stream(DataType.values())
             .filter(type -> type.base.equals(base))
             .findFirst()
@@ -226,73 +225,11 @@ public enum DataType {
     }
 
     /**
-     * Get a type for some data.
-     * @param data Some data.
-     * @return Type.
-     */
-    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
-    public static String type(final Object data) {
-        return DataType.from(data).base;
-    }
-
-    /**
-     * Convert data to hex.
-     * @param data Data.
-     * @return Hex representation of data.
-     */
-    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
-    public static byte[] toBytes(final Object data) {
-        return DataType.from(data).encode(data);
-    }
-
-    /**
-     * Convert boolean to bytes.
-     * @param data Boolean.
-     * @return Bytes.
-     */
-    private static byte[] hexBoolean(final boolean data) {
-        final byte[] result;
-        if (data) {
-            result = new byte[]{0x01};
-        } else {
-            result = new byte[]{0x00};
-        }
-        return result;
-    }
-
-    /**
-     * Encode data.
-     * @param data Data.
-     * @return Encoded data.
-     */
-    private byte[] encode(final Object data) {
-        return Optional.ofNullable(data).map(this.encoder).orElse(null);
-    }
-
-    /**
-     * Decode data.
-     * @param data Data.
-     * @return Decoded data.
-     */
-    Object decode(final byte[] data) {
-        return Optional.ofNullable(data).map(this.decoder).orElse(null);
-    }
-
-    /**
-     * Convert class name to bytes.
-     * @param name Class name.
-     * @return Bytes.
-     */
-    private static byte[] hexClass(final String name) {
-        return name.replace('.', '/').getBytes(StandardCharsets.UTF_8);
-    }
-
-    /**
-     * Get a data type for some data.
+     * Find a type by data.
      * @param data Data.
      * @return Data type.
      */
-    private static DataType from(final Object data) {
+    static DataType findByData(final Object data) {
         final DataType result;
         if (data == null) {
             result = DataType.NULL;
@@ -316,6 +253,56 @@ public enum DataType {
     }
 
     /**
+     * Type name.
+     * @return Type name.
+     */
+    String base() {
+        return this.base;
+    }
+
+    /**
+     * Encode data.
+     * @param data Data.
+     * @return Encoded data.
+     */
+    byte[] encode(final Object data) {
+        return Optional.ofNullable(data).map(this.encoder).orElse(null);
+    }
+
+    /**
+     * Decode data.
+     * @param data Data.
+     * @return Decoded data.
+     */
+    Object decode(final byte[] data) {
+        return Optional.ofNullable(data).map(this.decoder).orElse(null);
+    }
+
+    /**
+     * Convert class name to bytes.
+     * @param name Class name.
+     * @return Bytes.
+     */
+    private static byte[] hexClass(final String name) {
+        return name.replace('.', '/').getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Convert boolean to bytes.
+     * @param data Boolean.
+     * @return Bytes.
+     */
+    private static byte[] hexBoolean(final boolean data) {
+        final byte[] result;
+        if (data) {
+            result = new byte[]{0x01};
+        } else {
+            result = new byte[]{0x00};
+        }
+        return result;
+    }
+
+    /**
      * Convert type to bytes.
      * @param value Type.
      * @return Bytes.
@@ -328,9 +315,5 @@ public enum DataType {
                 String.format("Failed to get class name for %s", value), exception
             );
         }
-    }
-
-    public String base() {
-        return this.base;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
@@ -361,4 +361,8 @@ public enum DataType {
             );
         }
     }
+
+    public String base() {
+        return this.base;
+    }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
@@ -306,7 +306,7 @@ public enum DataType {
      * @param data Data.
      * @return Decoded data.
      */
-    private Object decode(final byte[] data) {
+    Object decode(final byte[] data) {
         return Optional.ofNullable(data).map(this.decoder).orElse(null);
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
@@ -217,7 +217,7 @@ public enum DataType {
     @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
     public static DataType find(final String base) {
         return Arrays.stream(DataType.values())
-            .filter(type -> type.fqn().equals(base))
+            .filter(type -> type.base.equals(base))
             .findFirst()
             .orElseThrow(
                 () -> new IllegalArgumentException(

--- a/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
@@ -256,7 +256,7 @@ public enum DataType {
      * Type name.
      * @return Type name.
      */
-    String base() {
+    String caption() {
         return this.base;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -57,7 +57,7 @@ public final class DirectivesValue implements Iterable<Directive> {
     /**
      * Type.
      */
-    private final String type;
+    private final String vtype;
 
     /**
      * Bytes.
@@ -100,7 +100,7 @@ public final class DirectivesValue implements Iterable<Directive> {
      */
     public DirectivesValue(final String name, final String type, final byte[] bytes) {
         this.name = name;
-        this.type = type;
+        this.vtype = type;
         this.bytes = bytes.clone();
     }
 
@@ -126,7 +126,7 @@ public final class DirectivesValue implements Iterable<Directive> {
      * @return Type
      */
     String type() {
-        return this.type;
+        return this.vtype;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -101,7 +101,7 @@ public final class DirectivesValue implements Iterable<Directive> {
     public DirectivesValue(final String name, final String type, final byte[] bytes) {
         this.name = name;
         this.type = type;
-        this.bytes = bytes;
+        this.bytes = bytes.clone();
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
+import java.util.Optional;
 import lombok.ToString;
 import org.eolang.jeo.representation.bytecode.BytecodeValue;
 import org.xembly.Directive;
@@ -101,7 +102,7 @@ public final class DirectivesValue implements Iterable<Directive> {
     public DirectivesValue(final String name, final String type, final byte[] bytes) {
         this.name = name;
         this.vtype = type;
-        this.bytes = bytes.clone();
+        this.bytes = Optional.ofNullable(bytes).map(byte[]::clone).orElse(null);
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -50,19 +50,19 @@ public final class DirectivesValue implements Iterable<Directive> {
     private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 
     /**
-     * Data.
-     */
-//    private final Object data;
-
-    /**
      * Name.
      */
     private final String name;
 
+    /**
+     * Type.
+     */
     private final String type;
 
+    /**
+     * Bytes.
+     */
     private final byte[] bytes;
-
 
     /**
      * Constructor.
@@ -83,6 +83,11 @@ public final class DirectivesValue implements Iterable<Directive> {
         this(name, new BytecodeValue(data));
     }
 
+    /**
+     * Constructor.
+     * @param name Name.
+     * @param value Value.
+     */
     public DirectivesValue(final String name, final BytecodeValue value) {
         this(name, value.type(), value.bytes());
     }
@@ -114,7 +119,6 @@ public final class DirectivesValue implements Iterable<Directive> {
      */
     String hex() {
         return DirectivesValue.bytesToHex(this.bytes);
-//        return DirectivesValue.bytesToHex(DataType.toBytes(this.data));
     }
 
     /**
@@ -123,7 +127,6 @@ public final class DirectivesValue implements Iterable<Directive> {
      */
     String type() {
         return this.type;
-//        return DataType.type(this.data);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -25,7 +25,7 @@ package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
 import lombok.ToString;
-import org.eolang.jeo.representation.bytecode.DataType;
+import org.eolang.jeo.representation.bytecode.BytecodeValue;
 import org.xembly.Directive;
 
 /**
@@ -52,12 +52,17 @@ public final class DirectivesValue implements Iterable<Directive> {
     /**
      * Data.
      */
-    private final Object data;
+//    private final Object data;
 
     /**
      * Name.
      */
     private final String name;
+
+    private final String type;
+
+    private final byte[] bytes;
+
 
     /**
      * Constructor.
@@ -75,8 +80,23 @@ public final class DirectivesValue implements Iterable<Directive> {
      * @param <T> Data type.
      */
     public <T> DirectivesValue(final String name, final T data) {
-        this.data = data;
+        this(name, new BytecodeValue(data));
+    }
+
+    public DirectivesValue(final String name, final BytecodeValue value) {
+        this(name, value.type(), value.bytes());
+    }
+
+    /**
+     * Constructor.
+     * @param name Name.
+     * @param type Type.
+     * @param bytes Bytes.
+     */
+    public DirectivesValue(final String name, final String type, final byte[] bytes) {
         this.name = name;
+        this.type = type;
+        this.bytes = bytes;
     }
 
     @Override
@@ -93,7 +113,8 @@ public final class DirectivesValue implements Iterable<Directive> {
      * @return Value
      */
     String hex() {
-        return DirectivesValue.bytesToHex(DataType.toBytes(this.data));
+        return DirectivesValue.bytesToHex(this.bytes);
+//        return DirectivesValue.bytesToHex(DataType.toBytes(this.data));
     }
 
     /**
@@ -101,7 +122,8 @@ public final class DirectivesValue implements Iterable<Directive> {
      * @return Type
      */
     String type() {
-        return DataType.type(this.data);
+        return this.type;
+//        return DataType.type(this.data);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
@@ -52,10 +52,12 @@ public final class XmlLabel implements XmlBytecodeEntry {
      * @return Bytecode label.
      */
     public BytecodeLabel bytecode() {
-        return new BytecodeLabel(
-            (Label) new BytecodeValue(DataType.LABEL, new XmlValue(this.node).bytes()).asObject(),
-            new AllLabels()
-        );
+//        return new BytecodeLabel(
+//            (Label) new BytecodeValue(DataType.LABEL, new XmlValue(this.node).bytes()).asObject(),
+//            new AllLabels()
+//        );
+        return new BytecodeLabel(new XmlValue(this.node).bytes());
+
 //        return new BytecodeLabel((Label) DataType.LABEL.decode(this.node.text()), new AllLabels());
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
@@ -24,9 +24,6 @@
 package org.eolang.jeo.representation.xmir;
 
 import org.eolang.jeo.representation.bytecode.BytecodeLabel;
-import org.eolang.jeo.representation.bytecode.BytecodeValue;
-import org.eolang.jeo.representation.bytecode.DataType;
-import org.objectweb.asm.Label;
 
 /**
  * XML representation of bytecode label.
@@ -52,12 +49,6 @@ public final class XmlLabel implements XmlBytecodeEntry {
      * @return Bytecode label.
      */
     public BytecodeLabel bytecode() {
-//        return new BytecodeLabel(
-//            (Label) new BytecodeValue(DataType.LABEL, new XmlValue(this.node).bytes()).asObject(),
-//            new AllLabels()
-//        );
         return new BytecodeLabel(new XmlValue(this.node).bytes());
-
-//        return new BytecodeLabel((Label) DataType.LABEL.decode(this.node.text()), new AllLabels());
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -218,14 +218,6 @@ public final class XmlNode {
     }
 
     /**
-     * Convert to XML document.
-     * @return XML document.
-     */
-    XMLDocument asDocument() {
-        return new XMLDocument(this.node);
-    }
-
-    /**
      * Get optional child node.
      * @param name Child node name.
      * @return Child node.

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlOperand.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlOperand.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation.xmir;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.eolang.jeo.representation.bytecode.DataType;
 import org.eolang.jeo.representation.directives.JeoFqn;
 
 /**
@@ -71,13 +70,22 @@ public final class XmlOperand {
         } else if (new JeoFqn("annotation").fqn().equals(base)) {
             result = new XmlAnnotation(this.raw).bytecode();
         } else if (new JeoFqn("annotation-property").fqn().equals(base)) {
-            final XmlAnnotationProperty xml = new XmlAnnotationProperty(this.raw);
-            result = xml.bytecode();
+            result = new XmlAnnotationProperty(this.raw).bytecode();
         } else {
-            final DataType type = DataType.find(base);
-            result = this.raw.children().findFirst()
-                .map(bytes -> type.decode(bytes.text()))
-                .orElse(null);
+            final int i = base.lastIndexOf('.');
+            final String clear = i == -1 ? base : base.substring(i + 1);
+            result = new XmlValue(this.raw).object();
+
+//            result = this.raw.children().findFirst()
+//                .map(XmlValue::new)
+//                .map(value -> value.object(clear))
+//                .orElse(null);
+//
+
+            //            final DataType type = DataType.find(base);
+//            result = this.raw.children().findFirst()
+//                .map(bytes -> type.decode(bytes.text()))
+//                .orElse(null);
         }
         return result;
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlOperand.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlOperand.java
@@ -72,20 +72,7 @@ public final class XmlOperand {
         } else if (new JeoFqn("annotation-property").fqn().equals(base)) {
             result = new XmlAnnotationProperty(this.raw).bytecode();
         } else {
-            final int i = base.lastIndexOf('.');
-            final String clear = i == -1 ? base : base.substring(i + 1);
             result = new XmlValue(this.raw).object();
-
-//            result = this.raw.children().findFirst()
-//                .map(XmlValue::new)
-//                .map(value -> value.object(clear))
-//                .orElse(null);
-//
-
-            //            final DataType type = DataType.find(base);
-//            result = this.raw.children().findFirst()
-//                .map(bytes -> type.decode(bytes.text()))
-//                .orElse(null);
         }
         return result;
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
@@ -138,7 +138,7 @@ public final class XmlValue {
     public Object object() {
         final String base = this.base();
         final Object result;
-        if (base.equals("string")) {
+        if ("string".equals(base)) {
             result = this.string();
         } else {
             result = new BytecodeValue(base, this.bytes()).object();

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
@@ -136,22 +136,14 @@ public final class XmlValue {
      * @return Object.
      */
     public Object object() {
-        final String base = this.node.attribute("base")
-            .orElseThrow(
-                () -> new IllegalStateException(
-                    String.format(
-                        "'%s' is not an argument because it doesn't have 'base' attribute",
-                        this.node
-                    )
-                )
-            );
-        final int i = base.lastIndexOf('.');
-        final String clear = i == -1 ? base : base.substring(i + 1);
-        if (clear.equals("string")) {
-            return this.string();
+        final String base = this.base();
+        final Object result;
+        if (base.equals("string")) {
+            result = this.string();
+        } else {
+            result = new BytecodeValue(base, this.bytes()).object();
         }
-        final byte[] bytes = this.bytes();
-        return new BytecodeValue(clear, bytes).asObject();
+        return result;
     }
 
     /**
@@ -162,5 +154,29 @@ public final class XmlValue {
      */
     private String hex() {
         return XmlValue.SPACE.matcher(this.node.firstChild().text().trim()).replaceAll("");
+    }
+
+    /**
+     * Get the type of the object without a package.
+     * @return Type without package.
+     */
+    private String base() {
+        final String base = this.node.attribute("base")
+            .orElseThrow(
+                () -> new IllegalStateException(
+                    String.format(
+                        "'%s' is not an argument because it doesn't have 'base' attribute",
+                        this.node
+                    )
+                )
+            );
+        final String result;
+        final int last = base.lastIndexOf('.');
+        if (last == -1) {
+            result = base;
+        } else {
+            result = base.substring(last + 1);
+        }
+        return result;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
@@ -26,6 +26,7 @@ package org.eolang.jeo.representation.xmir;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.eolang.jeo.representation.bytecode.BytecodeValue;
 
 /**
  * XML value.
@@ -128,6 +129,29 @@ public final class XmlValue {
             }
         }
         return res;
+    }
+
+    /**
+     * Convert hex string to an object.
+     * @return Object.
+     */
+    public Object object() {
+        final String base = this.node.attribute("base")
+            .orElseThrow(
+                () -> new IllegalStateException(
+                    String.format(
+                        "'%s' is not an argument because it doesn't have 'base' attribute",
+                        this.node
+                    )
+                )
+            );
+        final int i = base.lastIndexOf('.');
+        final String clear = i == -1 ? base : base.substring(i + 1);
+        if (clear.equals("string")) {
+            return this.string();
+        }
+        final byte[] bytes = this.bytes();
+        return new BytecodeValue(clear, bytes).asObject();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation.xmir;
 
 import java.util.Arrays;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -36,6 +37,11 @@ public final class XmlValue {
      * Hex radix.
      */
     private static final int RADIX = 16;
+
+    /**
+     * Space pattern.
+     */
+    private static final Pattern SPACE = Pattern.compile(" ");
 
     /**
      * XML node.
@@ -103,12 +109,34 @@ public final class XmlValue {
     }
 
     /**
+     * Convert hex string to a byte array.
+     * @return Byte array.
+     */
+    public byte[] bytes() {
+        final String hex = this.hex();
+        final byte[] res;
+        if (hex.isEmpty()) {
+            res = null;
+        } else {
+            final char[] chars = hex.toCharArray();
+            final int length = chars.length;
+            res = new byte[length / 2];
+            for (int index = 0; index < length; index += 2) {
+                res[index / 2] = (byte) Integer.parseInt(
+                    String.copyValueOf(new char[]{chars[index], chars[index + 1]}), XmlValue.RADIX
+                );
+            }
+        }
+        return res;
+    }
+
+    /**
      * Hex string.
      * Example:
      * - "20 57 6F 72 6C 64 21" -> "20576F726C6421"
      * @return Hex string.
      */
     private String hex() {
-        return this.node.firstChild().text().trim().replaceAll(" ", "");
+        return XmlValue.SPACE.matcher(this.node.firstChild().text().trim()).replaceAll("");
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/ClassNameVisitorTest.java
+++ b/src/test/java/org/eolang/jeo/representation/ClassNameVisitorTest.java
@@ -40,7 +40,7 @@ final class ClassNameVisitorTest {
     void retrievesClassName() {
         final ClassNameVisitor name = new ClassNameVisitor();
         final String expected = "representation/asm/ClassNameTest";
-        new ClassReader(new BytecodeProgram(new BytecodeClass(expected)).bytecode().asBytes())
+        new ClassReader(new BytecodeProgram(new BytecodeClass(expected)).bytecode().bytes())
             .accept(name, 0);
         MatcherAssert.assertThat(
             "Can't retrieve class name, or it's incorrect",

--- a/src/test/java/org/eolang/jeo/representation/asm/AsmProgramTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/AsmProgramTest.java
@@ -49,7 +49,7 @@ final class AsmProgramTest {
             .bytecode();
         MatcherAssert.assertThat(
             "We expect to receive the same bytecode",
-            new AsmProgram(same.asBytes()).bytecode().bytecode(),
+            new AsmProgram(same.bytes()).bytecode().bytecode(),
             Matchers.equalTo(same)
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeTest.java
@@ -39,7 +39,7 @@ final class BytecodeTest {
         final byte[] expected = {1, 2, 3};
         MatcherAssert.assertThat(
             "Bytecode should remain the same as we pass to the constructor",
-            new Bytecode(expected).asBytes(),
+            new Bytecode(expected).bytes(),
             Matchers.equalTo(expected)
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeValueTest.java
@@ -1,0 +1,32 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.bytecode;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BytecodeValueTest {
+
+
+
+}

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeValueTest.java
@@ -35,9 +35,9 @@ import org.objectweb.asm.Type;
 /**
  * Test case for {@link BytecodeValue}.
  * @since 0.6
+ * @checkstyle ParameterNumberCheck (500 lines)
  */
 final class BytecodeValueTest {
-
 
     @ParameterizedTest
     @MethodSource("arguments")
@@ -148,7 +148,9 @@ final class BytecodeValueTest {
             Arguments.of(
                 new BytecodeValue(BytecodeValue.class),
                 "class",
-                "org/eolang/jeo/representation/bytecode/BytecodeValue".getBytes(StandardCharsets.UTF_8),
+                "org/eolang/jeo/representation/bytecode/BytecodeValue".getBytes(
+                    StandardCharsets.UTF_8
+                ),
                 "org/eolang/jeo/representation/bytecode/BytecodeValue"
             ),
             Arguments.of(

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeValueTest.java
@@ -23,10 +23,146 @@
  */
 package org.eolang.jeo.representation.bytecode;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.objectweb.asm.Type;
 
-class BytecodeValueTest {
+/**
+ * Test case for {@link BytecodeValue}.
+ * @since 0.6
+ */
+final class BytecodeValueTest {
 
 
+    @ParameterizedTest
+    @MethodSource("arguments")
+    void convertsToBytes(
+        final BytecodeValue value,
+        final String type,
+        final byte[] bytes,
+        final Object object
+    ) {
+        MatcherAssert.assertThat(
+            "We expect that value will be converted to bytes correctly",
+            value.bytes(),
+            Matchers.equalTo(bytes)
+        );
+    }
 
+    @ParameterizedTest
+    @MethodSource("arguments")
+    void detectsType(
+        final BytecodeValue value,
+        final String type,
+        final byte[] bytes,
+        final Object object
+    ) {
+        MatcherAssert.assertThat(
+            "We expect that type will be detected correctly",
+            value.type(),
+            Matchers.equalTo(type)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("arguments")
+    void retrievesObject(
+        final BytecodeValue value,
+        final String type,
+        final byte[] bytes,
+        final Object object
+    ) {
+        MatcherAssert.assertThat(
+            "We expect that object will be retrieved from the value",
+            value.object(),
+            Matchers.equalTo(object)
+        );
+    }
+
+    /**
+     * Arguments for the tests.
+     * Used in these tests:
+     * @return Arguments.
+     */
+    static Stream<Arguments> arguments() {
+        return Stream.of(
+            Arguments.of(
+                new BytecodeValue(42),
+                "int",
+                new byte[]{0, 0, 0, 0, 0, 0, 0, 42},
+                42
+            ),
+            Arguments.of(
+                new BytecodeValue(42L),
+                "long",
+                new byte[]{0, 0, 0, 0, 0, 0, 0, 42},
+                42L
+            ),
+            Arguments.of(
+                new BytecodeValue(42.0),
+                "double",
+                new byte[]{64, 69, 0, 0, 0, 0, 0, 0},
+                42.0
+            ),
+            Arguments.of(
+                new BytecodeValue(42.0f),
+                "float",
+                new byte[]{66, 40, 0, 0},
+                42.0f
+            ),
+            Arguments.of(
+                new BytecodeValue(true),
+                "bool",
+                new byte[]{1},
+                true
+            ),
+            Arguments.of(
+                new BytecodeValue(false),
+                "bool",
+                new byte[]{0},
+                false
+            ),
+            Arguments.of(
+                new BytecodeValue("Hello!"),
+                "string",
+                new byte[]{72, 101, 108, 108, 111, 33},
+                "Hello!"
+            ),
+            Arguments.of(
+                new BytecodeValue(new byte[]{1, 2, 3}),
+                "bytes",
+                new byte[]{1, 2, 3},
+                new byte[]{1, 2, 3}
+            ),
+            Arguments.of(
+                new BytecodeValue(' '),
+                "char",
+                new byte[]{0, 32},
+                ' '
+            ),
+            Arguments.of(
+                new BytecodeValue(BytecodeValue.class),
+                "class",
+                "org/eolang/jeo/representation/bytecode/BytecodeValue".getBytes(StandardCharsets.UTF_8),
+                "org/eolang/jeo/representation/bytecode/BytecodeValue"
+            ),
+            Arguments.of(
+                new BytecodeValue(Type.INT_TYPE),
+                "type",
+                "I".getBytes(StandardCharsets.UTF_8),
+                Type.INT_TYPE
+            ),
+            Arguments.of(
+                new BytecodeValue(null),
+                "nullable",
+                null,
+                null
+            )
+        );
+    }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationAnnotationValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationAnnotationValueTest.java
@@ -27,7 +27,6 @@ import com.jcabi.matchers.XhtmlMatchers;
 import java.util.Collections;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotationAnnotationValue;
-import org.eolang.jeo.representation.bytecode.DataType;
 import org.eolang.jeo.representation.xmir.XmlAnnotationProperty;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.hamcrest.MatcherAssert;
@@ -50,7 +49,7 @@ final class DirectivesAnnotationAnnotationValueTest {
             new Xembler(
                 new DirectivesAnnotationAnnotationValue(
                     "name",
-                    Type.getDescriptor(DataType.class),
+                    Type.getDescriptor(String.class),
                     Collections.singletonList(new DirectivesPlainAnnotationValue())
                 )
             ).xml(),

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesEnumAnnotationValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesEnumAnnotationValueTest.java
@@ -24,8 +24,8 @@
 package org.eolang.jeo.representation.directives;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import java.time.DayOfWeek;
 import org.eolang.jeo.representation.bytecode.BytecodeEnumAnnotationValue;
-import org.eolang.jeo.representation.bytecode.DataType;
 import org.eolang.jeo.representation.xmir.XmlAnnotationProperty;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.hamcrest.MatcherAssert;
@@ -47,7 +47,7 @@ final class DirectivesEnumAnnotationValueTest {
             "Can't create an enum property with a name and a value",
             new Xembler(
                 new DirectivesEnumAnnotationValue(
-                    "name", Type.getDescriptor(DataType.class), "BOOL"
+                    "name", Type.getDescriptor(DayOfWeek.class), "MONDAY"
                 )
             ).xml(),
             XhtmlMatchers.hasXPaths(

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation.directives;
 
 import java.util.stream.Stream;
 import org.eolang.jeo.matchers.SameXml;
-import org.eolang.jeo.representation.bytecode.DataType;
 import org.eolang.jeo.representation.xmir.AllLabels;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -74,15 +73,6 @@ final class DirectivesValueTest {
             new SameXml(
                 "<o base='org.eolang.jeo.label'><o base='bytes' data='bytes'>73 6F 6D 65 2D 72 61 6E 64 6F 6D</o></o>"
             )
-        );
-    }
-
-    @Test
-    void decodesLabel() {
-        MatcherAssert.assertThat(
-            "Decodes label from XML",
-            DataType.find("org.eolang.jeo.label").decode("73 6F 6D 65 2D 72 61 6E 64 6F 6D"),
-            Matchers.equalTo(new AllLabels().label("some-random"))
         );
     }
 
@@ -150,19 +140,6 @@ final class DirectivesValueTest {
         );
     }
 
-    @ParameterizedTest
-    @MethodSource("encodedValues")
-    void decodesEncodesCorrectly(final Object origin, final String hex) {
-        MatcherAssert.assertThat(
-            "Decoding and encoding are not consistent",
-            origin,
-            Matchers.equalTo(
-                DataType.find(
-                    new JeoFqn(new DirectivesValue(origin).type()).fqn()
-                ).decode(hex)
-            )
-        );
-    }
 
     @Test
     void encodesType() {
@@ -211,24 +188,5 @@ final class DirectivesValueTest {
         );
     }
 
-    /**
-     * Arguments for {@link DirectivesValueTest#decodesEncodesCorrectly(Object, String)}.
-     * @return Stream of arguments.
-     */
-    static Stream<Arguments> encodedValues() {
-        return Stream.of(
-            Arguments.of(10, "00 00 00 00 00 00 00 0A"),
-            Arguments.of("Hello!", "48 65 6C 6C 6F 21"),
-            Arguments.of(new byte[]{1, 2, 3}, "01 02 03"),
-            Arguments.of('a', "00 61"),
-            Arguments.of(true, "01"),
-            Arguments.of(false, "00"),
-            Arguments.of(0.1d, "3F B9 99 99 99 99 99 9A"),
-            Arguments.of(
-                "org/eolang/jeo/representation/HexDataTest",
-                "6F 72 67 2F 65 6F 6C 61 6E 67 2F 6A 65 6F 2F 72 65 70 72 65 73 65 6E 74 61 74 69 6F 6E 2F 48 65 78 44 61 74 61 54 65 73 74"
-            ),
-            Arguments.of(new AllLabels().label("some"), "73 6F 6D 65")
-        );
-    }
+
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
@@ -140,7 +140,6 @@ final class DirectivesValueTest {
         );
     }
 
-
     @Test
     void encodesType() {
         final String value = new DirectivesValue(Type.INT_TYPE).hex();
@@ -187,6 +186,4 @@ final class DirectivesValueTest {
             )
         );
     }
-
-
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValuesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValuesTest.java
@@ -46,5 +46,4 @@ final class DirectivesValuesTest {
             )
         );
     }
-
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlFieldTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlFieldTest.java
@@ -85,15 +85,13 @@ final class XmlFieldTest {
         final int access = Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL;
         final String name = "serialVersionUID";
         final String descriptor = "Ljava/lang/String;";
-        final String xml = new Xembler(
-            new DirectivesField(access, name, descriptor, null, value)
-        ).xml();
-        System.out.println(xml);
         MatcherAssert.assertThat(
             "We expect the value to be the same",
             new XmlField(
                 new XmlNode(
-                    xml
+                    new Xembler(
+                        new DirectivesField(access, name, descriptor, null, value)
+                    ).xml()
                 )
             ).bytecode(),
             Matchers.equalTo(

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlFieldTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlFieldTest.java
@@ -85,13 +85,15 @@ final class XmlFieldTest {
         final int access = Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL;
         final String name = "serialVersionUID";
         final String descriptor = "Ljava/lang/String;";
+        final String xml = new Xembler(
+            new DirectivesField(access, name, descriptor, null, value)
+        ).xml();
+        System.out.println(xml);
         MatcherAssert.assertThat(
             "We expect the value to be the same",
             new XmlField(
                 new XmlNode(
-                    new Xembler(
-                        new DirectivesField(access, name, descriptor, null, value)
-                    ).xml()
+                    xml
                 )
             ).bytecode(),
             Matchers.equalTo(

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlValueTest.java
@@ -23,9 +23,15 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import java.util.stream.Stream;
+import org.eolang.jeo.representation.directives.DirectivesValue;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.xembly.Xembler;
 
 /**
  * Test case for {@link XmlValue}.
@@ -47,6 +53,38 @@ final class XmlValueTest {
             ),
             actual,
             Matchers.is(expected)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("values")
+    void decodesEncodesCorrectly(final Object origin) {
+        MatcherAssert.assertThat(
+            "Decoding and encoding are not consistent",
+            new XmlValue(
+                new XmlNode(new Xembler(new DirectivesValue(origin)).xmlQuietly())
+            ).object(),
+            Matchers.equalTo(origin)
+        );
+    }
+
+    /**
+     * Arguments for {@link XmlValue#decodesEncodesCorrectly(Object, String)}.
+     * @return Stream of arguments.
+     */
+    static Stream<Arguments> values() {
+        return Stream.of(
+            Arguments.of(10),
+            Arguments.of("Hello!"),
+            Arguments.of(new byte[]{1, 2, 3}),
+            Arguments.of('a'),
+            Arguments.of(true),
+            Arguments.of(false),
+            Arguments.of(0.1d),
+            Arguments.of(
+                "org/eolang/jeo/representation/HexDataTest"
+            ),
+            Arguments.of(new AllLabels().label("some"))
         );
     }
 }


### PR DESCRIPTION
In this PR I hide all the usages of the `DataType` class and use `BytecodeValue` instead.
Also, I added comprehensive unit testing for the `BytecodeValue` class.

Closes: #520.
History:
- **feat(#520): try to remove DataType from XmlLabel**
- **feat(#520): simplify XmlLabel even more**
- **feat(#520): hide DataType from several more places**
- **feat(#520): remove DataType from all the production classes**
- **feat(#520): remove DataType usages at all**
- **feat(#520): repair all the tests**
- **feat(#520): add javadocs for BytecodeValue**
- **feat(#520): properly test BytecodeValue**
- **feat(#520): fix all the code offences**
- **feat(#520): remove the puzzle for #520 issue**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `Bytecode` and `DataType` classes, enhancing the handling of bytecode representations, and improving the `DirectivesValue` class. It also introduces new tests and modifies existing ones for better consistency and clarity.

### Detailed summary
- Removed `asDocument()` method in `XmlNode`.
- Renamed `asBytes()` to `bytes()` in multiple classes.
- Added `bytes()` method to `XmlValue`.
- Introduced `BytecodeValue` class for typed bytecode values.
- Updated `DataType` methods for better clarity and functionality.
- Improved tests for `DirectivesValue` and `BytecodeValue`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->