### PR TITLE
feat(#540): Compute Max Locals And Stack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,7 @@ SOFTWARE.
             <configuration>
               <license>file:${basedir}/LICENSE.txt</license>
               <excludes>
-                <exclude>checkstyle:.*/BytecodeInstructionEntry.java</exclude>
+                <exclude>checkstyle:.*/BytecodeInstruction.java</exclude>
                 <exclude>pmd:/src/test/resources/.*</exclude>
                 <exclude>pmd:/src/it/.*</exclude>
                 <exclude>checkstyle:/src/site/.*</exclude>

--- a/src/it/spring-fat/verify.groovy
+++ b/src/it/spring-fat/verify.groovy
@@ -23,8 +23,8 @@
  */
 //Check logs first.
 String log = new File(basedir, 'build.log').text;
-assert log.contains("BUILD SUCCESS")
-assert log.contains("Glad to see you, Fat Spring...")
+assert log.contains("BUILD SUCCESS"): "BUILD FAILED"
+assert log.contains("Glad to see you, Fat Spring..."): "'Glad to see you, Fat Spring...' entry is not found"
 //Check that we have generated EO object files.
 //assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/spring/Application.xmir').exists()
 //assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/spring/Receptionist.xmir').exists()

--- a/src/main/java/org/eolang/jeo/BachedTranslator.java
+++ b/src/main/java/org/eolang/jeo/BachedTranslator.java
@@ -54,7 +54,7 @@ public final class BachedTranslator implements Translator {
     @Override
     public Stream<Representation> apply(final Stream<? extends Representation> representations) {
         return representations
-//            .parallel()
+            .parallel()
             .map(this::translate);
     }
 

--- a/src/main/java/org/eolang/jeo/BachedTranslator.java
+++ b/src/main/java/org/eolang/jeo/BachedTranslator.java
@@ -53,7 +53,9 @@ public final class BachedTranslator implements Translator {
 
     @Override
     public Stream<Representation> apply(final Stream<? extends Representation> representations) {
-        return representations.parallel().map(this::translate);
+        return representations
+//            .parallel()
+            .map(this::translate);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
@@ -485,7 +485,7 @@ public final class AsmProgram {
                     }
 
                     @Override
-                    public int stackImpact() {
+                    public int impact() {
                         return 0;
                     }
 

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
@@ -45,7 +45,7 @@ import org.eolang.jeo.representation.bytecode.BytecodeEntry;
 import org.eolang.jeo.representation.bytecode.BytecodeEnumAnnotationValue;
 import org.eolang.jeo.representation.bytecode.BytecodeField;
 import org.eolang.jeo.representation.bytecode.BytecodeFrame;
-import org.eolang.jeo.representation.bytecode.BytecodeInstructionEntry;
+import org.eolang.jeo.representation.bytecode.BytecodeInstruction;
 import org.eolang.jeo.representation.bytecode.BytecodeLabel;
 import org.eolang.jeo.representation.bytecode.BytecodeMaxs;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
@@ -344,31 +344,31 @@ public final class AsmProgram {
         final BytecodeEntry result;
         switch (node.getType()) {
             case AbstractInsnNode.INSN:
-                result = new BytecodeInstructionEntry(node.getOpcode());
+                result = new BytecodeInstruction(node.getOpcode());
                 break;
             case AbstractInsnNode.INT_INSN:
                 final IntInsnNode instr = IntInsnNode.class.cast(node);
-                result = new BytecodeInstructionEntry(
+                result = new BytecodeInstruction(
                     instr.getOpcode(),
                     instr.operand
                 );
                 break;
             case AbstractInsnNode.VAR_INSN:
                 final VarInsnNode varinstr = VarInsnNode.class.cast(node);
-                result = new BytecodeInstructionEntry(
+                result = new BytecodeInstruction(
                     varinstr.getOpcode(), varinstr.var
                 );
                 break;
             case AbstractInsnNode.TYPE_INSN:
                 final TypeInsnNode typeinstr = TypeInsnNode.class.cast(node);
-                result = new BytecodeInstructionEntry(
+                result = new BytecodeInstruction(
                     typeinstr.getOpcode(),
                     typeinstr.desc
                 );
                 break;
             case AbstractInsnNode.FIELD_INSN:
                 final FieldInsnNode field = FieldInsnNode.class.cast(node);
-                result = new BytecodeInstructionEntry(
+                result = new BytecodeInstruction(
                     field.getOpcode(),
                     field.owner,
                     field.name,
@@ -377,7 +377,7 @@ public final class AsmProgram {
                 break;
             case AbstractInsnNode.METHOD_INSN:
                 final MethodInsnNode method = MethodInsnNode.class.cast(node);
-                result = new BytecodeInstructionEntry(
+                result = new BytecodeInstruction(
                     method.getOpcode(),
                     method.owner,
                     method.name,
@@ -387,7 +387,7 @@ public final class AsmProgram {
                 break;
             case AbstractInsnNode.INVOKE_DYNAMIC_INSN:
                 final InvokeDynamicInsnNode dynamic = InvokeDynamicInsnNode.class.cast(node);
-                result = new BytecodeInstructionEntry(
+                result = new BytecodeInstruction(
                     dynamic.getOpcode(),
                     Stream.concat(
                         Stream.of(
@@ -401,7 +401,7 @@ public final class AsmProgram {
                 break;
             case AbstractInsnNode.JUMP_INSN:
                 final JumpInsnNode jump = JumpInsnNode.class.cast(node);
-                result = new BytecodeInstructionEntry(
+                result = new BytecodeInstruction(
                     jump.getOpcode(),
                     jump.label.getLabel()
                 );
@@ -415,14 +415,14 @@ public final class AsmProgram {
                 break;
             case AbstractInsnNode.LDC_INSN:
                 final LdcInsnNode ldc = LdcInsnNode.class.cast(node);
-                result = new BytecodeInstructionEntry(
+                result = new BytecodeInstruction(
                     ldc.getOpcode(),
                     ldc.cst
                 );
                 break;
             case AbstractInsnNode.IINC_INSN:
                 final IincInsnNode iinc = IincInsnNode.class.cast(node);
-                result = new BytecodeInstructionEntry(
+                result = new BytecodeInstruction(
                     iinc.getOpcode(),
                     iinc.var,
                     iinc.incr
@@ -430,7 +430,7 @@ public final class AsmProgram {
                 break;
             case AbstractInsnNode.TABLESWITCH_INSN:
                 final TableSwitchInsnNode table = TableSwitchInsnNode.class.cast(node);
-                result = new BytecodeInstructionEntry(
+                result = new BytecodeInstruction(
                     table.getOpcode(),
                     Stream.concat(
                         Stream.of(table.min, table.max, table.dflt.getLabel()),
@@ -440,7 +440,7 @@ public final class AsmProgram {
                 break;
             case AbstractInsnNode.LOOKUPSWITCH_INSN:
                 final LookupSwitchInsnNode lookup = LookupSwitchInsnNode.class.cast(node);
-                result = new BytecodeInstructionEntry(
+                result = new BytecodeInstruction(
                     lookup.getOpcode(),
                     Stream.concat(
                         Stream.of(lookup.dflt.getLabel()),
@@ -453,7 +453,7 @@ public final class AsmProgram {
                 break;
             case AbstractInsnNode.MULTIANEWARRAY_INSN:
                 final MultiANewArrayInsnNode multiarr = MultiANewArrayInsnNode.class.cast(node);
-                result = new BytecodeInstructionEntry(
+                result = new BytecodeInstruction(
                     multiarr.getOpcode(),
                     multiarr.desc,
                     multiarr.dims

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
@@ -485,6 +485,11 @@ public final class AsmProgram {
                     }
 
                     @Override
+                    public int stackImpact() {
+                        return 0;
+                    }
+
+                    @Override
                     public String testCode() {
                         return "";
                     }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation.bytecode;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
@@ -52,7 +53,7 @@ public final class BytecodeClass implements Testable {
     /**
      * Methods.
      */
-    private final List<BytecodeMethod> methods;
+    private final List<BytecodeMethod> cmethods;
 
     /**
      * Fields.
@@ -156,7 +157,7 @@ public final class BytecodeClass implements Testable {
         final BytecodeClassProperties props
     ) {
         this.name = name;
-        this.methods = methods;
+        this.cmethods = methods;
         this.fields = fields;
         this.annotations = annotations;
         this.attributes = attributes;
@@ -244,7 +245,7 @@ public final class BytecodeClass implements Testable {
     @Override
     public String testCode() {
         final StringBuilder builder = new StringBuilder(0);
-        for (final BytecodeMethod method : this.methods) {
+        for (final BytecodeMethod method : this.cmethods) {
             builder.append('.').append(method.testCode()).append('\n');
         }
         return String.format(
@@ -289,11 +290,19 @@ public final class BytecodeClass implements Testable {
     }
 
     /**
+     * Retrieve class methods.
+     * @return Class methods.
+     */
+    public List<BytecodeMethod> methods() {
+        return Collections.unmodifiableList(this.cmethods);
+    }
+
+    /**
      * Without methods.
      * @return The same class without methods.
      */
     public BytecodeClass withoutMethods() {
-        this.methods.clear();
+        this.cmethods.clear();
         return this;
     }
 
@@ -315,7 +324,7 @@ public final class BytecodeClass implements Testable {
             new ClassName(new PrefixedName(this.name).encode()),
             this.props.directives(),
             this.fields.stream().map(BytecodeField::directives).collect(Collectors.toList()),
-            this.methods.stream().map(method -> method.directives(counting))
+            this.cmethods.stream().map(method -> method.directives(counting))
                 .collect(Collectors.toList()),
             this.annotations.directives(),
             new DirectivesAttributes(
@@ -343,7 +352,7 @@ public final class BytecodeClass implements Testable {
             );
             this.annotations.write(visitor);
             this.fields.forEach(field -> field.write(visitor));
-            this.methods.forEach(method -> method.write(visitor));
+            this.cmethods.forEach(method -> method.write(visitor));
             this.attributes.forEach(attr -> attr.write(visitor));
             visitor.visitEnd();
         } catch (final IllegalArgumentException exception) {
@@ -368,7 +377,7 @@ public final class BytecodeClass implements Testable {
      * @return True if it has opcodes, false otherwise.
      */
     boolean hasOpcodes() {
-        return this.methods.stream().anyMatch(BytecodeMethod::hasOpcodes);
+        return this.cmethods.stream().anyMatch(BytecodeMethod::hasOpcodes);
     }
 
     /**
@@ -376,7 +385,7 @@ public final class BytecodeClass implements Testable {
      * @return True if it has labels, false otherwise.
      */
     boolean hasLabels() {
-        return this.methods.stream().anyMatch(BytecodeMethod::hasLabels);
+        return this.cmethods.stream().anyMatch(BytecodeMethod::hasLabels);
     }
 
     /**
@@ -385,7 +394,7 @@ public final class BytecodeClass implements Testable {
      * @return This object.
      */
     private BytecodeMethodBuilder withMethod(final BytecodeMethod method) {
-        this.methods.add(method);
+        this.cmethods.add(method);
         return new BytecodeMethodBuilder(this, method);
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeEntry.java
@@ -44,5 +44,5 @@ public interface BytecodeEntry extends Testable {
 
     boolean isOpcode();
 
-    int stackImpact();
+    int impact();
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeEntry.java
@@ -43,4 +43,6 @@ public interface BytecodeEntry extends Testable {
     boolean isLabel();
 
     boolean isOpcode();
+
+    int stackImpact();
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeFrame.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeFrame.java
@@ -139,6 +139,11 @@ public final class BytecodeFrame implements BytecodeEntry {
     }
 
     @Override
+    public int stackImpact() {
+        return 0;
+    }
+
+    @Override
     public String testCode() {
         return String.format(
             ".visitFrame(%d, %d, new Object[]{ %s }, %d, new Object[]{ %s })",

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeFrame.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeFrame.java
@@ -139,7 +139,7 @@ public final class BytecodeFrame implements BytecodeEntry {
     }
 
     @Override
-    public int stackImpact() {
+    public int impact() {
         return 0;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -170,7 +170,7 @@ public final class BytecodeInstruction implements BytecodeEntry {
      * @checkstyle JavaNCSSCheck (350 lines)
      * @checkstyle AvoidNestedBlocksCheck (350 lines)
      */
-    @SuppressWarnings("PMD.NcssCount")
+    @SuppressWarnings({"PMD.NcssCount", "PMD.ExcessiveMethodLength"})
     public int impact() {
         final int result;
         final Instruction instruction = Instruction.find(this.opcode);

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -170,6 +170,7 @@ public final class BytecodeInstruction implements BytecodeEntry {
         return Instruction.find(this.opcode).size();
     }
 
+    @ToString.Include
     @Override
     public String testCode() {
         final String args = Stream.concat(

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -1656,13 +1656,13 @@ public final class BytecodeInstruction implements BytecodeEntry {
             visitor.visitInvokeDynamicInsn(
                 String.valueOf(arguments.get(0)),
                 String.valueOf(arguments.get(1)),
-                (Handle) arguments.get(2),
+                Handle.class.cast(arguments.get(2)),
                 arguments.subList(3, arguments.size()).toArray()
             )
         ),
 
         /**
-         * Create new object of type identified by class reference in constant pool index.
+         * Create a new object of a type identified by class reference in constant pool index.
          */
         NEW(Opcodes.NEW, (visitor, arguments) ->
             visitor.visitTypeInsn(

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -409,7 +409,14 @@ public final class BytecodeInstruction implements BytecodeEntry {
                 return this.typeSize(Type.getType(String.valueOf(this.args.get(2)))) - 1;
             case PUTFIELD:
                 return (this.typeSize(Type.getType(String.valueOf(this.args.get(2)))) * -1) - 1;
-            case INVOKEVIRTUAL:
+            case INVOKEVIRTUAL:{
+                final String descr = String.valueOf(this.args.get(2));
+                final Type ret = Type.getReturnType(descr);
+                final Type[] types = Type.getArgumentTypes(descr);
+                final int args = Arrays.stream(types).mapToInt(this::typeSize).sum();
+                final int res = this.typeSize(ret) - 1 - args;
+                return res;
+            }
             case INVOKESPECIAL:
             case INVOKEINTERFACE: {
                 final String descr = String.valueOf(this.args.get(2));

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -451,11 +451,9 @@ public final class BytecodeInstruction implements BytecodeEntry {
                 /* get dimensions from instruction operands */
                 return -(int) (this.args.get(1)) + 1;
             case TABLESWITCH:
-                // Pops value, pushes value
-                return 0;
+                return -1;
             case LOOKUPSWITCH:
-                // Pops value, pushes value
-                return 0;
+                return -1;
             default:
                 throw new UnsupportedOperationException(
                     String.format(

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -146,7 +146,7 @@ public final class BytecodeInstruction implements BytecodeEntry {
      * Local variable index.
      * @return Local variable index.
      */
-    public int local() {
+    public int localIndex() {
         if (!this.isVarInstruction()) {
             throw new IllegalStateException(
                 String.format(

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -497,6 +497,8 @@ public final class BytecodeInstruction implements BytecodeEntry {
             case IF_ACMPNE:
             case IFNULL:
             case IFNONNULL:
+            case TABLESWITCH:
+            case LOOKUPSWITCH:
                 return true;
             default:
                 return false;
@@ -521,6 +523,18 @@ public final class BytecodeInstruction implements BytecodeEntry {
             case IF_ACMPNE:
             case IFNULL:
             case IFNONNULL:
+            case TABLESWITCH:
+            case LOOKUPSWITCH:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public boolean isSwitchInstruction() {
+        switch (Instruction.find(this.opcode)) {
+            case TABLESWITCH:
+            case LOOKUPSWITCH:
                 return true;
             default:
                 return false;
@@ -538,6 +552,38 @@ public final class BytecodeInstruction implements BytecodeEntry {
                 return true;
             default:
                 return false;
+        }
+    }
+
+    public List<Label> offsets() {
+        if (!this.isSwitchInstruction()) {
+            throw new IllegalStateException(
+                String.format(
+                    "Instruction %s is not a switch instruction",
+                    new OpcodeName(this.opcode).simplified()
+                )
+            );
+        }
+        switch (Instruction.find(this.opcode)) {
+            case TABLESWITCH: {
+                return this.args.stream()
+                    .filter(Label.class::isInstance)
+                    .map(Label.class::cast)
+                    .collect(Collectors.toList());
+            }
+            case LOOKUPSWITCH: {
+                return this.args.stream()
+                    .filter(Label.class::isInstance)
+                    .map(Label.class::cast)
+                    .collect(Collectors.toList());
+            }
+            default:
+                throw new IllegalStateException(
+                    String.format(
+                        "Instruction %s is not a switch instruction",
+                        new OpcodeName(this.opcode).simplified()
+                    )
+                );
         }
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -426,7 +426,11 @@ public final class BytecodeInstruction implements BytecodeEntry {
                 return this.typeSize(ret) - args;
             }
             case INVOKEDYNAMIC: {
-                return 0; //todo
+                final String descr = String.valueOf(this.args.get(1));
+                final Type ret = Type.getReturnType(descr);
+                final Type[] types = Type.getArgumentTypes(descr);
+                final int args = Arrays.stream(types).mapToInt(this::typeSize).sum();
+                return this.typeSize(ret) - args;
             }
             case NEW:
                 return 1;

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -448,9 +448,8 @@ public final class BytecodeInstruction implements BytecodeEntry {
                 // Pops dimensions, pushes arrayref
                 // Assuming dimensions are given (from operands)
                 // For now, let's assume dimensions = dims
-//                int dims = /* get dimensions from instruction operands */;
-//                return -dims + 1;
-                return 0;
+                /* get dimensions from instruction operands */
+                return -(int) (this.args.get(1)) + 1;
             case TABLESWITCH:
                 // Pops value, pushes value
                 return 0;

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -409,7 +409,7 @@ public final class BytecodeInstruction implements BytecodeEntry {
                 return this.typeSize(Type.getType(String.valueOf(this.args.get(2)))) - 1;
             case PUTFIELD:
                 return (this.typeSize(Type.getType(String.valueOf(this.args.get(2)))) * -1) - 1;
-            case INVOKEVIRTUAL:{
+            case INVOKEVIRTUAL: {
                 final String descr = String.valueOf(this.args.get(2));
                 final Type ret = Type.getReturnType(descr);
                 final Type[] types = Type.getArgumentTypes(descr);

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -47,7 +47,7 @@ import org.xembly.Directive;
  */
 @ToString
 @EqualsAndHashCode
-@SuppressWarnings("PMD.ExcessiveClassLength")
+@SuppressWarnings({"PMD.ExcessiveClassLength", "PMD.GodClass"})
 public final class BytecodeInstruction implements BytecodeEntry {
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -369,7 +369,15 @@ public final class BytecodeInstruction implements BytecodeEntry {
                 return -2;
             case RETURN:
                 return 0;
-            // Get and put field
+            case IINC:
+                return 0;
+            case LDC:
+                final Type ldcType = Type.getType(this.args.get(0).getClass());
+                if (ldcType == Type.DOUBLE_TYPE || ldcType == Type.LONG_TYPE) {
+                    return 2;
+                } else {
+                    return 1;
+                }
             case GETSTATIC:
                 final Type type = Type.getType(String.valueOf(this.args.get(2)));
                 if (type == Type.DOUBLE_TYPE || type == Type.LONG_TYPE) {
@@ -377,17 +385,13 @@ public final class BytecodeInstruction implements BytecodeEntry {
                 } else {
                     return 1;
                 }
-                // Needs field descriptor to determine stack change
-                // Assuming we have a method to get field size (1 or 2 slots)
-                // For example:
-                // return getFieldSize(fieldDescriptor);
-                // For now, we'll assume it's 1 slot
-//                return 1;
             case PUTSTATIC:
-                // Needs field descriptor
-                // Assuming it's 1 slot
-                return -1;
-
+                final Type putType = Type.getType(String.valueOf(this.args.get(2)));
+                if (putType == Type.DOUBLE_TYPE || putType == Type.LONG_TYPE) {
+                    return -2;
+                } else {
+                    return -1;
+                }
             case GETFIELD:
                 // Pops objectref (1 slot), pushes field value
                 // Net change depends on field size
@@ -462,7 +466,6 @@ public final class BytecodeInstruction implements BytecodeEntry {
             case IFNONNULL:
                 // Pops objectref: -1
                 return -1;
-
             // Default case
             default:
                 // For unrecognized opcodes, return 0 or throw an exception

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -523,8 +523,6 @@ public final class BytecodeInstruction implements BytecodeEntry {
             case IF_ACMPNE:
             case IFNULL:
             case IFNONNULL:
-            case TABLESWITCH:
-            case LOOKUPSWITCH:
                 return true;
             default:
                 return false;

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -191,7 +191,8 @@ public final class BytecodeInstruction implements BytecodeEntry {
     }
 
     public int stack() {
-        switch (Instruction.find(this.opcode)) {
+        final Instruction instruction = Instruction.find(this.opcode);
+        switch (instruction) {
             case NOP:
                 return 0;
             case ACONST_NULL:
@@ -392,42 +393,22 @@ public final class BytecodeInstruction implements BytecodeEntry {
                 return 0;
             case IINC:
                 return 0;
-            case LDC:
-                final Type ldcType = Type.getType(this.args.get(0).getClass());
-                if (ldcType == Type.DOUBLE_TYPE || ldcType == Type.LONG_TYPE) {
+            case LDC: {
+                final Class<?> clazz = this.args.get(0).getClass();
+                if (clazz == Long.class || clazz == Double.class) {
                     return 2;
                 } else {
-                    return 1;
+                    return this.typeSize(Type.getType(clazz));
                 }
+            }
             case GETSTATIC:
-                final Type type = Type.getType(String.valueOf(this.args.get(2)));
-                if (type == Type.DOUBLE_TYPE || type == Type.LONG_TYPE) {
-                    return 2;
-                } else {
-                    return 1;
-                }
+                return this.typeSize(Type.getType(String.valueOf(this.args.get(2))));
             case PUTSTATIC:
-                final Type putType = Type.getType(String.valueOf(this.args.get(2)));
-                if (putType == Type.DOUBLE_TYPE || putType == Type.LONG_TYPE) {
-                    return -2;
-                } else {
-                    return -1;
-                }
+                return this.typeSize(Type.getType(String.valueOf(this.args.get(2)))) * -1;
             case GETFIELD:
-                final Type fieldType = Type.getType(String.valueOf(this.args.get(2)));
-                if (fieldType == Type.DOUBLE_TYPE || fieldType == Type.LONG_TYPE) {
-                    return 1;
-                } else {
-                    return 0;
-                }
+                return this.typeSize(Type.getType(String.valueOf(this.args.get(2)))) - 1;
             case PUTFIELD:
-                final Type putFieldType = Type.getType(String.valueOf(this.args.get(2)));
-                if (putFieldType == Type.DOUBLE_TYPE || putFieldType == Type.LONG_TYPE) {
-                    return -3;
-                } else {
-                    return -2;
-                }
-                // Invoke method instructions
+                return (this.typeSize(Type.getType(String.valueOf(this.args.get(2)))) * -1) - 1;
             case INVOKEVIRTUAL:
             case INVOKESPECIAL:
             case INVOKEINTERFACE: {
@@ -445,9 +426,8 @@ public final class BytecodeInstruction implements BytecodeEntry {
                 return this.typeSize(ret) - args;
             }
             case INVOKEDYNAMIC: {
-                return 0;
+                return 0; //todo
             }
-            // New object
             case NEW:
                 return 1;
             case NEWARRAY:

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -414,47 +414,18 @@ public final class BytecodeInstruction implements BytecodeEntry {
     }
 
     /**
-     * Is this instruction a branch instruction?
+     * Is this instruction a jump instruction?
      * @return True if it is.
      */
-    boolean isBranch() {
-        final boolean result;
-        switch (Instruction.find(this.opcode)) {
-            case GOTO:
-            case JSR:
-            case RET:
-            case IFEQ:
-            case IFNE:
-            case IFLT:
-            case IFGE:
-            case IFGT:
-            case IFLE:
-            case IF_ICMPEQ:
-            case IF_ICMPNE:
-            case IF_ICMPLT:
-            case IF_ICMPGE:
-            case IF_ICMPGT:
-            case IF_ICMPLE:
-            case IF_ACMPEQ:
-            case IF_ACMPNE:
-            case IFNULL:
-            case IFNONNULL:
-            case TABLESWITCH:
-            case LOOKUPSWITCH:
-                result = true;
-                break;
-            default:
-                result = false;
-                break;
-        }
-        return result;
+    boolean isJump() {
+        return Instruction.find(this.opcode) == Instruction.GOTO;
     }
 
     /**
      * Is this instruction a conditional branch instruction?
      * @return True if it is.
      */
-    boolean isConditionalBranch() {
+    boolean isBranch() {
         final boolean result;
         switch (Instruction.find(this.opcode)) {
             case IFEQ:

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -190,7 +190,7 @@ public final class BytecodeInstruction implements BytecodeEntry {
         return String.format(".opcode(%s)", args);
     }
 
-    public int stack() {
+    public int stackImpact() {
         final Instruction instruction = Instruction.find(this.opcode);
         switch (instruction) {
             case NOP:
@@ -470,6 +470,110 @@ public final class BytecodeInstruction implements BytecodeEntry {
             return 0;
         }
         return 1;
+    }
+
+    public boolean isBranchInstruction() {
+        switch (Instruction.find(this.opcode)) {
+            case GOTO:
+            case JSR:
+            case RET:
+            case IFEQ:
+            case IFNE:
+            case IFLT:
+            case IFGE:
+            case IFGT:
+            case IFLE:
+            case IF_ICMPEQ:
+            case IF_ICMPNE:
+            case IF_ICMPLT:
+            case IF_ICMPGE:
+            case IF_ICMPGT:
+            case IF_ICMPLE:
+            case IF_ACMPEQ:
+            case IF_ACMPNE:
+            case IFNULL:
+            case IFNONNULL:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public boolean isConditionalBranchInstruction() {
+        switch (Instruction.find(this.opcode)) {
+            case IFEQ:
+            case IFNE:
+            case IFLT:
+            case IFGE:
+            case IFGT:
+            case IFLE:
+            case IF_ICMPEQ:
+            case IF_ICMPNE:
+            case IF_ICMPLT:
+            case IF_ICMPGE:
+            case IF_ICMPGT:
+            case IF_ICMPLE:
+            case IF_ACMPEQ:
+            case IF_ACMPNE:
+            case IFNULL:
+            case IFNONNULL:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public boolean isReturnInstruction() {
+        switch (Instruction.find(this.opcode)) {
+            case IRETURN:
+            case FRETURN:
+            case ARETURN:
+            case LRETURN:
+            case DRETURN:
+            case RETURN:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public Label offset() {
+        if (!this.isBranchInstruction()) {
+            throw new IllegalStateException(
+                String.format(
+                    "Instruction %s is not a branch instruction",
+                    new OpcodeName(this.opcode).simplified()
+                )
+            );
+        }
+        switch (Instruction.find(this.opcode)) {
+            case GOTO:
+            case JSR:
+            case IFEQ:
+            case IFNE:
+            case IFLT:
+            case IFGE:
+            case IFGT:
+            case IFLE:
+            case IF_ICMPEQ:
+            case IF_ICMPNE:
+            case IF_ICMPLT:
+            case IF_ICMPGE:
+            case IF_ICMPGT:
+            case IF_ICMPLE:
+            case IF_ACMPEQ:
+            case IF_ACMPNE:
+            case IFNULL:
+            case IFNONNULL:
+                return (Label) this.args.get(0);
+            default:
+                throw new IllegalStateException(
+                    String.format(
+                        "Instruction %s is not a branch instruction",
+                        new OpcodeName(this.opcode).simplified()
+                    )
+                );
+        }
     }
 
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -565,12 +565,7 @@ public final class BytecodeInstruction implements BytecodeEntry {
             );
         }
         switch (Instruction.find(this.opcode)) {
-            case TABLESWITCH: {
-                return this.args.stream()
-                    .filter(Label.class::isInstance)
-                    .map(Label.class::cast)
-                    .collect(Collectors.toList());
-            }
+            case TABLESWITCH:
             case LOOKUPSWITCH: {
                 return this.args.stream()
                     .filter(Label.class::isInstance)

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabel.java
@@ -106,7 +106,7 @@ public final class BytecodeLabel implements BytecodeEntry {
     }
 
     @Override
-    public int stackImpact() {
+    public int impact() {
         return 0;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabel.java
@@ -106,6 +106,11 @@ public final class BytecodeLabel implements BytecodeEntry {
     }
 
     @Override
+    public int stackImpact() {
+        return 0;
+    }
+
+    @Override
     public String testCode() {
         return String.format(".label(\"%s\")", this.labels.uid(this.label));
     }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -710,13 +710,13 @@ public final class BytecodeMethod implements Testable {
                             final int next = current + 1;
                             worklist.put(next, new Variables(currentVars));
                             break;
-                        } else if (var.isReturnInstruction()) {
-                            break;
                         } else {
                             final int jump = this.index(var.offset());
                             worklist.put(jump, new Variables(currentVars));
                             break;
                         }
+                    } else if (var.isReturnInstruction()) {
+                        break;
                     }
                     if (var.isVarInstruction()) {
                         currentVars.put(var);
@@ -760,7 +760,7 @@ public final class BytecodeMethod implements Testable {
 //                .orElseThrow(() -> new IllegalStateException(""));
 //            int current = curr.getKey();
 //            worklist.remove(current);
-//            if (all.get(current) != null) {
+//            if (all.get(current) != null && all.get(current).size() >= curr.getValue().size()) {
 //                continue;
 //            }
 //            currentVars = new Variables(curr.getValue());
@@ -782,13 +782,13 @@ public final class BytecodeMethod implements Testable {
 //                            final int next = current + 1;
 //                            worklist.put(next, new Variables(currentVars));
 //                            break;
-//                        } else if (var.isReturnInstruction()) {
-//                            break;
 //                        } else {
 //                            final int jump = this.index(var.offset());
 //                            worklist.put(jump, new Variables(currentVars));
 //                            break;
 //                        }
+//                    } else if (var.isReturnInstruction()) {
+//                        break;
 //                    }
 //                    if (var.isVarInstruction()) {
 //                        currentVars.put(var);
@@ -820,7 +820,7 @@ public final class BytecodeMethod implements Testable {
     @ToString
     private static class Variables {
 
-        private final Map<Integer, Integer> all;
+        private final TreeMap<Integer, Integer> all;
 
         public Variables() {
             this(new HashMap<>(0));
@@ -831,11 +831,16 @@ public final class BytecodeMethod implements Testable {
         }
 
         public Variables(final Map<Integer, Integer> all) {
-            this.all = new HashMap<>(all);
+            this.all = new TreeMap<>(all);
         }
 
         int size() {
-            return this.all.values().stream().mapToInt(Integer::intValue).sum();
+            if (all.isEmpty()) {
+                return 0;
+            }
+            final Map.Entry<Integer, Integer> entry = all.lastEntry();
+            return (entry.getKey() + 1) + ((int) (entry.getValue() * 0.5));
+//            return this.all.values().stream().mapToInt(Integer::intValue).sum();
         }
 
         public void put(BytecodeInstruction var) {
@@ -844,14 +849,6 @@ public final class BytecodeMethod implements Testable {
 
         public void put(int index, int value) {
             this.all.put(index, value);
-        }
-
-        public void putSlot(int index) {
-            this.all.put(index, 1);
-        }
-
-        public void putTwoSlots(int index) {
-            this.all.put(index, 2);
         }
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -469,9 +469,9 @@ public final class BytecodeMethod implements Testable {
                             for (Label offset : offsets) {
                                 final int target = this.index(offset);
                                 if (visited.get(target) == null
-//                                    || visited.get(target) <= stack
+                                    || visited.get(target) < stack
                                 ) {
-//                                    visited.put(target, stack);
+                                    visited.put(target, stack);
                                     worklist.add(target);
                                 }
                             }
@@ -479,9 +479,9 @@ public final class BytecodeMethod implements Testable {
                         } else if (var.isConditionalBranchInstruction()) {
                             final int jump = this.index(var.offset());
                             if (visited.get(jump) == null
-//                                || visited.get(jump) <= stack
+                                || visited.get(jump) < stack
                             ) {
-//                                visited.put(jump, stack);
+                                visited.put(jump, stack);
                                 worklist.add(jump);
 
                             }
@@ -489,9 +489,9 @@ public final class BytecodeMethod implements Testable {
                             if (var.isConditionalBranchInstruction()) {
                                 final int next = current + 1;
                                 if (visited.get(next) == null
-//                                        || visited.get(next) <= stack
+                                        || visited.get(next) < stack
                                 ) {
-//                                        visited.put(next, stack);
+                                        visited.put(next, stack);
                                     worklist.add(next);
                                 }
                             }
@@ -502,9 +502,9 @@ public final class BytecodeMethod implements Testable {
                         } else {
                             final int jump = this.index(var.offset());
                             if (visited.get(jump) == null
-//                                || visited.get(jump) <= stack
+                                || visited.get(jump) < stack
                             ) {
-//                                visited.put(jump, stack);
+                                visited.put(jump, stack);
                                 worklist.add(jump);
                             }
                             break;

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.bytecode;
 
+import com.jcabi.log.Logger;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -431,7 +432,9 @@ public final class BytecodeMethod implements Testable {
         return this.directives(true);
     }
 
+
     private int computeStack() {
+        Logger.info(this, "Computing stack for %s", this.properties);
         int max = 0;
         final Deque<Integer> worklist = new ArrayDeque<>(0);
         final int length = this.instructions.size();
@@ -450,31 +453,25 @@ public final class BytecodeMethod implements Testable {
                 );
                 if (entry instanceof BytecodeInstruction) {
                     final BytecodeInstruction var = BytecodeInstruction.class.cast(entry);
-//                    stack += var.stackImpact();
-//                    max = Math.max(max, stack);
-//                    final int finalStack = stack;
-//                    visited.compute(
-//                        current, (k, v) -> v == null ? finalStack : Math.max(v, finalStack)
-//                    );
                     if (var.isBranchInstruction()) {
                         if (var.isSwitchInstruction()) {
                             final List<Label> offsets = var.offsets();
                             for (Label offset : offsets) {
                                 final int target = this.index(offset);
-                                if (visited.get(target) == null || visited.get(target) < stack) {
+                                if (visited.get(target) == null) {
                                     worklist.add(target);
                                 }
                             }
-                            if (var.isConditionalBranchInstruction()) {
-                                final int next = current + 1;
-                                if (visited.get(next) == null || visited.get(next) < stack) {
-                                    worklist.add(next);
-                                }
-                            }
+//                            if (var.isConditionalBranchInstruction()) {
+//                                final int next = current + 1;
+//                                if (visited.get(next) == null || visited.get(next) < stack) {
+//                                    worklist.add(next);
+//                                }
+//                            }
                             break;
                         } else {
                             final int jump = this.index(var.offset());
-                            if (visited.get(jump) == null || visited.get(jump) < stack) {
+                            if (visited.get(jump) == null) {
                                 worklist.add(jump);
                                 if (var.isConditionalBranchInstruction()) {
                                     final int next = current + 1;
@@ -493,13 +490,6 @@ public final class BytecodeMethod implements Testable {
                 current++;
             }
         }
-//        for (final BytecodeEntry instruction : this.instructions) {
-//            if (instruction instanceof BytecodeInstruction) {
-//                final BytecodeInstruction var = BytecodeInstruction.class.cast(instruction);
-//                stack += var.stackImpact();
-//                max = Math.max(max, stack);
-//            }
-//        }
         return max;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -36,6 +36,7 @@ import org.eolang.jeo.representation.xmir.AllLabels;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 
 /**
  * Bytecode method.
@@ -425,7 +426,16 @@ public final class BytecodeMethod implements Testable {
      * @return Max local variables.
      */
     private int computeLocals() {
-        this.properties.descriptor();
-        return 0;
+//        final Type[] types = Type.getArgumentTypes(this.properties.descriptor());
+//        int arguments = types[0].getSize();
+//
+
+        int res = Arrays.stream(Type.getArgumentTypes(this.properties.descriptor()))
+            .mapToInt(Type::getSize)
+            .sum();
+        if (!this.properties.isStatic()) {
+            res++;
+        }
+        return res;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -100,7 +100,7 @@ public final class BytecodeMethod implements Testable {
      * Constructor.
      * @param instructions Method instructions.
      */
-    public BytecodeMethod(BytecodeEntry... instructions) {
+    public BytecodeMethod(final BytecodeEntry... instructions) {
         this(
             new ArrayList<>(0),
             Arrays.asList(instructions),

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -475,7 +475,7 @@ public final class BytecodeMethod implements Testable {
                                 worklist.add(jump);
                                 if (var.isConditionalBranchInstruction()) {
                                     final int next = current + 1;
-                                    if (visited.get(next) == null || visited.get(next) < stack) {
+                                    if (visited.get(next) == null) {
                                         worklist.add(next);
                                     }
                                 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -489,9 +489,9 @@ public final class BytecodeMethod implements Testable {
                             if (var.isConditionalBranchInstruction()) {
                                 final int next = current + 1;
                                 if (visited.get(next) == null
-                                        || visited.get(next) < stack
+                                    || visited.get(next) < stack
                                 ) {
-                                        visited.put(next, stack);
+                                    visited.put(next, stack);
                                     worklist.add(next);
                                 }
                             }
@@ -562,7 +562,8 @@ public final class BytecodeMethod implements Testable {
                         variables.put(key, 2);
                     } else {
                         final int key = var.localIndex();
-                        variables.put(key, 1);
+                        variables.putIfAbsent(key, 1);
+                        variables.compute(key, (k, v) -> v == 2 ? 2 : 1);
                     }
                 }
             }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -448,6 +448,4 @@ public final class BytecodeMethod implements Testable {
                 .collect(Collectors.toList())
         ).value();
     }
-
-
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -617,7 +617,10 @@ public final class BytecodeMethod implements Testable {
                         nxt = this.computeLocalsWithCFG(
                             new HashMap<>(variables), nextIndex, new HashSet<>(visited));
                     }
-                    return Math.max(branch, nxt);
+                    return Math.max(
+                        Math.max(branch, nxt),
+                        variables.values().stream().mapToInt(Integer::intValue).sum()
+                    );
                 } else if (var.isReturnInstruction()) {
                     return variables.values().stream().mapToInt(Integer::intValue).sum();
                 } else if (var.isSwitchInstruction()) {

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -439,13 +440,13 @@ public final class BytecodeMethod implements Testable {
         final Deque<Integer> worklist = new ArrayDeque<>(0);
         final int length = this.instructions.size();
         worklist.add(0);
-        Map<Integer, Integer> visited = new HashMap<>(0);
+        Map<Integer, Integer> visited = new TreeMap<>();
 
         this.tryblocks.stream()
             .map(BytecodeTryCatchBlock.class::cast)
             .map(BytecodeTryCatchBlock::handler)
             .map(this::index)
-            .peek(ind-> visited.put(ind, 1))
+            .peek(ind -> visited.put(ind, 1))
             .forEach(worklist::add);
 
 
@@ -467,31 +468,43 @@ public final class BytecodeMethod implements Testable {
                             final List<Label> offsets = var.offsets();
                             for (Label offset : offsets) {
                                 final int target = this.index(offset);
-                                if (visited.get(target) == null || visited.get(target) < stack) {
-                                    visited.put(target, stack);
+                                if (visited.get(target) == null
+//                                    || visited.get(target) <= stack
+                                ) {
+//                                    visited.put(target, stack);
                                     worklist.add(target);
                                 }
                             }
                             break;
                         } else if (var.isConditionalBranchInstruction()) {
                             final int jump = this.index(var.offset());
-                            if (visited.get(jump) == null || visited.get(jump) < stack) {
+                            if (visited.get(jump) == null
+//                                || visited.get(jump) <= stack
+                            ) {
+//                                visited.put(jump, stack);
                                 worklist.add(jump);
-                                if (var.isConditionalBranchInstruction()) {
-                                    final int next = current + 1;
-                                    if (visited.get(next) == null || visited.get(next) < stack) {
-                                        visited.put(next, stack);
-                                        worklist.add(next);
-                                    }
+
+                            }
+
+                            if (var.isConditionalBranchInstruction()) {
+                                final int next = current + 1;
+                                if (visited.get(next) == null
+//                                        || visited.get(next) <= stack
+                                ) {
+//                                        visited.put(next, stack);
+                                    worklist.add(next);
                                 }
                             }
+
                             break;
                         } else if (var.isReturnInstruction()) {
                             break;
                         } else {
                             final int jump = this.index(var.offset());
-                            if (visited.get(jump) == null || visited.get(jump) < stack) {
-                                visited.put(jump, stack);
+                            if (visited.get(jump) == null
+//                                || visited.get(jump) <= stack
+                            ) {
+//                                visited.put(jump, stack);
                                 worklist.add(jump);
                             }
                             break;

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -324,7 +324,7 @@ public final class BytecodeMethod implements Testable {
                 this.tryblocks.forEach(block -> block.writeTo(mvisitor));
                 this.instructions.forEach(instruction -> instruction.writeTo(mvisitor));
 //                mvisitor.visitMaxs(this.maxs.stack(), this.maxs.locals());
-                mvisitor.visitMaxs(computeStack(), computeLocals());
+                mvisitor.visitMaxs(this.computeStack(), this.computeLocals());
             }
             mvisitor.visitEnd();
         } catch (final NegativeArraySizeException exception) {

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -440,6 +440,15 @@ public final class BytecodeMethod implements Testable {
         final int length = this.instructions.size();
         worklist.add(0);
         Map<Integer, Integer> visited = new HashMap<>(0);
+
+        this.tryblocks.stream()
+            .map(BytecodeTryCatchBlock.class::cast)
+            .map(BytecodeTryCatchBlock::handler)
+            .map(this::index)
+            .peek(ind-> visited.put(ind, 1))
+            .forEach(worklist::add);
+
+
         while (!worklist.isEmpty()) {
             int current = worklist.pop();
             int stack = visited.get(current) == null ? 0 : visited.get(current);
@@ -493,6 +502,14 @@ public final class BytecodeMethod implements Testable {
             }
         }
         return max;
+    }
+
+    private String trackStack(final Map<Integer, Integer> visited) {
+        String res = "";
+        for (int i = 0; i < this.instructions.size(); i++) {
+            res += String.format("%s: %d\n", this.instructions.get(i).testCode(), visited.get(i));
+        }
+        return res;
     }
 
     private int index(final Label label) {

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -457,20 +457,37 @@ public final class BytecodeMethod implements Testable {
 //                        current, (k, v) -> v == null ? finalStack : Math.max(v, finalStack)
 //                    );
                     if (var.isBranchInstruction()) {
-                        final int jump = this.index(var.offset());
-                        if (visited.get(jump) == null || visited.get(jump) < stack) {
-                            worklist.add(jump);
+                        if (var.isSwitchInstruction()) {
+                            final List<Label> offsets = var.offsets();
+                            for (Label offset : offsets) {
+                                final int target = this.index(offset);
+                                if (visited.get(target) == null || visited.get(target) < stack) {
+                                    worklist.add(target);
+                                }
+                            }
                             if (var.isConditionalBranchInstruction()) {
                                 final int next = current + 1;
                                 if (visited.get(next) == null || visited.get(next) < stack) {
                                     worklist.add(next);
                                 }
                             }
+                            break;
+                        } else {
+                            final int jump = this.index(var.offset());
+                            if (visited.get(jump) == null || visited.get(jump) < stack) {
+                                worklist.add(jump);
+                                if (var.isConditionalBranchInstruction()) {
+                                    final int next = current + 1;
+                                    if (visited.get(next) == null || visited.get(next) < stack) {
+                                        worklist.add(next);
+                                    }
+                                }
+                                break;
+                            }
                         }
-                        break;
-                    }
-                    if (var.isReturnInstruction()) {
-                        break;
+                        if (var.isReturnInstruction()) {
+                            break;
+                        }
                     }
                 }
                 current++;

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -314,7 +314,8 @@ public final class BytecodeMethod implements Testable {
         try {
             final MethodVisitor mvisitor = this.properties.writeMethod(
                 visitor,
-                this.maxs.compute()
+//                this.maxs.compute()
+                false
             );
             this.annotations.write(mvisitor);
             this.defvalues.forEach(defvalue -> defvalue.writeTo(mvisitor));
@@ -322,7 +323,8 @@ public final class BytecodeMethod implements Testable {
                 mvisitor.visitCode();
                 this.tryblocks.forEach(block -> block.writeTo(mvisitor));
                 this.instructions.forEach(instruction -> instruction.writeTo(mvisitor));
-                mvisitor.visitMaxs(this.maxs.stack(), this.maxs.locals());
+//                mvisitor.visitMaxs(this.maxs.stack(), this.maxs.locals());
+                mvisitor.visitMaxs(computeStack(), computeLocals());
             }
             mvisitor.visitEnd();
         } catch (final NegativeArraySizeException exception) {

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -320,8 +320,7 @@ public final class BytecodeMethod implements Testable {
         try {
             final MethodVisitor mvisitor = this.properties.writeMethod(
                 visitor,
-                false
-//                this.maxs.compute()
+                this.maxs.compute()
             );
             this.annotations.write(mvisitor);
             this.defvalues.forEach(defvalue -> defvalue.writeTo(mvisitor));

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -385,7 +385,7 @@ public final class BytecodeMethod implements Testable {
      * @return This object.
      */
     BytecodeMethod opcode(final int opcode, final Object... args) {
-        return this.entry(new BytecodeInstructionEntry(this.labels, opcode, args));
+        return this.entry(new BytecodeInstruction(this.labels, opcode, args));
     }
 
     /**
@@ -426,16 +426,23 @@ public final class BytecodeMethod implements Testable {
      * @return Max local variables.
      */
     private int computeLocals() {
-//        final Type[] types = Type.getArgumentTypes(this.properties.descriptor());
-//        int arguments = types[0].getSize();
-//
-
-        int res = Arrays.stream(Type.getArgumentTypes(this.properties.descriptor()))
+        int max = Arrays.stream(Type.getArgumentTypes(this.properties.descriptor()))
             .mapToInt(Type::getSize)
             .sum();
-        if (!this.properties.isStatic()) {
-            res++;
+        for (final BytecodeEntry instruction : this.instructions) {
+            if (instruction instanceof BytecodeInstruction) {
+                final BytecodeInstruction var = BytecodeInstruction.class.cast(instruction);
+                if (var.isVarInstruction()) {
+                    if (var.size() == 2)
+                        max = Math.max(max, var.local() + 1);
+                    else
+                        max = Math.max(max, var.local());
+                }
+            }
         }
-        return res;
+        if (!this.properties.isStatic()) {
+            max += 1;
+        }
+        return max;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -459,6 +459,7 @@ public final class BytecodeMethod implements Testable {
                             for (Label offset : offsets) {
                                 final int target = this.index(offset);
                                 if (visited.get(target) == null || visited.get(target) < stack) {
+                                    visited.put(target, stack);
                                     worklist.add(target);
                                 }
                             }
@@ -470,6 +471,7 @@ public final class BytecodeMethod implements Testable {
                                 if (var.isConditionalBranchInstruction()) {
                                     final int next = current + 1;
                                     if (visited.get(next) == null || visited.get(next) < stack) {
+                                        visited.put(next, stack);
                                         worklist.add(next);
                                     }
                                 }
@@ -480,6 +482,7 @@ public final class BytecodeMethod implements Testable {
                         } else {
                             final int jump = this.index(var.offset());
                             if (visited.get(jump) == null || visited.get(jump) < stack) {
+                                visited.put(jump, stack);
                                 worklist.add(jump);
                             }
                             break;
@@ -516,16 +519,10 @@ public final class BytecodeMethod implements Testable {
             first = 1;
         }
         final Type[] types = Type.getArgumentTypes(this.properties.descriptor());
-
-
         for (int index = 0; index < types.length; index++) {
             final Type type = types[index];
             variables.put(index * type.getSize() + first, type.getSize());
         }
-
-//        int max = Arrays.stream(types)
-//            .mapToInt(Type::getSize)
-//            .sum();
         for (final BytecodeEntry instruction : this.instructions) {
             if (instruction instanceof BytecodeInstruction) {
                 final BytecodeInstruction var = BytecodeInstruction.class.cast(instruction);
@@ -533,19 +530,13 @@ public final class BytecodeMethod implements Testable {
                     if (var.size() == 2) {
                         final int key = var.localIndex();
                         variables.put(key, 2);
-                    }
-//                        max = Math.max(max, var.localIndex() + 1);
-                    else {
+                    } else {
                         final int key = var.localIndex();
                         variables.put(key, 1);
                     }
-//                        max = Math.max(max, var.localIndex());
                 }
             }
         }
-//        if (!this.properties.isStatic()) {
-//            max += 1;
-//        }
         int max = variables.values().stream().mapToInt(Integer::intValue).sum();
         return max;
     }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -426,7 +426,6 @@ public final class BytecodeMethod implements Testable {
      */
     private int computeStack() {
         return new MaxStack(
-            this.properties,
             this.instructions,
             this.tryblocks.stream()
                 .filter(BytecodeTryCatchBlock.class::isInstance)

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -677,15 +677,8 @@ public final class BytecodeMethod implements Testable {
             initial.put(index * type.getSize() + first, type.getSize());
         }
         Map<Integer, Variables> all = new TreeMap<>();
-//        all.put(0, initial);
         Map<Integer, Variables> worklist = new HashMap<>();
         worklist.put(0, initial);
-//        Variables tryVariables = new Variables(initial);
-//        this.tryblocks.stream()
-//            .map(BytecodeTryCatchBlock.class::cast)
-//            .map(BytecodeTryCatchBlock::handler)
-//            .map(this::index)
-//            .forEach(ind -> worklist.put(ind, tryVariables));
         final int total = this.instructions.size();
         Variables currentVars;
         while (!worklist.isEmpty()) {
@@ -695,17 +688,9 @@ public final class BytecodeMethod implements Testable {
                 .orElseThrow(() -> new IllegalStateException(""));
             int current = curr.getKey();
             worklist.remove(current);
-
-
             if (all.get(current) != null) {
                 continue;
             }
-
-//            catches(current).stream().forEach(ind -> {
-//                worklist.put(ind, new Variables(curr.getValue()));
-//            });
-
-
             currentVars = new Variables(curr.getValue());
             while (current < total) {
                 BytecodeEntry entry = this.instructions.get(current);
@@ -745,8 +730,82 @@ public final class BytecodeMethod implements Testable {
                 current++;
             }
         }
+//        __________
+//        this.tryblocks.stream().map(BytecodeTryCatchBlock.class::cast)
+//            .forEach(block -> {
+//                    final int start = this.index(block.start());
+//                    final int end = this.index(block.end());
+//                    final List<Variables> collect = all.entrySet().stream().filter(
+//                        entry -> entry.getKey() >= start && entry.getKey() <= end
+//                    ).map(Map.Entry::getValue).collect(Collectors.toList());
+//                    if (!collect.isEmpty()) {
+//                        Variables max = collect.get(0);
+//                        for (final Variables variables : collect) {
+//                            if (variables.size() > max.size()) {
+//                                max = variables;
+//                            }
+//                        }
+//                        worklist.put(
+//                            this.index(block.handler()),
+//                            new Variables(max)
+//                        );
+//                    }
+//                }
+//            );
+// ----------
+//        while (!worklist.isEmpty()) {
+//            final Map.Entry<Integer, Variables> curr = worklist.entrySet()
+//                .stream()
+//                .findFirst()
+//                .orElseThrow(() -> new IllegalStateException(""));
+//            int current = curr.getKey();
+//            worklist.remove(current);
+//            if (all.get(current) != null) {
+//                continue;
+//            }
+//            currentVars = new Variables(curr.getValue());
+//            while (current < total) {
+//                BytecodeEntry entry = this.instructions.get(current);
+//                if (entry instanceof BytecodeInstruction) {
+//                    final BytecodeInstruction var = BytecodeInstruction.class.cast(entry);
+//                    if (var.isBranchInstruction()) {
+//                        if (var.isSwitchInstruction()) {
+//                            final List<Label> offsets = var.offsets();
+//                            for (Label offset : offsets) {
+//                                final int target = this.index(offset);
+//                                worklist.put(target, new Variables(currentVars));
+//                            }
+//                            break;
+//                        } else if (var.isConditionalBranchInstruction()) {
+//                            final int jump = this.index(var.offset());
+//                            worklist.put(jump, new Variables(currentVars));
+//                            final int next = current + 1;
+//                            worklist.put(next, new Variables(currentVars));
+//                            break;
+//                        } else if (var.isReturnInstruction()) {
+//                            break;
+//                        } else {
+//                            final int jump = this.index(var.offset());
+//                            worklist.put(jump, new Variables(currentVars));
+//                            break;
+//                        }
+//                    }
+//                    if (var.isVarInstruction()) {
+//                        currentVars.put(var);
+//                    }
+//                }
+//                final Variables value = new Variables(currentVars);
+//                this.catches(current).stream().forEach(ind -> {
+//                    worklist.put(ind, new Variables(value));
+//                });
+//                all.put(current, value);
+//                current++;
+//            }
+//        }
+
         return all.values().stream().mapToInt(Variables::size).max().orElse(0);
     }
+
 
     private List<Integer> catches(final int instruction) {
         return this.tryblocks.stream().map(BytecodeTryCatchBlock.class::cast)

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -568,6 +568,7 @@ public final class BytecodeMethod implements Testable {
 
 
     private int computeLocalsWithCFG() {
+        Logger.info(this, "Computing locals for %s", this.properties);
         Map<Integer, Integer> variables = new HashMap<>(0);
         int first = 0;
         if (!this.properties.isStatic()) {
@@ -633,7 +634,10 @@ public final class BytecodeMethod implements Testable {
                             max = Math.max(
                                 max,
                                 this.computeLocalsWithCFG(
-                                    new HashMap<>(variables), index1, new HashSet<>(visited))
+                                    new HashMap<>(variables),
+                                    index1,
+                                    new HashSet<>(visited)
+                                )
                             );
                         }
                     }
@@ -644,7 +648,8 @@ public final class BytecodeMethod implements Testable {
                         return variables.values().stream().mapToInt(Integer::intValue).sum();
                     } else {
                         visited.add(jump);
-                        return this.computeLocalsWithCFG(new HashMap<>(variables), jump, visited);
+                        return this.computeLocalsWithCFG(
+                            new HashMap<>(variables), jump, new HashSet<>(visited));
                     }
                 }
                 if (var.isVarInstruction()) {

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -701,9 +701,9 @@ public final class BytecodeMethod implements Testable {
                 continue;
             }
 
-            catches(current).stream().forEach(ind -> {
-                worklist.put(ind, new Variables(curr.getValue()));
-            });
+//            catches(current).stream().forEach(ind -> {
+//                worklist.put(ind, new Variables(curr.getValue()));
+//            });
 
 
             currentVars = new Variables(curr.getValue());
@@ -738,6 +738,9 @@ public final class BytecodeMethod implements Testable {
                     }
                 }
                 final Variables value = new Variables(currentVars);
+                this.catches(current).stream().forEach(ind -> {
+                    worklist.put(ind, new Variables(value));
+                });
                 all.put(current, value);
                 current++;
             }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -458,31 +458,30 @@ public final class BytecodeMethod implements Testable {
                             final List<Label> offsets = var.offsets();
                             for (Label offset : offsets) {
                                 final int target = this.index(offset);
-                                if (visited.get(target) == null) {
+                                if (visited.get(target) == null || visited.get(target) < stack) {
                                     worklist.add(target);
                                 }
                             }
-//                            if (var.isConditionalBranchInstruction()) {
-//                                final int next = current + 1;
-//                                if (visited.get(next) == null || visited.get(next) < stack) {
-//                                    worklist.add(next);
-//                                }
-//                            }
                             break;
-                        } else {
+                        } else if (var.isConditionalBranchInstruction()) {
                             final int jump = this.index(var.offset());
-                            if (visited.get(jump) == null) {
+                            if (visited.get(jump) == null || visited.get(jump) < stack) {
                                 worklist.add(jump);
                                 if (var.isConditionalBranchInstruction()) {
                                     final int next = current + 1;
-                                    if (visited.get(next) == null) {
+                                    if (visited.get(next) == null || visited.get(next) < stack) {
                                         worklist.add(next);
                                     }
                                 }
-                                break;
                             }
-                        }
-                        if (var.isReturnInstruction()) {
+                            break;
+                        } else if (var.isReturnInstruction()) {
+                            break;
+                        } else {
+                            final int jump = this.index(var.offset());
+                            if (visited.get(jump) == null || visited.get(jump) < stack) {
+                                worklist.add(jump);
+                            }
                             break;
                         }
                     }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -23,15 +23,9 @@
  */
 package org.eolang.jeo.representation.bytecode;
 
-import com.jcabi.log.Logger;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Deque;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -42,7 +36,6 @@ import org.eolang.jeo.representation.xmir.AllLabels;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 
 /**
  * Bytecode method.
@@ -427,80 +420,19 @@ public final class BytecodeMethod implements Testable {
         return this.directives(true);
     }
 
+    /**
+     * Compute max stack.
+     * @return Max stack.
+     */
     private int computeStack() {
-        Logger.info(this, "Computing stack for %s", this.properties);
-        int max = 0;
-        final Deque<Integer> worklist = new ArrayDeque<>(0);
-        final int length = this.instructions.size();
-        worklist.add(0);
-        Map<Integer, Integer> visited = new TreeMap<>();
-        this.tryblocks.stream()
-            .map(BytecodeTryCatchBlock.class::cast)
-            .map(BytecodeTryCatchBlock::handler)
-            .map(this::index)
-            .peek(ind -> visited.put(ind, 1))
-            .forEach(worklist::add);
-        while (!worklist.isEmpty()) {
-            int current = worklist.pop();
-            int stack = visited.get(current) == null ? 0 : visited.get(current);
-            while (current < length) {
-                BytecodeEntry entry = this.instructions.get(current);
-                stack += entry.stackImpact();
-                max = Math.max(max, stack);
-                final int finalStack = stack;
-                visited.compute(
-                    current, (k, v) -> v == null ? finalStack : Math.max(v, finalStack)
-                );
-                if (entry instanceof BytecodeInstruction) {
-                    final BytecodeInstruction var = BytecodeInstruction.class.cast(entry);
-                    if (var.isBranchInstruction()) {
-                        if (var.isSwitchInstruction()) {
-                            final List<Label> offsets = var.offsets();
-                            for (Label offset : offsets) {
-                                final int target = this.index(offset);
-                                if (visited.get(target) == null
-                                    || visited.get(target) < stack
-                                ) {
-                                    visited.put(target, stack);
-                                    worklist.add(target);
-                                }
-                            }
-                            break;
-                        } else if (var.isConditionalBranchInstruction()) {
-                            final int jump = this.index(var.offset());
-                            if (visited.get(jump) == null
-                                || visited.get(jump) < stack
-                            ) {
-                                visited.put(jump, stack);
-                                worklist.add(jump);
-
-                            }
-                            final int next = current + 1;
-                            if (visited.get(next) == null
-                                || visited.get(next) < stack
-                            ) {
-                                visited.put(next, stack);
-                                worklist.add(next);
-                            }
-                            break;
-                        } else if (var.isReturnInstruction()) {
-                            break;
-                        } else {
-                            final int jump = this.index(var.offset());
-                            if (visited.get(jump) == null
-                                || visited.get(jump) < stack
-                            ) {
-                                visited.put(jump, stack);
-                                worklist.add(jump);
-                            }
-                            break;
-                        }
-                    }
-                }
-                current++;
-            }
-        }
-        return max;
+        return new MaxStack(
+            this.properties,
+            this.instructions,
+            this.tryblocks.stream()
+                .filter(BytecodeTryCatchBlock.class::isInstance)
+                .map(BytecodeTryCatchBlock.class::cast)
+                .collect(Collectors.toList())
+        ).value();
     }
 
     /**
@@ -509,134 +441,14 @@ public final class BytecodeMethod implements Testable {
      */
     private int computeLocals() {
         return new MaxLocals(
-            this.properties, this.instructions,
+            this.properties,
+            this.instructions,
             this.tryblocks.stream()
                 .filter(BytecodeTryCatchBlock.class::isInstance)
                 .map(BytecodeTryCatchBlock.class::cast)
                 .collect(Collectors.toList())
         ).value();
-//        Logger.info(this, "Computing locals for %s", this.properties);
-//        Variables initial = new Variables();
-//        int first = 0;
-//        if (!this.properties.isStatic()) {
-//            initial.put(0, 1);
-//            first = 1;
-//        }
-//        final Type[] types = Type.getArgumentTypes(this.properties.descriptor());
-//        for (int index = 0; index < types.length; index++) {
-//            final Type type = types[index];
-//            initial.put(index * type.getSize() + first, type.getSize());
-//        }
-//        Map<Integer, Variables> all = new TreeMap<>();
-//        Map<Integer, Variables> worklist = new HashMap<>();
-//        worklist.put(0, initial);
-//        final int total = this.instructions.size();
-//        Variables currentVars;
-//        while (!worklist.isEmpty()) {
-//            final Map.Entry<Integer, Variables> curr = worklist.entrySet()
-//                .stream()
-//                .findFirst()
-//                .orElseThrow(() -> new IllegalStateException(""));
-//            int current = curr.getKey();
-//            worklist.remove(current);
-//            if (all.get(current) != null) {
-//                continue;
-//            }
-//            currentVars = new Variables(curr.getValue());
-//            while (current < total) {
-//                BytecodeEntry entry = this.instructions.get(current);
-//                if (entry instanceof BytecodeInstruction) {
-//                    final BytecodeInstruction var = BytecodeInstruction.class.cast(entry);
-//                    if (var.isBranchInstruction()) {
-//                        if (var.isSwitchInstruction()) {
-//                            final List<Label> offsets = var.offsets();
-//                            for (Label offset : offsets) {
-//                                final int target = this.index(offset);
-//                                worklist.put(target, new Variables(currentVars));
-//                            }
-//                            break;
-//                        } else if (var.isConditionalBranchInstruction()) {
-//                            final int jump = this.index(var.offset());
-//                            worklist.put(jump, new Variables(currentVars));
-//                            final int next = current + 1;
-//                            worklist.put(next, new Variables(currentVars));
-//                            break;
-//                        } else {
-//                            final int jump = this.index(var.offset());
-//                            worklist.put(jump, new Variables(currentVars));
-//                            break;
-//                        }
-//                    } else if (var.isReturnInstruction()) {
-//                        break;
-//                    }
-//                    if (var.isVarInstruction()) {
-//                        currentVars.put(var);
-//                    }
-//                }
-//                final Variables value = new Variables(currentVars);
-//                this.catches(current).stream().forEach(ind -> {
-//                    worklist.put(ind, new Variables(value));
-//                });
-//                all.put(current, value);
-//                current++;
-//            }
-//        }
-//        return all.values().stream().mapToInt(Variables::size).max().orElse(0);
     }
 
-    private List<Integer> catches(final int instruction) {
-        return this.tryblocks.stream().map(BytecodeTryCatchBlock.class::cast)
-            .filter(
-                block -> index(block.start()) <= instruction
-                    && index(block.end()) >= instruction
-            ).map(
-                block -> index(block.handler())
-            ).collect(Collectors.toList());
-    }
 
-    private int index(final Label label) {
-        for (int index = 0; index < this.instructions.size(); index++) {
-            final BytecodeEntry entry = this.instructions.get(index);
-            final BytecodeLabel obj = new BytecodeLabel(label, new AllLabels());
-            final boolean equals = entry.equals(obj);
-            if (equals) {
-                return index;
-            }
-        }
-        throw new IllegalStateException("Label not found");
-    }
-
-    @ToString
-    private static class Variables {
-
-        private final TreeMap<Integer, Integer> all;
-
-        public Variables() {
-            this(new HashMap<>(0));
-        }
-
-        public Variables(final Variables vars) {
-            this(vars.all);
-        }
-
-        public Variables(final Map<Integer, Integer> all) {
-            this.all = new TreeMap<>(all);
-        }
-
-        int size() {
-            if (all.isEmpty()) {
-                return 0;
-            }
-            final Map.Entry<Integer, Integer> entry = all.lastEntry();
-            return (entry.getKey() + 1) + ((int) (entry.getValue() * 0.5));
-        }
-
-        public void put(BytecodeInstruction var) {
-            this.put(var.localIndex(), var.size());
-        }
-
-        public void put(int index, int value) {
-            this.all.put(index, value);
-        }
-    }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -433,7 +433,6 @@ public final class BytecodeMethod implements Testable {
         return this.directives(true);
     }
 
-
     private int computeStack() {
         Logger.info(this, "Computing stack for %s", this.properties);
         int max = 0;
@@ -441,15 +440,12 @@ public final class BytecodeMethod implements Testable {
         final int length = this.instructions.size();
         worklist.add(0);
         Map<Integer, Integer> visited = new TreeMap<>();
-
         this.tryblocks.stream()
             .map(BytecodeTryCatchBlock.class::cast)
             .map(BytecodeTryCatchBlock::handler)
             .map(this::index)
             .peek(ind -> visited.put(ind, 1))
             .forEach(worklist::add);
-
-
         while (!worklist.isEmpty()) {
             int current = worklist.pop();
             int stack = visited.get(current) == null ? 0 : visited.get(current);
@@ -485,17 +481,13 @@ public final class BytecodeMethod implements Testable {
                                 worklist.add(jump);
 
                             }
-
-                            if (var.isConditionalBranchInstruction()) {
-                                final int next = current + 1;
-                                if (visited.get(next) == null
-                                    || visited.get(next) < stack
-                                ) {
-                                    visited.put(next, stack);
-                                    worklist.add(next);
-                                }
+                            final int next = current + 1;
+                            if (visited.get(next) == null
+                                || visited.get(next) < stack
+                            ) {
+                                visited.put(next, stack);
+                                worklist.add(next);
                             }
-
                             break;
                         } else if (var.isReturnInstruction()) {
                             break;

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -366,7 +366,7 @@ public final class BytecodeMethod implements Testable {
      * @return Maxs.
      */
     BytecodeMaxs computeMaxs() {
-        return new BytecodeMaxs();
+        return new BytecodeMaxs(0, this.computeLocals());
     }
 
     /**
@@ -418,5 +418,14 @@ public final class BytecodeMethod implements Testable {
      */
     DirectivesMethod directives() {
         return this.directives(true);
+    }
+
+    /**
+     * Compute max local variables.
+     * @return Max local variables.
+     */
+    private int computeLocals() {
+        this.properties.descriptor();
+        return 0;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -367,7 +367,7 @@ public final class BytecodeMethod implements Testable {
      * @return Maxs.
      */
     BytecodeMaxs computeMaxs() {
-        return new BytecodeMaxs(0, this.computeLocals());
+        return new BytecodeMaxs(this.computeStack(), this.computeLocals());
     }
 
     /**
@@ -419,6 +419,19 @@ public final class BytecodeMethod implements Testable {
      */
     DirectivesMethod directives() {
         return this.directives(true);
+    }
+
+    private int computeStack() {
+        int stack = 0;
+        int max = 0;
+        for (final BytecodeEntry instruction : this.instructions) {
+            if (instruction instanceof BytecodeInstruction) {
+                final BytecodeInstruction var = BytecodeInstruction.class.cast(instruction);
+                stack += var.stack();
+                max = Math.max(max, stack);
+            }
+        }
+        return max;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation.bytecode;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
@@ -93,6 +94,21 @@ public final class BytecodeMethod implements Testable {
      */
     public BytecodeMethod(final String name) {
         this(name, "()V", Opcodes.ACC_PUBLIC);
+    }
+
+    /**
+     * Constructor.
+     * @param instructions Method instructions.
+     */
+    public BytecodeMethod(BytecodeEntry... instructions) {
+        this(
+            new ArrayList<>(0),
+            Arrays.asList(instructions),
+            new BytecodeAnnotations(),
+            new BytecodeMethodProperties("foo", "()V", "", Opcodes.ACC_PUBLIC),
+            new ArrayList<>(0),
+            new BytecodeMaxs(0, 0)
+        );
     }
 
     /**
@@ -343,6 +359,22 @@ public final class BytecodeMethod implements Testable {
                 exception
             );
         }
+    }
+
+    /**
+     * Compute maxs.
+     * @return Maxs.
+     */
+    BytecodeMaxs computeMaxs() {
+        return new BytecodeMaxs();
+    }
+
+    /**
+     * Current maxs.
+     * @return Maxs.
+     */
+    BytecodeMaxs currentMaxs() {
+        return this.maxs;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
@@ -186,6 +186,14 @@ public final class BytecodeMethodProperties implements Testable {
     }
 
     /**
+     * Is method static.
+     * @return True if the method is static.
+     */
+    public boolean isStatic() {
+        return (this.access & Opcodes.ACC_STATIC) != 0;
+    }
+
+    /**
      * Convert to directives.
      * @param maxs Maxs.
      * @return Directives.

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
@@ -119,6 +119,14 @@ public final class BytecodeTryCatchBlock implements BytecodeEntry {
         return "// Try-catch blocks are not supported in tests yet";
     }
 
+    public Label start() {
+        return this.start;
+    }
+
+    public Label end() {
+        return this.end;
+    }
+
     public Label handler() {
         return this.handler;
     }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
@@ -110,7 +110,7 @@ public final class BytecodeTryCatchBlock implements BytecodeEntry {
     }
 
     @Override
-    public int stackImpact() {
+    public int impact() {
         return 0;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
@@ -110,6 +110,11 @@ public final class BytecodeTryCatchBlock implements BytecodeEntry {
     }
 
     @Override
+    public int stackImpact() {
+        return 0;
+    }
+
+    @Override
     public String testCode() {
         return "// Try-catch blocks are not supported in tests yet";
     }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
@@ -118,4 +118,9 @@ public final class BytecodeTryCatchBlock implements BytecodeEntry {
     public String testCode() {
         return "// Try-catch blocks are not supported in tests yet";
     }
+
+    public Label handler() {
+        return this.handler;
+    }
+
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
@@ -119,15 +119,27 @@ public final class BytecodeTryCatchBlock implements BytecodeEntry {
         return "// Try-catch blocks are not supported in tests yet";
     }
 
-    public Label start() {
+    /**
+     * Start label.
+     * @return Label.
+     */
+    Label startLabel() {
         return this.start;
     }
 
-    public Label end() {
+    /**
+     * End label.
+     * @return Label.
+     */
+    Label endLabel() {
         return this.end;
     }
 
-    public Label handler() {
+    /**
+     * Handler label.
+     * @return Label.
+     */
+    Label handlerLabel() {
         return this.handler;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/CustomClassWriter.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/CustomClassWriter.java
@@ -101,13 +101,13 @@ public final class CustomClassWriter extends ClassVisitor {
      * @param exceptions Method exceptions.
      * @param compute If frames should be computed.
      * @return Method visitor.
-     * @checkstyle ParameterNumberCheck (25 lines)
      * @todo #540:90min Compute StackMap frames for Java methods.
      *  Currently we compute only max locals and max stack values for the methods.
      *  See {@link BytecodeMethod#computeMaxs()} method.
      *  However it's not enough to compute only max locals and max stack values.
      *  We also need to compute StackMap frames for the methods.
      *  When we compute frames we can remove this class entirely.
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     @SuppressWarnings("PMD.UseObjectForClearerAPI")
     MethodVisitor visitMethod(

--- a/src/main/java/org/eolang/jeo/representation/bytecode/CustomClassWriter.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/CustomClassWriter.java
@@ -135,6 +135,7 @@ public final class CustomClassWriter extends ClassVisitor {
      * @param signature Method signature.
      * @param exceptions Method exceptions.
      * @return Method visitor.
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     @SuppressWarnings({"PMD.AvoidAccessibilityAlteration", "PMD.UseObjectForClearerAPI"})
     private MethodVisitor visitMethodWithoutFrames(

--- a/src/main/java/org/eolang/jeo/representation/bytecode/CustomClassWriter.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/CustomClassWriter.java
@@ -101,7 +101,13 @@ public final class CustomClassWriter extends ClassVisitor {
      * @param exceptions Method exceptions.
      * @param compute If frames should be computed.
      * @return Method visitor.
-     * @checkstyle ParameterNumberCheck (5 lines)
+     * @checkstyle ParameterNumberCheck (25 lines)
+     * @todo #540:90min Compute StackMap frames for Java methods.
+     *  Currently we compute only max locals and max stack values for the methods.
+     *  See {@link BytecodeMethod#computeMaxs()} method.
+     *  However it's not enough to compute only max locals and max stack values.
+     *  We also need to compute StackMap frames for the methods.
+     *  When we compute frames we can remove this class entirely.
      */
     @SuppressWarnings("PMD.UseObjectForClearerAPI")
     MethodVisitor visitMethod(
@@ -129,15 +135,6 @@ public final class CustomClassWriter extends ClassVisitor {
      * @param signature Method signature.
      * @param exceptions Method exceptions.
      * @return Method visitor.
-     * @todo #528:90min Remove ad-hoc solution for method frames, stack and locals computation.
-     *  This method is a workaround for the issue with the ASM library that doesn't allow
-     *  to compute frames and stack values per method basis. Here I use reflection to change
-     *  the computation mode to COMPUTE_ALL_FRAMES and then restore it back to the original value.
-     *  This is a hacky solution and should be removed once the issue is fixed in the ASM library.
-     *  Another option is to compute all this values ourselves.
-     *  You can read more about this issue here:
-     *  https://stackoverflow.com/questions/78262674/how-to-mix-manual-and-automatic-calculation-of-max-locals-max-stack-and-frames
-     * @checkstyle ParameterNumberCheck (25 lines)
      */
     @SuppressWarnings({"PMD.AvoidAccessibilityAlteration", "PMD.UseObjectForClearerAPI"})
     private MethodVisitor visitMethodWithoutFrames(

--- a/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
@@ -36,7 +36,7 @@ import org.objectweb.asm.Type;
  * All supported data types.
  * @since 0.3
  */
-public enum DataType {
+enum DataType {
 
     /**
      * Boolean.

--- a/src/main/java/org/eolang/jeo/representation/bytecode/InstructionsFlow.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/InstructionsFlow.java
@@ -69,11 +69,8 @@ public final class InstructionsFlow {
      * @return Index.
      */
     int index(final Label label) {
-        for (int index = 0; index < this.instructions.size(); index++) {
-            final BytecodeEntry entry = this.instructions.get(index);
-            final BytecodeLabel obj = new BytecodeLabel(label, new AllLabels());
-            final boolean equals = entry.equals(obj);
-            if (equals) {
+        for (int index = 0; index < this.instructions.size(); ++index) {
+            if (this.instructions.get(index).equals(new BytecodeLabel(label, new AllLabels()))) {
                 return index;
             }
         }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/InstructionsFlow.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/InstructionsFlow.java
@@ -27,6 +27,10 @@ import java.util.List;
 import org.eolang.jeo.representation.xmir.AllLabels;
 import org.objectweb.asm.Label;
 
+/**
+ * Bytecode instructions flow.
+ * @since 0.6
+ */
 public final class InstructionsFlow {
 
     /**
@@ -34,18 +38,36 @@ public final class InstructionsFlow {
      */
     private final List<? extends BytecodeEntry> instructions;
 
-    public InstructionsFlow(final List<? extends BytecodeEntry> instructions) {
+    /**
+     * Constructor.
+     * @param instructions Instructions.
+     */
+    InstructionsFlow(final List<? extends BytecodeEntry> instructions) {
         this.instructions = instructions;
     }
 
+    /**
+     * Get size.
+     * @return Size.
+     */
     public int size() {
         return this.instructions.size();
     }
 
+    /**
+     * Get instruction.
+     * @param index Index.
+     * @return Instruction.
+     */
     public BytecodeEntry get(final int index) {
         return this.instructions.get(index);
     }
 
+    /**
+     * Index of the label.
+     * @param label Label.
+     * @return Index.
+     */
     int index(final Label label) {
         for (int index = 0; index < this.instructions.size(); index++) {
             final BytecodeEntry entry = this.instructions.get(index);

--- a/src/main/java/org/eolang/jeo/representation/bytecode/InstructionsFlow.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/InstructionsFlow.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.bytecode;
+
+import java.util.List;
+import org.eolang.jeo.representation.xmir.AllLabels;
+import org.objectweb.asm.Label;
+
+public final class InstructionsFlow {
+
+    /**
+     * Method instructions.
+     */
+    private final List<? extends BytecodeEntry> instructions;
+
+    public InstructionsFlow(final List<? extends BytecodeEntry> instructions) {
+        this.instructions = instructions;
+    }
+
+    public int size() {
+        return this.instructions.size();
+    }
+
+    public BytecodeEntry get(final int index) {
+        return this.instructions.get(index);
+    }
+
+    int index(final Label label) {
+        for (int index = 0; index < this.instructions.size(); index++) {
+            final BytecodeEntry entry = this.instructions.get(index);
+            final BytecodeLabel obj = new BytecodeLabel(label, new AllLabels());
+            final boolean equals = entry.equals(obj);
+            if (equals) {
+                return index;
+            }
+        }
+        throw new IllegalStateException(String.format("Label %s not found", label));
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/bytecode/MaxLocals.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/MaxLocals.java
@@ -1,0 +1,184 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.bytecode;
+
+import com.jcabi.log.Logger;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import lombok.ToString;
+import org.eolang.jeo.representation.xmir.AllLabels;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Type;
+
+/**
+ * Bytecode method max locals.
+ * This class knows hot to compute the maximum number of local variables
+ * that can be used by a method.
+ * @since 0.6
+ */
+final class MaxLocals {
+
+    private final BytecodeMethodProperties props;
+    private final List<BytecodeEntry> instructions;
+    private final List<BytecodeTryCatchBlock> blocks;
+
+    MaxLocals(
+        final BytecodeMethodProperties props,
+        final List<BytecodeEntry> instructions,
+        final List<BytecodeTryCatchBlock> blocks
+    ) {
+        this.props = props;
+        this.instructions = instructions;
+        this.blocks = blocks;
+    }
+
+    public int value() {
+        Logger.info(this, "Computing locals for %s", this.props);
+        Variables initial = new Variables();
+        int first = 0;
+        if (!this.props.isStatic()) {
+            initial.put(0, 1);
+            first = 1;
+        }
+        final Type[] types = Type.getArgumentTypes(this.props.descriptor());
+        for (int index = 0; index < types.length; index++) {
+            final Type type = types[index];
+            initial.put(index * type.getSize() + first, type.getSize());
+        }
+        Map<Integer, Variables> all = new TreeMap<>();
+        Map<Integer, Variables> worklist = new HashMap<>();
+        worklist.put(0, initial);
+        final int total = this.instructions.size();
+        Variables currentVars;
+        while (!worklist.isEmpty()) {
+            final Map.Entry<Integer, Variables> curr = worklist.entrySet()
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(""));
+            int current = curr.getKey();
+            worklist.remove(current);
+            if (all.get(current) != null) {
+                continue;
+            }
+            currentVars = new Variables(curr.getValue());
+            while (current < total) {
+                BytecodeEntry entry = this.instructions.get(current);
+                if (entry instanceof BytecodeInstruction) {
+                    final BytecodeInstruction var = BytecodeInstruction.class.cast(entry);
+                    if (var.isBranchInstruction()) {
+                        if (var.isSwitchInstruction()) {
+                            final List<Label> offsets = var.offsets();
+                            for (Label offset : offsets) {
+                                final int target = this.index(offset);
+                                worklist.put(target, new Variables(currentVars));
+                            }
+                            break;
+                        } else if (var.isConditionalBranchInstruction()) {
+                            final int jump = this.index(var.offset());
+                            worklist.put(jump, new Variables(currentVars));
+                            final int next = current + 1;
+                            worklist.put(next, new Variables(currentVars));
+                            break;
+                        } else {
+                            final int jump = this.index(var.offset());
+                            worklist.put(jump, new Variables(currentVars));
+                            break;
+                        }
+                    } else if (var.isReturnInstruction()) {
+                        break;
+                    }
+                    if (var.isVarInstruction()) {
+                        currentVars.put(var);
+                    }
+                }
+                final Variables value = new Variables(currentVars);
+                this.catches(current).stream().forEach(ind -> {
+                    worklist.put(ind, new Variables(value));
+                });
+                all.put(current, value);
+                current++;
+            }
+        }
+        return all.values().stream().mapToInt(Variables::size).max().orElse(0);
+    }
+
+    private List<Integer> catches(final int instruction) {
+        return this.blocks.stream().map(BytecodeTryCatchBlock.class::cast)
+            .filter(
+                block -> index(block.start()) <= instruction
+                    && index(block.end()) >= instruction
+            ).map(
+                block -> index(block.handler())
+            ).collect(Collectors.toList());
+    }
+
+    private int index(final Label label) {
+        for (int index = 0; index < this.instructions.size(); index++) {
+            final BytecodeEntry entry = this.instructions.get(index);
+            final BytecodeLabel obj = new BytecodeLabel(label, new AllLabels());
+            final boolean equals = entry.equals(obj);
+            if (equals) {
+                return index;
+            }
+        }
+        throw new IllegalStateException("Label not found");
+    }
+
+    @ToString
+    private static class Variables {
+
+        private final TreeMap<Integer, Integer> all;
+
+        public Variables() {
+            this(new HashMap<>(0));
+        }
+
+        public Variables(final Variables vars) {
+            this(vars.all);
+        }
+
+        public Variables(final Map<Integer, Integer> all) {
+            this.all = new TreeMap<>(all);
+        }
+
+        int size() {
+            if (all.isEmpty()) {
+                return 0;
+            }
+            final Map.Entry<Integer, Integer> entry = all.lastEntry();
+            return (entry.getKey() + 1) + ((int) (entry.getValue() * 0.5));
+        }
+
+        public void put(BytecodeInstruction var) {
+            this.put(var.localIndex(), var.size());
+        }
+
+        public void put(int index, int value) {
+            this.all.put(index, value);
+        }
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/bytecode/MaxLocals.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/MaxLocals.java
@@ -41,6 +41,10 @@ import org.objectweb.asm.Type;
  *  The MaxLocals class has a high cognitive complexity. Refactor the class
  *  to reduce the complexity. You might also extract some methods to make
  *  the class more readable. Don't forget to remove the @SuppressWarnings.
+ * @checkstyle CyclomaticComplexityCheck (500 lines)
+ * @checkstyle JavaNCSSCheck (500 lines)
+ * @checkstyle AvoidInlineConditionalsCheck (500 lines)
+ * @checkstyle NestedIfDepthCheck (500 lines)
  */
 final class MaxLocals {
 
@@ -92,8 +96,9 @@ final class MaxLocals {
     /**
      * Compute the maximum number of local variables.
      * @return Maximum number of local variables.
+     * @checkstyle ExecutableStatementCountCheck (100 lines)
      */
-    @SuppressWarnings("CognitiveComplexity")
+    @SuppressWarnings("PMD.CognitiveComplexity")
     public int value() {
         final Variables initial = new Variables();
         int first = 0;
@@ -102,7 +107,7 @@ final class MaxLocals {
             first = 1;
         }
         final Type[] types = Type.getArgumentTypes(this.props.descriptor());
-        for (int index = 0; index < types.length; index++) {
+        for (int index = 0; index < types.length; ++index) {
             final Type type = types[index];
             initial.put(index * type.getSize() + first, type.getSize());
         }
@@ -110,7 +115,7 @@ final class MaxLocals {
         final Map<Integer, Variables> worklist = new HashMap<>(0);
         worklist.put(0, initial);
         final int total = this.instructions.size();
-        Variables currentVars;
+        Variables currentv;
         while (!worklist.isEmpty()) {
             final Map.Entry<Integer, Variables> curr = worklist.entrySet()
                 .stream()
@@ -121,7 +126,7 @@ final class MaxLocals {
             if (all.get(current) != null) {
                 continue;
             }
-            currentVars = new Variables(curr.getValue());
+            currentv = new Variables(curr.getValue());
             while (current < total) {
                 final BytecodeEntry entry = this.instructions.get(current);
                 if (entry instanceof BytecodeInstruction) {
@@ -130,33 +135,32 @@ final class MaxLocals {
                         final List<Label> offsets = var.offsets();
                         for (final Label offset : offsets) {
                             final int target = this.instructions.index(offset);
-                            worklist.put(target, new Variables(currentVars));
+                            worklist.put(target, new Variables(currentv));
                         }
                         break;
                     } else if (var.isBranch()) {
                         final Label label = var.jump();
                         final int jump = this.instructions.index(label);
-                        worklist.put(jump, new Variables(currentVars));
+                        worklist.put(jump, new Variables(currentv));
                         final int next = current + 1;
-                        worklist.put(next, new Variables(currentVars));
+                        worklist.put(next, new Variables(currentv));
                         break;
                     } else if (var.isJump()) {
                         final Label label = var.jump();
                         final int jump = this.instructions.index(label);
-                        worklist.put(jump, new Variables(currentVars));
+                        worklist.put(jump, new Variables(currentv));
                         break;
                     } else if (var.isReturn()) {
                         break;
                     } else if (var.isVarInstruction()) {
-                        currentVars.put(var);
+                        currentv.put(var);
                     }
                 }
-                final Variables value = new Variables(currentVars);
-                this.suitableBlocks(current).stream().forEach(ind -> {
-                    worklist.put(ind, new Variables(value));
-                });
+                final Variables value = new Variables(currentv);
+                this.suitableBlocks(current)
+                    .forEach(ind -> worklist.put(ind, new Variables(value)));
                 all.put(current, value);
-                current++;
+                ++current;
             }
         }
         return all.values().stream().mapToInt(Variables::size).max().orElse(0);
@@ -185,6 +189,7 @@ final class MaxLocals {
 
         /**
          * All variables.
+         * @checkstyle IllegalTypeCheck (5 lines)
          */
         @SuppressWarnings("PMD.LooseCoupling")
         private final TreeMap<Integer, Integer> all;
@@ -227,7 +232,7 @@ final class MaxLocals {
 
         /**
          * Put variable.
-         * @param var
+         * @param var Variable.
          */
         void put(final BytecodeInstruction var) {
             this.put(var.varIndex(), var.varSize());

--- a/src/main/java/org/eolang/jeo/representation/bytecode/MaxStack.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/MaxStack.java
@@ -1,0 +1,144 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.bytecode;
+
+import com.jcabi.log.Logger;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.eolang.jeo.representation.xmir.AllLabels;
+import org.objectweb.asm.Label;
+
+/**
+ * Bytecode method max stack.
+ * This class knows hot to compute the maximum size of the stack
+ * that can be used by a method.
+ * @since 0.6
+ */
+public final class MaxStack {
+
+    private final BytecodeMethodProperties properties;
+    private final List<BytecodeEntry> instructions;
+    private final List<BytecodeTryCatchBlock> tryblocks;
+
+    public MaxStack(
+        final BytecodeMethodProperties properties, final List<BytecodeEntry> instructions,
+        final List<BytecodeTryCatchBlock> tryblocks
+    ) {
+        this.properties = properties;
+        this.instructions = instructions;
+        this.tryblocks = tryblocks;
+    }
+
+    public int value() {
+        Logger.info(this, "Computing stack for %s", this.properties);
+        int max = 0;
+        final Deque<Integer> worklist = new ArrayDeque<>(0);
+        final int length = this.instructions.size();
+        worklist.add(0);
+        Map<Integer, Integer> visited = new TreeMap<>();
+        this.tryblocks.stream()
+            .map(BytecodeTryCatchBlock.class::cast)
+            .map(BytecodeTryCatchBlock::handler)
+            .map(this::index)
+            .peek(ind -> visited.put(ind, 1))
+            .forEach(worklist::add);
+        while (!worklist.isEmpty()) {
+            int current = worklist.pop();
+            int stack = visited.get(current) == null ? 0 : visited.get(current);
+            while (current < length) {
+                BytecodeEntry entry = this.instructions.get(current);
+                stack += entry.stackImpact();
+                max = Math.max(max, stack);
+                final int finalStack = stack;
+                visited.compute(
+                    current, (k, v) -> v == null ? finalStack : Math.max(v, finalStack)
+                );
+                if (entry instanceof BytecodeInstruction) {
+                    final BytecodeInstruction var = BytecodeInstruction.class.cast(entry);
+                    if (var.isBranchInstruction()) {
+                        if (var.isSwitchInstruction()) {
+                            final List<Label> offsets = var.offsets();
+                            for (Label offset : offsets) {
+                                final int target = this.index(offset);
+                                if (visited.get(target) == null
+                                    || visited.get(target) < stack
+                                ) {
+                                    visited.put(target, stack);
+                                    worklist.add(target);
+                                }
+                            }
+                            break;
+                        } else if (var.isConditionalBranchInstruction()) {
+                            final int jump = this.index(var.offset());
+                            if (visited.get(jump) == null
+                                || visited.get(jump) < stack
+                            ) {
+                                visited.put(jump, stack);
+                                worklist.add(jump);
+
+                            }
+                            final int next = current + 1;
+                            if (visited.get(next) == null
+                                || visited.get(next) < stack
+                            ) {
+                                visited.put(next, stack);
+                                worklist.add(next);
+                            }
+                            break;
+                        } else if (var.isReturnInstruction()) {
+                            break;
+                        } else {
+                            final int jump = this.index(var.offset());
+                            if (visited.get(jump) == null
+                                || visited.get(jump) < stack
+                            ) {
+                                visited.put(jump, stack);
+                                worklist.add(jump);
+                            }
+                            break;
+                        }
+                    }
+                }
+                current++;
+            }
+        }
+        return max;
+    }
+
+
+    private int index(final Label label) {
+        for (int index = 0; index < this.instructions.size(); index++) {
+            final BytecodeEntry entry = this.instructions.get(index);
+            final BytecodeLabel obj = new BytecodeLabel(label, new AllLabels());
+            final boolean equals = entry.equals(obj);
+            if (equals) {
+                return index;
+            }
+        }
+        throw new IllegalStateException("Label not found");
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/bytecode/MaxStack.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/MaxStack.java
@@ -51,23 +51,26 @@ final class MaxStack {
     /**
      * Constructor.
      * @param instructions Instructions.
-     * @param tryblocks Try-catch blocks.
+     * @param catches Try-catch blocks.
      */
     MaxStack(
         final List<? extends BytecodeEntry> instructions,
-        final List<BytecodeTryCatchBlock> tryblocks
+        final List<BytecodeTryCatchBlock> catches
     ) {
-        this(new InstructionsFlow(instructions), tryblocks);
+        this(new InstructionsFlow(instructions), catches);
     }
 
     /**
      * Compute the maximum stack size.
      * @param instructions Instructions.
-     * @param blocks Try-catch blocks.
+     * @param catches Try-catch blocks.
      */
-    public MaxStack(final InstructionsFlow instructions, final List<BytecodeTryCatchBlock> blocks) {
+    private MaxStack(
+        final InstructionsFlow instructions,
+        final List<BytecodeTryCatchBlock> catches
+    ) {
         this.instructions = instructions;
-        this.blocks = blocks;
+        this.blocks = catches;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/MaxStack.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/MaxStack.java
@@ -39,6 +39,10 @@ import org.objectweb.asm.Label;
  *  The MaxLocals class has a high cognitive complexity. Refactor the class
  *  to reduce the complexity. You might also extract some methods to make
  *  the class more readable. Don't forget to remove the @SuppressWarnings.
+ * @checkstyle CyclomaticComplexityCheck (500 lines)
+ * @checkstyle JavaNCSSCheck (500 lines)
+ * @checkstyle AvoidInlineConditionalsCheck (500 lines)
+ * @checkstyle NestedIfDepthCheck (500 lines)
  */
 final class MaxStack {
 
@@ -81,8 +85,7 @@ final class MaxStack {
      * Compute the maximum stack size.
      * @return Maximum stack size.
      */
-    @SuppressWarnings("CognitiveComplexity")
-
+    @SuppressWarnings("PMD.CognitiveComplexity")
     public int value() {
         int max = 0;
         final Deque<Integer> worklist = new ArrayDeque<>(0);
@@ -99,7 +102,7 @@ final class MaxStack {
             int current = worklist.pop();
             int stack = visited.get(current) == null ? 0 : visited.get(current);
             while (current < length) {
-                BytecodeEntry entry = this.instructions.get(current);
+                final BytecodeEntry entry = this.instructions.get(current);
                 stack += entry.impact();
                 max = Math.max(max, stack);
                 final int fstack = stack;
@@ -128,7 +131,6 @@ final class MaxStack {
                         ) {
                             visited.put(jump, stack);
                             worklist.add(jump);
-
                         }
                         final int next = current + 1;
                         if (visited.get(next) == null
@@ -152,7 +154,7 @@ final class MaxStack {
                         break;
                     }
                 }
-                current++;
+                ++current;
             }
         }
         return max;

--- a/src/main/java/org/eolang/jeo/representation/bytecode/MaxStack.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/MaxStack.java
@@ -94,7 +94,7 @@ final class MaxStack {
             int stack = visited.get(current) == null ? 0 : visited.get(current);
             while (current < length) {
                 BytecodeEntry entry = this.instructions.get(current);
-                stack += entry.stackImpact();
+                stack += entry.impact();
                 max = Math.max(max, stack);
                 final int finalStack = stack;
                 visited.compute(
@@ -102,8 +102,8 @@ final class MaxStack {
                 );
                 if (entry instanceof BytecodeInstruction) {
                     final BytecodeInstruction var = BytecodeInstruction.class.cast(entry);
-                    if (var.isBranchInstruction()) {
-                        if (var.isSwitchInstruction()) {
+                    if (var.isBranch()) {
+                        if (var.isSwitch()) {
                             final List<Label> offsets = var.offsets();
                             for (Label offset : offsets) {
                                 final int target = this.instructions.index(offset);
@@ -115,8 +115,8 @@ final class MaxStack {
                                 }
                             }
                             break;
-                        } else if (var.isConditionalBranchInstruction()) {
-                            final Label label = var.offset();
+                        } else if (var.isConditionalBranch()) {
+                            final Label label = var.jump();
                             final int jump = this.instructions.index(label);
                             if (visited.get(jump) == null
                                 || visited.get(jump) < stack
@@ -133,10 +133,8 @@ final class MaxStack {
                                 worklist.add(next);
                             }
                             break;
-                        } else if (var.isReturnInstruction()) {
-                            break;
                         } else {
-                            final Label label = var.offset();
+                            final Label label = var.jump();
                             final int jump = this.instructions.index(label);
                             if (visited.get(jump) == null
                                 || visited.get(jump) < stack
@@ -146,6 +144,8 @@ final class MaxStack {
                             }
                             break;
                         }
+                    } else if (var.isReturn()) {
+                        break;
                     }
                 }
                 current++;

--- a/src/main/java/org/eolang/jeo/representation/bytecode/MaxStack.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/MaxStack.java
@@ -102,48 +102,46 @@ final class MaxStack {
                 );
                 if (entry instanceof BytecodeInstruction) {
                     final BytecodeInstruction var = BytecodeInstruction.class.cast(entry);
-                    if (var.isBranch()) {
-                        if (var.isSwitch()) {
-                            final List<Label> offsets = var.offsets();
-                            for (Label offset : offsets) {
-                                final int target = this.instructions.index(offset);
-                                if (visited.get(target) == null
-                                    || visited.get(target) < stack
-                                ) {
-                                    visited.put(target, stack);
-                                    worklist.add(target);
-                                }
-                            }
-                            break;
-                        } else if (var.isConditionalBranch()) {
-                            final Label label = var.jump();
-                            final int jump = this.instructions.index(label);
-                            if (visited.get(jump) == null
-                                || visited.get(jump) < stack
+                    if (var.isSwitch()) {
+                        final List<Label> offsets = var.offsets();
+                        for (Label offset : offsets) {
+                            final int target = this.instructions.index(offset);
+                            if (visited.get(target) == null
+                                || visited.get(target) < stack
                             ) {
-                                visited.put(jump, stack);
-                                worklist.add(jump);
-
+                                visited.put(target, stack);
+                                worklist.add(target);
                             }
-                            final int next = current + 1;
-                            if (visited.get(next) == null
-                                || visited.get(next) < stack
-                            ) {
-                                visited.put(next, stack);
-                                worklist.add(next);
-                            }
-                            break;
-                        } else {
-                            final Label label = var.jump();
-                            final int jump = this.instructions.index(label);
-                            if (visited.get(jump) == null
-                                || visited.get(jump) < stack
-                            ) {
-                                visited.put(jump, stack);
-                                worklist.add(jump);
-                            }
-                            break;
                         }
+                        break;
+                    } else if (var.isBranch()) {
+                        final Label label = var.jump();
+                        final int jump = this.instructions.index(label);
+                        if (visited.get(jump) == null
+                            || visited.get(jump) < stack
+                        ) {
+                            visited.put(jump, stack);
+                            worklist.add(jump);
+
+                        }
+                        final int next = current + 1;
+                        if (visited.get(next) == null
+                            || visited.get(next) < stack
+                        ) {
+                            visited.put(next, stack);
+                            worklist.add(next);
+                        }
+                        break;
+                    } else if (var.isJump()) {
+                        final Label label = var.jump();
+                        final int jump = this.instructions.index(label);
+                        if (visited.get(jump) == null
+                            || visited.get(jump) < stack
+                        ) {
+                            visited.put(jump, stack);
+                            worklist.add(jump);
+                        }
+                        break;
                     } else if (var.isReturn()) {
                         break;
                     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.eolang.jeo.representation.bytecode.BytecodeInstructionEntry;
+import org.eolang.jeo.representation.bytecode.BytecodeInstruction;
 import org.eolang.jeo.representation.directives.DirectivesInstruction;
 import org.xembly.Transformers;
 import org.xembly.Xembler;
@@ -92,8 +92,8 @@ public final class XmlInstruction implements XmlBytecodeEntry {
      * Convert to bytecode.
      * @return Bytecode instruction.
      */
-    public BytecodeInstructionEntry bytecode() {
-        return new BytecodeInstructionEntry(
+    public BytecodeInstruction bytecode() {
+        return new BytecodeInstruction(
             this.opcode(),
             this.operands().stream().map(XmlOperand::asObject).collect(Collectors.toList())
         );

--- a/src/test/java/it/JavaSourceClass.java
+++ b/src/test/java/it/JavaSourceClass.java
@@ -48,7 +48,7 @@ import org.eolang.jeo.representation.bytecode.Bytecode;
  * @since 0.1
  */
 @SuppressWarnings("JTCOP.RuleCorrectTestName")
-final class JavaSourceClass {
+public final class JavaSourceClass {
 
     /**
      * Name of Java class.
@@ -64,7 +64,7 @@ final class JavaSourceClass {
      * Constructor.
      * @param resource Resource of Java class.
      */
-    JavaSourceClass(final String resource) {
+    public JavaSourceClass(final String resource) {
         this(JavaSourceClass.filename(resource), new ResourceOf(resource));
     }
 
@@ -82,7 +82,7 @@ final class JavaSourceClass {
      * Compile the Java class.
      * @return Bytecode of compiled class.
      */
-    Bytecode compile() {
+    public Bytecode compile() {
         final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
         final BytecodeManager manager = new BytecodeManager(compiler);
         final boolean successful = compiler.getTask(

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -96,12 +96,12 @@ final class BytecodeClassTest {
     void createsBytecodeWithDefaultConstructor() {
         MatcherAssert.assertThat(
             "Can't create bytecode with default public constructor",
-            new BytecodeProgram(new BytecodeClass("DefaultConstructor")
-                .withConstructor(Opcodes.ACC_PUBLIC)
-                .opcode(Opcodes.RETURN)
-                .up()
-            )
-                .bytecode(),
+            new BytecodeProgram(
+                new BytecodeClass("DefaultConstructor")
+                    .withConstructor(Opcodes.ACC_PUBLIC)
+                    .opcode(Opcodes.RETURN)
+                    .up()
+            ).bytecode(),
             Matchers.notNullValue()
         );
     }
@@ -189,8 +189,7 @@ final class BytecodeClassTest {
             () -> new BytecodeProgram(new BytecodeClass("org/eolang/benchmark/F")
                 .withMethod("j$foo", "()I", 1025)
                 .up()
-            )
-                .bytecode(),
+            ).bytecode(),
             "We expect no exception here because all instructions are valid. This is an abstract method."
         );
     }
@@ -209,8 +208,7 @@ final class BytecodeClassTest {
                 .opcode(Opcodes.IRETURN)
                 .label(new Label())
                 .up()
-            )
-                .bytecode(),
+            ).bytecode(),
             "We expect an exception here because the bytecode is broken"
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -23,10 +23,14 @@
  */
 package org.eolang.jeo.representation.bytecode;
 
+import com.jcabi.log.Logger;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
+import it.JavaSourceClass;
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.eolang.jeo.representation.asm.AsmProgram;
 import org.eolang.jeo.representation.directives.HasMethod;
 import org.eolang.jeo.representation.xmir.AllLabels;
 import org.hamcrest.MatcherAssert;
@@ -450,5 +454,23 @@ final class BytecodeMethodTest {
                 Matchers.containsString("label")
             )
         );
+    }
+
+    @Test
+    void computesMaxsCorrectly() {
+        final List<BytecodeMethod> methods = new AsmProgram(
+            new JavaSourceClass("maxs/Maxs.java").compile().bytes()
+        ).bytecode().top().methods();
+        for (final BytecodeMethod method : methods) {
+            Logger.info(this, "Computing maxs for method %s", method.name());
+            MatcherAssert.assertThat(
+                String.format(
+                    "Maxs weren't computed correctly for method %s",
+                    method.name()
+                ),
+                method.computeMaxs(),
+                Matchers.equalTo(method.currentMaxs())
+            );
+        }
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -462,14 +462,19 @@ final class BytecodeMethodTest {
             new JavaSourceClass("maxs/Maxs.java").compile().bytes()
         ).bytecode().top().methods();
         for (final BytecodeMethod method : methods) {
-            Logger.info(this, "Computing maxs for method %s", method.name());
+            Logger.info(
+                this,
+                "Computing maxs for method %s, expected %s",
+                method.name(),
+                method.currentMaxs()
+            );
             MatcherAssert.assertThat(
                 String.format(
                     "Maxs weren't computed correctly for method %s",
                     method.name()
                 ),
-                method.computeMaxs(),
-                Matchers.equalTo(method.currentMaxs())
+                method.computeMaxs().locals(),
+                Matchers.equalTo(method.currentMaxs().locals())
             );
         }
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -469,8 +469,8 @@ final class BytecodeMethodTest {
                 "Maxs weren't computed correctly for method %s",
                 name
             ),
-            method.computeMaxs().locals(),
-            Matchers.equalTo(expected.locals())
+            method.computeMaxs(),
+            Matchers.equalTo(expected)
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -23,11 +23,9 @@
  */
 package org.eolang.jeo.representation.bytecode;
 
-import com.jcabi.log.Logger;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
 import it.JavaSourceClass;
-import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.asm.AsmProgram;
@@ -380,7 +378,7 @@ final class BytecodeMethodTest {
             "MultiArray instruction wasn't visited successfully.",
             new Xembler(
                 new BytecodeMethod().entry(
-                    new BytecodeInstructionEntry(Opcodes.MULTIANEWARRAY, "java/lang/String", 2)
+                    new BytecodeInstruction(Opcodes.MULTIANEWARRAY, "java/lang/String", 2)
                 ).directives()
             ).xml(),
             Matchers.allOf(
@@ -396,7 +394,7 @@ final class BytecodeMethodTest {
             "Iinc instruction wasn't visited successfully.",
             new Xembler(
                 new BytecodeMethod().entry(
-                    new BytecodeInstructionEntry(Opcodes.IINC, 1, 2)
+                    new BytecodeInstruction(Opcodes.IINC, 1, 2)
                 ).directives()
             ).xml(),
             Matchers.allOf(
@@ -413,7 +411,7 @@ final class BytecodeMethodTest {
             "LookupSwitch instruction wasn't visited successfully.",
             new Xembler(
                 new BytecodeMethod().entry(
-                    new BytecodeInstructionEntry(
+                    new BytecodeInstruction(
                         Opcodes.LOOKUPSWITCH,
                         Stream.concat(
                             Stream.of(new Label()),
@@ -441,7 +439,7 @@ final class BytecodeMethodTest {
             "TableSwitch instruction wasn't visited successfully.",
             new Xembler(
                 new BytecodeMethod().entry(
-                    new BytecodeInstructionEntry(
+                    new BytecodeInstruction(
                         Opcodes.TABLESWITCH,
                         Stream.concat(
                             Stream.of(1, 3, new Label()),

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
@@ -23,7 +23,7 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import org.eolang.jeo.representation.bytecode.BytecodeInstructionEntry;
+import org.eolang.jeo.representation.bytecode.BytecodeInstruction;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -38,7 +38,7 @@ final class XmlInstructionTest {
     /**
      * Default instruction which we use for testing.
      */
-    private static final BytecodeInstructionEntry INST = new BytecodeInstructionEntry(
+    private static final BytecodeInstruction INST = new BytecodeInstruction(
         Opcodes.INVOKESPECIAL, 1, 2, 3
     );
 

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
@@ -26,7 +26,7 @@ package org.eolang.jeo.representation.xmir;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.eolang.jeo.representation.bytecode.BytecodeInstructionEntry;
+import org.eolang.jeo.representation.bytecode.BytecodeInstruction;
 import org.eolang.jeo.representation.bytecode.BytecodeLabel;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -112,7 +112,7 @@ final class XmlNodeTest {
             "Can't convert to instruction entry",
             new XmlNode(
                 new Xembler(
-                    new BytecodeInstructionEntry(Opcodes.ICONST_2).directives(false)
+                    new BytecodeInstruction(Opcodes.ICONST_2).directives(false)
                 ).xml()
             ).toEntry(),
             Matchers.instanceOf(XmlInstruction.class)

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -709,6 +709,25 @@ public class Maxs {
         return true;
     }
 
+    public int elseIf(int x) {
+        if (x > 0) {
+            return 1;
+        } else if (x < 0) {
+            return -1;
+        } else {
+            return 0;
+        }
+    }
+
+    public int complexPredicatesinIf(int x) {
+        if (x > 0 && x % 2 == 0) {
+            return 1;
+        } else if (x < 0 && x % 2 == 0) {
+            return -1;
+        } else {
+            return 0;
+        }
+    }
 
     // Inner class to add complexity
     private class Inner {

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import java.util.ArrayList;
 
 
 /**
@@ -793,6 +794,40 @@ public class Maxs {
             return connection.getContentLengthLong();
         }
     }
+    private final Object statusListenerListLock = new Object();
+    private final List<Object> statusListenerList = new ArrayList<>();
+
+    public boolean add(Object listener) {
+        synchronized (this.statusListenerListLock) {
+            if (listener instanceof String) {
+                boolean isPresent = this.checkForPresence(this.statusListenerList, listener.getClass());
+                if (isPresent) {
+                    return false;
+                }
+            }
+            this.statusListenerList.add(listener);
+            return true;
+        }
+    }
+
+    private boolean checkForPresence(List<Object> list, Class<?> cls) {
+        for (Object obj : list) {
+            if (obj.getClass().equals(cls)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void displayListeners() {
+        synchronized (this.statusListenerListLock) {
+            System.out.println("Current Listeners:");
+            for (Object listener : statusListenerList) {
+                System.out.println(" - " + listener + " (" + listener.getClass().getSimpleName() + ")");
+            }
+        }
+    }
+
 
     // Inner class to add complexity
     private class Inner {

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -31,6 +31,9 @@
  */
 public class Maxs {
 
+    public static final double DOUBLE_CONSTANT = 3.14d;
+    public static final float FLOAT_CONSTANT = 3.14f;
+
     public static void main(String[] args) {
         System.out.println(fortyTwo());
         System.out.println("passed");
@@ -285,6 +288,24 @@ public class Maxs {
         String part2 = inner.partTwo(); // local variable 4
         sb.append(part1).append(part2);
         return sb.toString();
+    }
+
+    /**
+     * Loads double constant.
+     * This method has 3 local variables (including 'this') and 4 stack elements.
+     */
+    public double loadDoubleConstant() {
+        double d = Maxs.DOUBLE_CONSTANT;
+        return d * 3d;
+    }
+
+    /**
+     * Loads float constant.
+     * This method has 2 local variables (including 'this') and 2 stack elements.
+     */
+    public float loadFloatConstant() {
+        float f = Maxs.FLOAT_CONSTANT;
+        return f * 3f;
     }
 
     // Inner class to add complexity

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -424,6 +424,16 @@ public class Maxs {
         return a - b;
     }
 
+    private void ifstatement(int initial) {
+        if (initial > 10) {
+            long a = 42L * System.currentTimeMillis();
+            long b = 42L * System.currentTimeMillis();
+            System.out.println("Hello: " + a + b);
+        } else {
+            System.out.println("World");
+        }
+    }
+
     // Inner class to add complexity
     private class Inner {
         public String partOne() {

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -428,9 +428,26 @@ public class Maxs {
         if (initial > 10) {
             long a = 42L * System.currentTimeMillis();
             long b = 42L * System.currentTimeMillis();
+            int d = 10;
+            int x1 = 10;
+            int x2 = 20;
+            int x3 = 30;
+            int x4 = 40;
+            int x5 = 50;
+            int x6 = 60;
+            int x7 = 70;
+            a = a + b + x1 + x2 + x3 + x4 + x5 + x6 + x7;
+            a += d;
             System.out.println("Hello: " + a + b);
         } else {
-            System.out.println("World");
+            long a = 42L * System.currentTimeMillis();
+            int b = 10;
+            a = a + b;
+            int c = 112;
+            a += c;
+            b += c;
+            a += b;
+            System.out.println("World: " + a);
         }
     }
 

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -324,7 +324,6 @@ public class Maxs {
 
     /**
      * Put float constant.
-     * This method has 1 local variables (including 'this') and 1 stack elements.
      */
     public int putFloatConstant() {
         Maxs.FLOAT_CONSTANT = 42f;
@@ -333,19 +332,81 @@ public class Maxs {
 
     /**
      * Loads int field
-     * This method has 1 local variables (including 'this') and 1 stack elements.
      */
     public int loadIntField() {
-        return this.someIntField;
+        return new Maxs().someIntField;
     }
 
     /**
      * Loads long field
-     * This method has 1 local variables (including 'this') and 2 stack elements.
      */
     public long loadLongField() {
-        return this.someLongField;
+        return new Maxs().someLongField;
     }
+
+    /**
+     * Puts long field
+     * @param value Value to put
+     */
+    public void putsLongField(final long value) {
+        this.someLongField = value;
+    }
+
+    /**
+     * Puts int field
+     * @param value Value to put
+     */
+    public void putsIntField(final int value) {
+        this.someIntField = value;
+    }
+
+    /**
+     * Multiarray example.
+     */
+    public int[][][] multiarrayExample() {
+        int[][][] multiarray = new int[2][3][4];
+        long[][][][] longMultiarray = new long[2][3][4][5];
+        longMultiarray[1][2][3][4] = 42L;
+        longMultiarray[1][1][3][4] = 42L;
+        multiarray[1][2][3] = (int) longMultiarray[1][2][3][4] + (int) longMultiarray[1][1][3][4];
+        return multiarray;
+    }
+
+    /**
+     * Lookup switch example.
+     */
+    public int lookupSwitchExample(int key) {
+        switch (key) {
+            case 1:
+                return 1;
+            case 2:
+                return 2;
+            case 3:
+                return 3;
+            default:
+                return -1;
+        }
+    }
+
+    /**
+     * Table switch example.
+     */
+    public int tableSwitchExample(int key) {
+        switch (key) {
+            case 100:
+                return 1;
+            case 200:
+                return 2;
+            case 300:
+                return 3;
+            case 7070:
+                return 4;
+            default:
+                return -1;
+        }
+    }
+
+
 
     // Inner class to add complexity
     private class Inner {

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -375,7 +375,7 @@ public class Maxs {
     /**
      * Lookup switch example.
      */
-    public int lookupSwitchExample(int key) {
+    public int tableSwitchExample(int key) {
         switch (key) {
             case 1:
                 return 1;
@@ -391,22 +391,38 @@ public class Maxs {
     /**
      * Table switch example.
      */
-    public int tableSwitchExample(int key) {
+    public int lookupSwitchExample(int key) {
         switch (key) {
-            case 100:
+            case 1:
                 return 1;
-            case 200:
+            case 10:
                 return 2;
-            case 300:
+            case 100:
                 return 3;
-            case 7070:
+            case 1000:
                 return 4;
             default:
                 return -1;
         }
     }
 
+    private long invokeSpecial() {
+        return new Maxs().privateMethod(3, 4) * 2L;
+    }
 
+    private long privateMethod(long a, long b) {
+        System.out.println("Private method");
+        return a + b;
+    }
+
+    private static int invokeStatic() {
+        return staticMethod(10, 5) * 2;
+    }
+
+    private static int staticMethod(int a, int b) {
+        System.out.println("Static method");
+        return a - b;
+    }
 
     // Inner class to add complexity
     private class Inner {

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -22,6 +22,9 @@
  * SOFTWARE.
  */
 
+import java.lang.Math;
+import javax.validation.constraints.Max;
+
 /**
  * This class contains many different methods with different number of local
  * variables and stack elements.
@@ -31,8 +34,10 @@
  */
 public class Maxs {
 
-    public static final double DOUBLE_CONSTANT = 3.14d;
-    public static final float FLOAT_CONSTANT = 3.14f;
+    public static double DOUBLE_CONSTANT = 3.14d;
+    public static float FLOAT_CONSTANT = 3.14f;
+    private int someIntField = 42;
+    private long someLongField = 42L;
 
     public static void main(String[] args) {
         System.out.println(fortyTwo());
@@ -295,7 +300,7 @@ public class Maxs {
      * This method has 3 local variables (including 'this') and 4 stack elements.
      */
     public double loadDoubleConstant() {
-        double d = Maxs.DOUBLE_CONSTANT;
+        double d = Math.PI;
         return d * 3d;
     }
 
@@ -306,6 +311,40 @@ public class Maxs {
     public float loadFloatConstant() {
         float f = Maxs.FLOAT_CONSTANT;
         return f * 3f;
+    }
+
+    /**
+     * Put double constant.
+     * This method has 1 local variables (including 'this') and 1 stack elements.
+     */
+    public long putDoubleConstant() {
+        Maxs.DOUBLE_CONSTANT = 42L;
+        return 3L;
+    }
+
+    /**
+     * Put float constant.
+     * This method has 1 local variables (including 'this') and 1 stack elements.
+     */
+    public int putFloatConstant() {
+        Maxs.FLOAT_CONSTANT = 42f;
+        return 3;
+    }
+
+    /**
+     * Loads int field
+     * This method has 1 local variables (including 'this') and 1 stack elements.
+     */
+    public int loadIntField() {
+        return this.someIntField;
+    }
+
+    /**
+     * Loads long field
+     * This method has 1 local variables (including 'this') and 2 stack elements.
+     */
+    public long loadLongField() {
+        return this.someLongField;
     }
 
     // Inner class to add complexity

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -22,21 +22,25 @@
  * SOFTWARE.
  */
 
-import java.lang.Math;
-import java.util.List;
 import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.net.HttpURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import java.lang.reflect.Constructor;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.ArrayList;
-import java.util.Arrays;
+
 
 /**
  * This class contains many different methods with different number of local
@@ -762,6 +766,27 @@ public class Maxs {
         }
     }
 
+    public long contentLength() throws IOException, URISyntaxException {
+        URL url = new URL("https://www.example.com");
+        if (isEvenAndPositive(10)) {
+            File file = new File(url.toURI());
+            long length = file.length();
+            if (length == 0L && !file.exists()) {
+                throw new FileNotFoundException(
+                    url.toString() + " cannot be resolved in the file system for checking its content length"
+                );
+            } else {
+                return length;
+            }
+        } else {
+            URLConnection connection = url.openConnection();
+            if (connection instanceof HttpURLConnection) {
+                HttpURLConnection httpConn = (HttpURLConnection) connection;
+                httpConn.setRequestMethod("HEAD");
+            }
+            return connection.getContentLengthLong();
+        }
+    }
 
     // Inner class to add complexity
     private class Inner {

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -627,6 +627,11 @@ public class Maxs {
         return Stream.of(x).allMatch(n -> n > 0 && n % 2 == 0);
     }
 
+    public static int problematicStatic(String[] args) {
+        String obj = args[0];
+        return obj.length();
+    }
+
     // Inner class to add complexity
     private class Inner {
         public String partOne() {

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Constructor;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * This class contains many different methods with different number of local
@@ -747,6 +748,33 @@ public class Maxs {
             // The result is intentionally discarded to match the bytecode 'pop' instruction
         } catch (Exception ex) {
             throw new IllegalStateException("Cannot bind to SpringApplication", ex);
+        }
+    }
+
+    protected void configurePropertySources(Object var1, String[] var2) {
+        String var3 = String.valueOf(var1);
+
+        if (this.collection != null) {
+            String defaultProps = String.valueOf(this.collection);
+            // Simulate addOrMerge operation by concatenating strings
+            defaultProps.concat(var3);
+            // Result is intentionally discarded to match the original bytecode behavior
+        }
+
+        if (this.growCollection && var2.length > 0) {
+            String var4 = "commandLineArgs";
+            if (var3.contains(var4)) {
+                String var5 = var3;
+                StringBuilder var6 = new StringBuilder(var4);
+                var6.append("springApplicationCommandLineArgs");
+                var6.append(Arrays.toString(var2));
+                var6.append(var5);
+                // Simulate replace operation
+                var3 = var3.replace(var4, var6.toString());
+            } else {
+                // Simulate addFirst operation by prepending strings
+                var3 = Arrays.toString(var2) + var3;
+            }
         }
     }
 

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -64,6 +64,26 @@ public class Maxs {
     }
 
     /**
+     * This method has 5 local variables ('double' types and 'this') and 2 stack elements.
+     * @param a
+     * @param b
+     * @return a / b
+     */
+    public double div(double a, double b) {
+        return a / b;
+    }
+
+    /**
+     * This method has 4 local ('long' types) variables and 2 stack elements.
+     * @param a
+     * @param b
+     * @return a * b
+     */
+    public static long mul(long a, long b) {
+        return a * b;
+    }
+
+    /**
      * This method has 11 (including 'this') local variables and 1 stack element.
      */
     public int manyLocals() {
@@ -78,5 +98,24 @@ public class Maxs {
         int i = (int) System.currentTimeMillis();
         int j = (int) System.currentTimeMillis();
         return a + b + c + d + e + f + g + h + i + j;
+    }
+
+    /**
+     * This method has 25 local variables because it uses 'long' types.
+     */
+    public long manyLocals2() {
+        long a = System.currentTimeMillis();
+        long b = System.currentTimeMillis();
+        long c = System.currentTimeMillis();
+        long d = System.currentTimeMillis();
+        long e = System.currentTimeMillis();
+        long f = System.currentTimeMillis();
+        long g = System.currentTimeMillis();
+        long h = System.currentTimeMillis();
+        long i = System.currentTimeMillis();
+        long j = System.currentTimeMillis();
+        long k = System.currentTimeMillis();
+        long l = System.currentTimeMillis();
+        return a + b + c + d + e + f + g + h + i + j + k + l;
     }
 }

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * This class contains many different methods with different number of local
+ * variables and stack elements.
+ * Primarly this class is used in {@link BytecodeMethodTest} to test how the
+ * {@link BytecodeMethod} class counts the maxs.
+ * @since 0.6
+ */
+public class Maxs {
+
+    public static void main(String[] args) {
+        System.out.println(fortyTwo());
+        System.out.println("passed");
+    }
+
+    /**
+     * This method has 0 local variables and 1 stack element.
+     * @return 42
+     */
+    static byte fortyTwo() {
+        return 42;
+    }
+
+    /**
+     * This method has 3 local variables (including 'this') and 2 stack elements.
+     * @param a
+     * @param b
+     * @return a + b
+     */
+    public int add(int a, int b) {
+        return a + b;
+    }
+
+    /**
+     * This method has 2 local variables and 2 stack elements.
+     * @param a
+     * @param b
+     */
+    public static int sub(int a, int b) {
+        return a - b;
+    }
+}

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -62,4 +62,21 @@ public class Maxs {
     public static int sub(int a, int b) {
         return a - b;
     }
+
+    /**
+     * This method has 11 (including 'this') local variables and 1 stack element.
+     */
+    public int manyLocals() {
+        int a = (int) System.currentTimeMillis();
+        int b = (int) System.currentTimeMillis();
+        int c = (int) System.currentTimeMillis();
+        int d = (int) System.currentTimeMillis();
+        int e = (int) System.currentTimeMillis();
+        int f = (int) System.currentTimeMillis();
+        int g = (int) System.currentTimeMillis();
+        int h = (int) System.currentTimeMillis();
+        int i = (int) System.currentTimeMillis();
+        int j = (int) System.currentTimeMillis();
+        return a + b + c + d + e + f + g + h + i + j;
+    }
 }

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -23,7 +23,14 @@
  */
 
 import java.lang.Math;
-import javax.validation.constraints.Max;
+import java.util.List;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * This class contains many different methods with different number of local
@@ -449,6 +456,175 @@ public class Maxs {
             a += b;
             System.out.println("World: " + a);
         }
+    }
+
+    public int sumUpTo(int n) {
+        int sum = 0;
+        for (int i = 1; i <= n; i++) {
+            sum += i;
+        }
+        return sum;
+    }
+
+    public String categorizeNumber(int x) {
+        if (x > 0) {
+            if (x % 2 == 0) {
+                return "Positive Even";
+            } else {
+                return "Positive Odd";
+            }
+        } else {
+            return "Non-Positive";
+        }
+    }
+
+    public int divide(int a, int b) {
+        try {
+            return a / b;
+        } catch (ArithmeticException e) {
+            System.out.println("Division by zero!");
+            return 0;
+        }
+    }
+
+
+    public int factorial(int n) {
+        if (n <= 1) {
+            return 1;
+        } else {
+            return n * factorial(n - 1);
+        }
+    }
+
+    public boolean isEvenAndPositive(int x) {
+        return (x > 0) && (x % 2 == 0);
+    }
+
+    public boolean isEitherZeroOrNegative(int x) {
+        return (x == 0) || (x < 0);
+    }
+
+    public int countDown(int start) {
+        int count = start;
+        while (count > 0) {
+            count--;
+        }
+        return count;
+    }
+
+    public int findFirstPositive(int[] numbers) {
+        int index = 0;
+        int result = -1;
+        do {
+            if (numbers[index] > 0) {
+                result = numbers[index];
+                break;
+            }
+            index++;
+        } while (index < numbers.length);
+        return result;
+    }
+
+    public int sumElements(List<Integer> list) {
+        int sum = 0;
+        for (int num : list) {
+            sum += num;
+        }
+        return sum;
+    }
+
+    public int multiplyMatrices(int[][] matrixA, int[][] matrixB) {
+        int rows = matrixA.length;
+        int cols = matrixB[0].length;
+        int[][] result = new int[rows][cols];
+        for (int i = 0; i < rows; i++) {
+            for (int j = 0; j < cols; j++) {
+                for (int k = 0; k < matrixA[0].length; k++) {
+                    result[i][j] += matrixA[i][k] * matrixB[k][j];
+                }
+            }
+        }
+        return result[0][0];
+    }
+
+    public void readFile(String filename) {
+        BufferedReader reader = null;
+        try {
+            reader = new BufferedReader(new FileReader(filename));
+            String line;
+            while ((line = reader.readLine()) != null) {
+                System.out.println(line);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (IOException ex) {
+                    ex.printStackTrace();
+                }
+            }
+        }
+    }
+
+    public void processFile(String filename) {
+        try {
+            int number = Integer.parseInt(filename);
+            System.out.println("Number: " + number);
+        } catch (NumberFormatException e) {
+            System.out.println("Invalid number format.");
+        } catch (Exception e) {
+            System.out.println("An error occurred.");
+        }
+    }
+
+    public void writeFile(String filename, String content) {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(filename))) {
+            writer.write(content);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void infiniteLoopWithBreak() {
+        int i = 0;
+        while (true) {
+            if (i > 10) {
+                break;
+            }
+            i++;
+        }
+    }
+
+    public int sumOddNumbers(int[] numbers) {
+        int sum = 0;
+        for (int num : numbers) {
+            if (num % 2 == 0) {
+                continue;
+            }
+            sum += num;
+        }
+        return sum;
+    }
+
+    public void validateAge(int age) {
+        if (age < 0) {
+            throw new IllegalArgumentException("Age cannot be negative.");
+        }
+        System.out.println("Age is valid.");
+    }
+
+    public Function<String, Integer> stringLengthMethodRefStreamed() {
+        return String::length;
+    }
+
+    public long countEvenNumbersStreamed(List<Integer> numbers) {
+        return numbers.stream().filter(n -> n % 2 == 0).count();
+    }
+
+    public boolean isEvenAndPositiveStreamed(int x) {
+        return Stream.of(x).allMatch(n -> n > 0 && n % 2 == 0);
     }
 
     // Inner class to add complexity

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -118,4 +118,183 @@ public class Maxs {
         long l = System.currentTimeMillis();
         return a + b + c + d + e + f + g + h + i + j + k + l;
     }
+
+    /**
+     * This method has 6 local variables (including 'this') and 3 stack elements.
+     * It includes a loop with a local variable declared inside.
+     * @param limit
+     * @return the sum from 0 to limit
+     */
+    public int sumWithLoop(int limit) {
+        int sum = 0;       // local variable 1
+        int i = 0;         // local variable 2
+        for (; i < limit; i++) { // 'i' is reused
+            int temp = i;   // local variable 3 (reused in each loop iteration)
+            sum += temp;
+        }
+        return sum;
+    }
+
+    /**
+     * This method has 4 local variables (including 'this') and 4 stack elements.
+     * It includes conditional statements with local variables declared inside branches.
+     * @param flag
+     * @return different values based on flag
+     */
+    public int conditionalMethod(boolean flag) {
+        if (flag) {
+            int a = 10;    // local variable 1
+            return a;
+        } else {
+            int b = 20;    // local variable 2
+            return b;
+        }
+    }
+
+    /**
+     * This method has 5 local variables (including 'this') and 5 stack elements.
+     * It includes a try-catch block with a local variable in the catch clause.
+     * @param x
+     * @param y
+     * @return division result or -1 if exception occurs
+     */
+    public int tryCatchMethod(int x, int y) {
+        try {
+            int result = x / y; // local variable 1
+            return result;
+        } catch (ArithmeticException e) { // local variable 2
+            e.printStackTrace();
+            return -1;
+        }
+    }
+
+    /**
+     * This method has 7 local variables (including 'this') and 4 stack elements.
+     * It includes multiple return points and a finally block.
+     * @param a
+     * @param b
+     * @return the greater of a or b
+     */
+    public int multipleReturns(int a, int b) {
+        try {
+            if (a > b) {
+                return a; // return point 1
+            } else {
+                return b; // return point 2
+            }
+        } finally {
+            System.out.println("Finally block executed");
+        }
+    }
+
+    /**
+     * This method has 5 local variables (including 'this') and 3 stack elements.
+     * It uses a switch-case statement with local variables inside cases.
+     * @param option
+     * @return based on option
+     */
+    public String switchCaseMethod(int option) {
+        String result;
+        switch (option) {
+            case 1:
+                result = "One"; // local variable 1
+                break;
+            case 2:
+                result = "Two"; // local variable 2
+                break;
+            default:
+                result = "Other"; // local variable 3
+                break;
+        }
+        return result;
+    }
+
+    /**
+     * This method has 4 local variables (including 'this') and 2 stack elements.
+     * It uses recursion.
+     * @param n
+     * @return factorial of n
+     */
+    public int recursiveFactorial(int n) {
+        if (n <= 1) {
+            return 1;
+        }
+        return n * recursiveFactorial(n - 1);
+    }
+
+    /**
+     * This method has 8 local variables (including 'this') and 3 stack elements.
+     * It uses nested loops with multiple local variables.
+     * @return the product of sums
+     */
+    public int nestedLoops() {
+        int product = 1; // local variable 1
+        for (int i = 0; i < 5; i++) { // local variable 2
+            int sum = 0; // local variable 3
+            for (int j = 0; j < 5; j++) { // local variable 4
+                sum += j;
+            }
+            product *= sum;
+        }
+        return product;
+    }
+
+    /**
+     * This method has 9 local variables (including 'this') and 4 stack elements.
+     * It includes a loop with try-catch inside.
+     * @param numbers
+     * @return sum of numbers
+     */
+    public int loopWithTryCatch(int[] numbers) {
+        int sum = 0; // local variable 1
+        for (int i = 0; i < numbers.length; i++) { // local variable 2
+            try {
+                sum += numbers[i]; // local variable 3
+            } catch (ArrayIndexOutOfBoundsException e) { // local variable 4
+                e.printStackTrace();
+            }
+        }
+        return sum;
+    }
+
+    /**
+     * This method has 6 local variables (including 'this') and 3 stack elements.
+     * It uses an array and manipulates its elements.
+     * @param size
+     * @return the sum of array elements
+     */
+    public int arrayManipulation(int size) {
+        int[] array = new int[size]; // local variable 1
+        int sum = 0; // local variable 2
+        for (int i = 0; i < size; i++) { // local variable 3
+            array[i] = i * 2;
+            sum += array[i];
+        }
+        return sum;
+    }
+
+    /**
+     * This method has 7 local variables (including 'this') and 4 stack elements.
+     * It creates and uses an inner class instance.
+     * @return concatenated string
+     */
+    public String innerClassMethod() {
+        StringBuilder sb = new StringBuilder(); // local variable 1
+        Inner inner = new Inner(); // local variable 2
+        String part1 = inner.partOne(); // local variable 3
+        String part2 = inner.partTwo(); // local variable 4
+        sb.append(part1).append(part2);
+        return sb.toString();
+    }
+
+    // Inner class to add complexity
+    private class Inner {
+        public String partOne() {
+            return "Hello, ";
+        }
+
+        public String partTwo() {
+            return "World!";
+        }
+    }
 }

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -753,26 +753,10 @@ public class Maxs {
 
     protected void configurePropertySources(Object var1, String[] var2) {
         String var3 = String.valueOf(var1);
-
-        if (this.collection != null) {
-            String defaultProps = String.valueOf(this.collection);
-            // Simulate addOrMerge operation by concatenating strings
-            defaultProps.concat(var3);
-            // Result is intentionally discarded to match the original bytecode behavior
-        }
-
         if (this.growCollection && var2.length > 0) {
-            String var4 = "commandLineArgs";
-            if (var3.contains(var4)) {
+            if (var3.contains("commandLineArgs")) {
                 String var5 = var3;
-                StringBuilder var6 = new StringBuilder(var4);
-                var6.append("springApplicationCommandLineArgs");
-                var6.append(Arrays.toString(var2));
-                var6.append(var5);
-                // Simulate replace operation
-                var3 = var3.replace(var4, var6.toString());
             } else {
-                // Simulate addFirst operation by prepending strings
                 var3 = Arrays.toString(var2) + var3;
             }
         }

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -29,6 +29,7 @@ import java.io.FileReader;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Locale;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import java.lang.reflect.Constructor;
@@ -728,6 +729,27 @@ public class Maxs {
             return 0;
         }
     }
+
+    protected void protectedMethod(String variable) {
+        try {
+            String.format(variable, "UTF-8").toLowerCase(Locale.getDefault());
+        } catch (Exception var3) {
+            throw new IllegalStateException("Cant format the variable", var3);
+        }
+    }
+
+    protected void bindToSpringApplication(Object environment) {
+        try {
+            String envStr = String.valueOf(environment);
+            String key = "spring.main";
+            String thisStr = String.valueOf(this);
+            envStr.concat(key).concat(thisStr);
+            // The result is intentionally discarded to match the bytecode 'pop' instruction
+        } catch (Exception ex) {
+            throw new IllegalStateException("Cannot bind to SpringApplication", ex);
+        }
+    }
+
 
     // Inner class to add complexity
     private class Inner {

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -632,6 +632,19 @@ public class Maxs {
         return obj.length();
     }
 
+    public int switchInsideLoopCase(byte x) {
+        for (int i = 0; i < 10; ++i) {
+            switch (x) {
+                case 1:
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unexpected value: " + x);
+            }
+        }
+        return 2;
+    }
+
+
     // Inner class to add complexity
     private class Inner {
         public String partOne() {

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -472,6 +472,18 @@ public class Maxs {
         }
     }
 
+    public void simpleIf(int x) {
+        if (x > 0) {
+            long a = 1L * System.currentTimeMillis();
+            int b = 10;
+            System.out.println("Hello: " + (a + b));
+        } else {
+            int a = 10;
+            long b = 1L * System.currentTimeMillis();
+            System.out.println("Bye: " + (a + b));
+        }
+    }
+
     public int sumUpTo(int n) {
         int sum = 0;
         for (int i = 1; i <= n; i++) {

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -766,18 +766,12 @@ public class Maxs {
         }
     }
 
-    public long contentLength() throws IOException, URISyntaxException {
+    public long contentLength(int x) throws IOException, URISyntaxException {
         URL url = new URL("https://www.example.com");
         if (isEvenAndPositive(10)) {
             File file = new File(url.toURI());
             long length = file.length();
-            if (length == 0L && !file.exists()) {
-                throw new FileNotFoundException(
-                    url.toString() + " cannot be resolved in the file system for checking its content length"
-                );
-            } else {
-                return length;
-            }
+            return -10;
         } else {
             URLConnection connection = url.openConnection();
             if (connection instanceof HttpURLConnection) {


### PR DESCRIPTION
Instead of relying on Java ASM library, we can count `max_locals` and `max_stack` values ourselves.
This changes allow to remove the ad-hoc solution related to switching computation modes in Java ASM library.

Closes: #540.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on refactoring the `BytecodeInstructionEntry` to `BytecodeInstruction`, adding methods for calculating the impact on stack and local variables, and enhancing the `BytecodeMethod` class to manage instructions and compute max stack and locals.

### Detailed summary
- Renamed `BytecodeInstructionEntry` to `BytecodeInstruction`.
- Added `impact()` method to calculate stack impact.
- Introduced `MaxStack` and `MaxLocals` classes for computing maximum stack and local variables.
- Added new methods in `BytecodeMethod` for managing instructions and computing maxs.
- Updated tests to reflect changes in the instruction handling.

> The following files were skipped due to too many changes: `src/test/resources/maxs/Maxs.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->