### PR TITLE
feat(#532): Remove Outdated Puzzle

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
@@ -38,11 +38,6 @@ import org.xembly.Directive;
 /**
  * Bytecode annotation.
  * @since 0.2
- * @todo #488:90min Refactor Annotations Implementation.
- *  Current implementation of annotations mapping is rather complicated.
- *  I would say it's over-engineered. We have a lot of classes and interfaces
- *  that are used to represent annotations in different formats. We should
- *  refactor this implementation to make it simpler and more readable.
  */
 @ToString
 @EqualsAndHashCode

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
@@ -56,7 +56,7 @@ public final class BytecodeAnnotation implements BytecodeAnnotationValue {
     /**
      * Properties.
      */
-    private final List<BytecodeAnnotationValue> properties;
+    private final List<BytecodeAnnotationValue> values;
 
     /**
      * Constructor.
@@ -71,16 +71,16 @@ public final class BytecodeAnnotation implements BytecodeAnnotationValue {
      * Constructor.
      * @param descriptor Descriptor.
      * @param visible Visible.
-     * @param properties Properties.
+     * @param vals Properties.
      */
     public BytecodeAnnotation(
         final String descriptor,
         final boolean visible,
-        final List<BytecodeAnnotationValue> properties
+        final List<BytecodeAnnotationValue> vals
     ) {
         this.descr = descriptor;
         this.visible = visible;
-        this.properties = properties;
+        this.values = vals;
     }
 
     /**
@@ -90,7 +90,7 @@ public final class BytecodeAnnotation implements BytecodeAnnotationValue {
      */
     public BytecodeAnnotation write(final ClassVisitor visitor) {
         final AnnotationVisitor avisitor = visitor.visitAnnotation(this.descr, this.visible);
-        this.properties.forEach(property -> property.writeTo(avisitor));
+        this.values.forEach(property -> property.writeTo(avisitor));
         return this;
     }
 
@@ -101,7 +101,7 @@ public final class BytecodeAnnotation implements BytecodeAnnotationValue {
      */
     public BytecodeAnnotation write(final MethodVisitor visitor) {
         final AnnotationVisitor avisitor = visitor.visitAnnotation(this.descr, this.visible);
-        this.properties.forEach(property -> property.writeTo(avisitor));
+        this.values.forEach(property -> property.writeTo(avisitor));
         return this;
     }
 
@@ -115,7 +115,7 @@ public final class BytecodeAnnotation implements BytecodeAnnotationValue {
         final AnnotationVisitor avisitor = visitor.visitParameterAnnotation(
             index, this.descr, this.visible
         );
-        this.properties.forEach(property -> property.writeTo(avisitor));
+        this.values.forEach(property -> property.writeTo(avisitor));
         return this;
     }
 
@@ -126,14 +126,14 @@ public final class BytecodeAnnotation implements BytecodeAnnotationValue {
      */
     public BytecodeAnnotation write(final FieldVisitor visitor) {
         final AnnotationVisitor avisitor = visitor.visitAnnotation(this.descr, this.visible);
-        this.properties.forEach(property -> property.writeTo(avisitor));
+        this.values.forEach(property -> property.writeTo(avisitor));
         return this;
     }
 
     @Override
     public void writeTo(final AnnotationVisitor visitor) {
         final AnnotationVisitor inner = visitor.visitAnnotation(this.descr, this.descr);
-        this.properties.forEach(property -> property.writeTo(inner));
+        this.values.forEach(property -> property.writeTo(inner));
     }
 
     @Override
@@ -141,7 +141,7 @@ public final class BytecodeAnnotation implements BytecodeAnnotationValue {
         return new DirectivesAnnotation(
             this.descr,
             this.visible,
-            this.properties.stream()
+            this.values.stream()
                 .map(BytecodeAnnotationValue::directives)
                 .collect(Collectors.toList())
         );

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
@@ -56,7 +56,7 @@ public class XmlAnnotation {
         return new BytecodeAnnotation(
             this.descriptor(),
             this.visible(),
-            this.props()
+            this.values()
         );
     }
 
@@ -85,13 +85,13 @@ public class XmlAnnotation {
      * Annotation properties.
      * @return Properties.
      */
-    private List<BytecodeAnnotationValue> props() {
+    private List<BytecodeAnnotationValue> values() {
         return this.node.children()
             .filter(
                 xmlnode -> xmlnode.hasAttribute("base", new JeoFqn("annotation-property").fqn())
             )
-            .map(XmlAnnotationProperty::new)
-            .map(XmlAnnotationProperty::bytecode)
+            .map(XmlAnnotationValue::new)
+            .map(XmlAnnotationValue::bytecode)
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotationValue.java
@@ -35,7 +35,7 @@ import org.eolang.jeo.representation.bytecode.BytecodePlainAnnotationValue;
  * Xmir annotation property.
  * @since 0.3
  */
-public final class XmlAnnotationProperty {
+public final class XmlAnnotationValue {
 
     /**
      * Annotation property XML node.
@@ -46,7 +46,7 @@ public final class XmlAnnotationProperty {
      * Constructor.
      * @param xmlnode XML node.
      */
-    public XmlAnnotationProperty(final XmlNode xmlnode) {
+    public XmlAnnotationValue(final XmlNode xmlnode) {
         this.node = xmlnode;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlDefaultValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlDefaultValue.java
@@ -53,7 +53,7 @@ public final class XmlDefaultValue {
     public Optional<BytecodeDefaultValue> bytecode() {
         return this.node.children().findFirst().map(
             property -> new BytecodeDefaultValue(
-                new XmlAnnotationProperty(property).bytecode()
+                new XmlAnnotationValue(property).bytecode()
             )
         );
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlOperand.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlOperand.java
@@ -70,7 +70,7 @@ public final class XmlOperand {
         } else if (new JeoFqn("annotation").fqn().equals(base)) {
             result = new XmlAnnotation(this.raw).bytecode();
         } else if (new JeoFqn("annotation-property").fqn().equals(base)) {
-            result = new XmlAnnotationProperty(this.raw).bytecode();
+            result = new XmlAnnotationValue(this.raw).bytecode();
         } else {
             result = new XmlValue(this.raw).object();
         }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationAnnotationValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationAnnotationValueTest.java
@@ -27,7 +27,7 @@ import com.jcabi.matchers.XhtmlMatchers;
 import java.util.Collections;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotationAnnotationValue;
-import org.eolang.jeo.representation.xmir.XmlAnnotationProperty;
+import org.eolang.jeo.representation.xmir.XmlAnnotationValue;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -67,7 +67,7 @@ final class DirectivesAnnotationAnnotationValueTest {
         final boolean visible = true;
         MatcherAssert.assertThat(
             "Incorrect annotation property type",
-            new XmlAnnotationProperty(
+            new XmlAnnotationValue(
                 new XmlNode(
                     new Xembler(
                         new DirectivesAnnotationAnnotationValue(

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesArrayAnnotationValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesArrayAnnotationValueTest.java
@@ -27,7 +27,7 @@ import com.jcabi.matchers.XhtmlMatchers;
 import java.util.Collections;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
 import org.eolang.jeo.representation.bytecode.BytecodeArrayAnnotationValue;
-import org.eolang.jeo.representation.xmir.XmlAnnotationProperty;
+import org.eolang.jeo.representation.xmir.XmlAnnotationValue;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -65,7 +65,7 @@ final class DirectivesArrayAnnotationValueTest {
         final boolean visible = true;
         MatcherAssert.assertThat(
             "Incorrect array annotation property",
-            new XmlAnnotationProperty(
+            new XmlAnnotationValue(
                 new XmlNode(
                     new Xembler(
                         new DirectivesArrayAnnotationValue(

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesEnumAnnotationValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesEnumAnnotationValueTest.java
@@ -26,7 +26,7 @@ package org.eolang.jeo.representation.directives;
 import com.jcabi.matchers.XhtmlMatchers;
 import java.time.DayOfWeek;
 import org.eolang.jeo.representation.bytecode.BytecodeEnumAnnotationValue;
-import org.eolang.jeo.representation.xmir.XmlAnnotationProperty;
+import org.eolang.jeo.representation.xmir.XmlAnnotationValue;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -64,7 +64,7 @@ final class DirectivesEnumAnnotationValueTest {
         final String value = "BOOL";
         MatcherAssert.assertThat(
             "Incorrect annotation property for enum property",
-            new XmlAnnotationProperty(
+            new XmlAnnotationValue(
                 new XmlNode(
                     new Xembler(new DirectivesEnumAnnotationValue(name, descriptor, value)).xml()
                 )

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesPlainAnnotationValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesPlainAnnotationValueTest.java
@@ -25,7 +25,7 @@ package org.eolang.jeo.representation.directives;
 
 import com.jcabi.matchers.XhtmlMatchers;
 import org.eolang.jeo.representation.bytecode.BytecodePlainAnnotationValue;
-import org.eolang.jeo.representation.xmir.XmlAnnotationProperty;
+import org.eolang.jeo.representation.xmir.XmlAnnotationValue;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -59,7 +59,7 @@ final class DirectivesPlainAnnotationValueTest {
         final int value = 1;
         MatcherAssert.assertThat(
             "Incorrect annotation property for plain property",
-            new XmlAnnotationProperty(
+            new XmlAnnotationValue(
                 new XmlNode(
                     new Xembler(new DirectivesPlainAnnotationValue(name, value)).xml()
                 )


### PR DESCRIPTION
Remove the outdated puzzle related to `BytecodeAnnotation` refactoring.

Closes: #532.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors the annotation handling in the `eolang` project by renaming and replacing instances of `XmlAnnotationProperty` with `XmlAnnotationValue`. This change improves clarity in the code regarding the distinction between annotations and their values.

### Detailed summary
- Renamed `XmlAnnotationProperty` to `XmlAnnotationValue`.
- Updated constructors and method calls to use `XmlAnnotationValue`.
- Changed method names from `props()` to `values()` in relevant classes.
- Adjusted test cases to reflect the new class name and functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->