### PR TITLE
Enable EO Printing in 'bytecode-to-eo' IT

### DIFF
--- a/src/it/bytecode-to-eo/pom.xml
+++ b/src/it/bytecode-to-eo/pom.xml
@@ -67,47 +67,31 @@ SOFTWARE.
           </execution>
         </executions>
       </plugin>
-      <!--
-        @todo #610:30min Enable EO Printing in 'bytecode-to-eo' it.
-         The `print` goal is currently disabled because it doesn't
-         support Java 8. You can read more about it right here:
-         https://github.com/objectionary/eo/issues/3207
-         Once it is implemented, this comment should be removed and the goal
-         should be enabled. Don't forget to enable checks in `verify.groovy`
-         file related to `.eo` files. Now they are commented.
-      -->
-            <plugin>
-              <groupId>org.eolang</groupId>
-              <artifactId>eo-maven-plugin</artifactId>
-              <version>0.39.1</version>
-              <executions>
-                <execution>
-                  <id>convert-xmir-to-eo</id>
-                  <phase>process-classes</phase>
-                  <goals>
-                    <goal>print</goal>
-                  </goals>
-                  <configuration>
-                    <printSourcesDir>${project.build.directory}/generated-sources/jeo-xmir</printSourcesDir>
-                    <printOutputDir>${project.build.directory}/generated-sources/jeo-eo</printOutputDir>
-                  </configuration>
-                </execution>
-              </executions>
-            </plugin>
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
         <version>0.39.1</version>
         <executions>
           <execution>
-            <id>convert-xmir-to-eo</id>
+            <id>convert-xmir-to-phi</id>
             <phase>process-classes</phase>
             <goals>
               <goal>xmir-to-phi</goal>
             </goals>
             <configuration>
               <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
-              <phiOutputDir>${project.build.directory}/generated-sources/jeo-eo</phiOutputDir>
+              <phiOutputDir>${project.build.directory}/generated-sources/jeo-phi</phiOutputDir>
+            </configuration>
+          </execution>
+          <execution>
+            <id>convert-xmir-to-eo</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>print</goal>
+            </goals>
+            <configuration>
+              <printSourcesDir>${project.build.directory}/generated-sources/jeo-xmir</printSourcesDir>
+              <printOutputDir>${project.build.directory}/generated-sources/jeo-eo</printOutputDir>
             </configuration>
           </execution>
         </executions>

--- a/src/it/bytecode-to-eo/pom.xml
+++ b/src/it/bytecode-to-eo/pom.xml
@@ -76,24 +76,24 @@ SOFTWARE.
          should be enabled. Don't forget to enable checks in `verify.groovy`
          file related to `.eo` files. Now they are commented.
       -->
-      <!--      <plugin>-->
-      <!--        <groupId>org.eolang</groupId>-->
-      <!--        <artifactId>eo-maven-plugin</artifactId>-->
-      <!--        <version>0.39.0</version>-->
-      <!--        <executions>-->
-      <!--          <execution>-->
-      <!--            <id>convert-xmir-to-eo</id>-->
-      <!--            <phase>process-classes</phase>-->
-      <!--            <goals>-->
-      <!--              <goal>print</goal>-->
-      <!--            </goals>-->
-      <!--            <configuration>-->
-      <!--              <printSourcesDir>${project.build.directory}/generated-sources/jeo-xmir</printSourcesDir>-->
-      <!--              <printOutputDir>${project.build.directory}/generated-sources/jeo-eo</printOutputDir>-->
-      <!--            </configuration>-->
-      <!--          </execution>-->
-      <!--        </executions>-->
-      <!--      </plugin>-->
+            <plugin>
+              <groupId>org.eolang</groupId>
+              <artifactId>eo-maven-plugin</artifactId>
+              <version>0.39.1</version>
+              <executions>
+                <execution>
+                  <id>convert-xmir-to-eo</id>
+                  <phase>process-classes</phase>
+                  <goals>
+                    <goal>print</goal>
+                  </goals>
+                  <configuration>
+                    <printSourcesDir>${project.build.directory}/generated-sources/jeo-xmir</printSourcesDir>
+                    <printOutputDir>${project.build.directory}/generated-sources/jeo-eo</printOutputDir>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>

--- a/src/it/bytecode-to-eo/verify.groovy
+++ b/src/it/bytecode-to-eo/verify.groovy
@@ -30,5 +30,6 @@ assert log.contains("WithoutPackage.class' disassembled to ")
 assert log.contains("BUILD SUCCESS")
 //Check that we have generated XMIR object file.
 assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/Application.xmir').exists()
-//assert new File(basedir, 'target/generated-sources/jeo-eo/org/eolang/jeo/Application.eo').exists()
+assert new File(basedir, 'target/generated-sources/jeo-eo/org/eolang/jeo/Application.eo').exists()
+assert new File(basedir, 'target/generated-sources/jeo-phi/org/eolang/jeo/Application.phi').exists()
 true


### PR DESCRIPTION
Enable EO printing in the `bytecode-to-eo` integration test.

Closes: #618.
History:
- **feat(#618): enable eo printing in 'bytecode-to-eo' integration test**
- **feat(#618): enable all the checks in the integration test 'bytecode-to-eo'**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the verification process for generated files in the `bytecode-to-eo` project. It modifies assertions in the `verify.groovy` file and changes the configuration in the `pom.xml` for the `eo-maven-plugin`.

### Detailed summary
- Updated assertion in `verify.groovy` to check for the existence of `Application.eo` and added check for `Application.phi`.
- Removed commented-out section in `pom.xml` related to enabling EO printing.
- Changed the execution ID from `convert-xmir-to-eo` to `convert-xmir-to-phi` in `pom.xml`.
- Updated output directory for `phiOutputDir` to `jeo-phi`.
- Added a new execution for `convert-xmir-to-eo` in `pom.xml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->