### PR TITLE
feat(#753): Fix The Problem With The First Digit Naming

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValues.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValues.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.xembly.Directive;
 
@@ -39,6 +40,11 @@ import org.xembly.Directive;
  * @since 0.6
  */
 public final class DirectivesValues implements Iterable<Directive> {
+
+    /**
+     * Pattern to remove all non-digits from the beginning of a string.
+     */
+    private static final Pattern DIGITS = Pattern.compile("^[0-9]");
 
     /**
      * Tuple name.
@@ -90,10 +96,20 @@ public final class DirectivesValues implements Iterable<Directive> {
     private String nonEmptyName() {
         final String result;
         if (this.name.isEmpty()) {
-            result = UUID.randomUUID().toString().toLowerCase(Locale.getDefault());
+            result = DirectivesValues.randomName();
         } else {
             result = this.name;
         }
         return result;
+    }
+
+    /**
+     * Generate random name.
+     * @return Random name.
+     */
+    private static String randomName() {
+        return DirectivesValues.DIGITS.matcher(
+            UUID.randomUUID().toString().toLowerCase(Locale.getDefault())
+        ).replaceAll("a");
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValuesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValuesTest.java
@@ -24,7 +24,10 @@
 package org.eolang.jeo.representation.directives;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import org.eolang.jeo.representation.xmir.XmlNode;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
@@ -44,6 +47,21 @@ final class DirectivesValuesTest {
                 "./o[contains(@base,'seq1') and @name='name']",
                 "./o[contains(@base,'seq1') and @name='name']/o/o[@data='bytes' and text()='76 61 6C 75 65']"
             )
+        );
+    }
+
+    @RepeatedTest(100)
+    void generatesRandomNameWithoutFirstDigit() {
+        MatcherAssert.assertThat(
+            "We expect that the name of the tuple will be generated randomly and will not start with a digit",
+            new XmlNode(
+                new Xembler(
+                    new DirectivesValues("", "some-value")
+                ).xmlQuietly()).attribute("name")
+                .orElseThrow(
+                    () -> new IllegalStateException("Name attribute is absent")
+                ),
+            Matchers.matchesRegex("^[^0-9].*")
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValuesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValuesTest.java
@@ -53,14 +53,14 @@ final class DirectivesValuesTest {
     @RepeatedTest(100)
     void generatesRandomNameWithoutFirstDigit() {
         MatcherAssert.assertThat(
-            "We expect that the name of the tuple will be generated randomly and will not start with a digit",
+            "We expect that the name of the sequence will be generated randomly and will not start with a digit",
             new XmlNode(
                 new Xembler(
                     new DirectivesValues("", "some-value")
-                ).xmlQuietly()).attribute("name")
-                .orElseThrow(
-                    () -> new IllegalStateException("Name attribute is absent")
-                ),
+                ).xmlQuietly()
+            ).attribute("name").orElseThrow(
+                () -> new IllegalStateException("Name attribute is absent")
+            ),
             Matchers.matchesRegex("^[^0-9].*")
         );
     }


### PR DESCRIPTION
In this PR I fixed the name genearation strategy for sequences of values. Now all the randomly generated names will start with a letter.

Closes: #753.
History:
- **feat(#753): do not generate names with the first digit**
- **feat(#753): fix all the code offences**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new feature to generate random names for `DirectivesValues`, ensuring they do not start with a digit. It also adds a test case to validate this behavior.

### Detailed summary
- Added a regex pattern `DIGITS` in `DirectivesValues` to identify leading digits.
- Implemented a `randomName()` method in `DirectivesValues` to generate valid random names.
- Created a new test method `generatesRandomNameWithoutFirstDigit()` in `DirectivesValuesTest` to validate the random name generation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->