### PR TITLE
feat(#757): Add Informative Messages For Exceptions

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
@@ -147,6 +147,11 @@ public final class XmirRepresentation implements Representation {
                 String.format("Can't transform '%s' to bytecode", xmir),
                 exception
             );
+        } catch (final IllegalStateException exception) {
+            throw new IllegalStateException(
+                String.format("Can't transform XMIR to bytecode from the '%s' source", this.source),
+                exception
+            );
         }
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesBytes.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesBytes.java
@@ -43,7 +43,7 @@ public final class DirectivesBytes implements Iterable<Directive> {
      * Constructor.
      * @param hex Hex representation of bytes.
      */
-    DirectivesBytes(final String hex) {
+    public DirectivesBytes(final String hex) {
         this.hex = hex;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/ParsingException.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/ParsingException.java
@@ -28,7 +28,7 @@ package org.eolang.jeo.representation.xmir;
  * This exception is thrown when XMIR parsing fails.
  * @since 0.6
  */
-final class XmirParsingException extends IllegalStateException {
+final class ParsingException extends IllegalStateException {
 
     /**
      * Serial version UID.
@@ -40,7 +40,7 @@ final class XmirParsingException extends IllegalStateException {
      * @param message Message.
      * @param cause Cause.
      */
-    XmirParsingException(final String message, final Throwable cause) {
+    ParsingException(final String message, final Throwable cause) {
         super(message, cause);
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmirParsingException.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmirParsingException.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.xmir;
+
+/**
+ * XMIR parsing exception.
+ * This exception is thrown when XMIR parsing fails.
+ * @since 0.6
+ */
+final class XmirParsingException extends IllegalStateException {
+
+    /**
+     * Serial version UID.
+     */
+    private static final long serialVersionUID = 4711234567890L;
+
+    /**
+     * Constructor.
+     * @param message Message.
+     * @param cause Cause.
+     */
+    XmirParsingException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -94,21 +94,31 @@ public final class XmlClass {
      * @return Bytecode class.
      */
     public BytecodeClass bytecode() {
-        return new BytecodeClass(
-            new PrefixedName(this.name()).decode(),
-            this.methods().stream().map(XmlMethod::bytecode)
-                .collect(Collectors.toList()),
-            this.fields().stream()
-                .map(XmlField::bytecode)
-                .collect(Collectors.toList()),
-            this.annotations()
-                .map(XmlAnnotations::bytecode)
-                .orElse(new BytecodeAnnotations()),
-            this.attributes()
-                .map(XmlAttributes::attributes)
-                .orElse(new ArrayList<>(0)),
-            this.properties().bytecode()
-        );
+        try {
+            return new BytecodeClass(
+                new PrefixedName(this.name()).decode(),
+                this.methods().stream().map(XmlMethod::bytecode)
+                    .collect(Collectors.toList()),
+                this.fields().stream()
+                    .map(XmlField::bytecode)
+                    .collect(Collectors.toList()),
+                this.annotations()
+                    .map(XmlAnnotations::bytecode)
+                    .orElse(new BytecodeAnnotations()),
+                this.attributes()
+                    .map(XmlAttributes::attributes)
+                    .orElse(new ArrayList<>(0)),
+                this.properties().bytecode()
+            );
+        } catch (final IllegalStateException exception) {
+            throw new XmirParsingException(
+                String.format(
+                    "Unexpected exception during parsing the class '%s'",
+                    this.name()
+                ),
+                exception
+            );
+        }
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -111,7 +111,7 @@ public final class XmlClass {
                 this.properties().bytecode()
             );
         } catch (final IllegalStateException exception) {
-            throw new XmirParsingException(
+            throw new ParsingException(
                 String.format(
                     "Unexpected exception during parsing the class '%s'",
                     this.name()

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -131,7 +131,7 @@ public final class XmlMethod {
                     .orElse(new BytecodeMaxs(0, 0))
             );
         } catch (final IllegalStateException exception) {
-            throw new XmirParsingException(
+            throw new ParsingException(
                 String.format(
                     "Unexpected exception during parsing the method '%s'",
                     this.name()
@@ -183,14 +183,24 @@ public final class XmlMethod {
      * @return Properties.
      */
     private BytecodeMethodProperties properties() {
-        return new BytecodeMethodProperties(
-            this.access(),
-            this.name(),
-            this.descriptor(),
-            this.signature(),
-            this.params(),
-            this.exceptions()
-        );
+        try {
+            return new BytecodeMethodProperties(
+                this.access(),
+                this.name(),
+                this.descriptor(),
+                this.signature(),
+                this.params(),
+                this.exceptions()
+            );
+        } catch (final IllegalStateException exception) {
+            throw new ParsingException(
+                String.format(
+                    "Unexpected exception during parsing the method '%s' properties",
+                    this.name()
+                ),
+                exception
+            );
+        }
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -109,26 +109,36 @@ public final class XmlMethod {
      * @return Bytecode method.
      */
     public BytecodeMethod bytecode() {
-        return new BytecodeMethod(
-            this.trycatchEntries()
-                .stream()
-                .map(XmlTryCatchEntry::bytecode)
-                .collect(Collectors.toList()),
-            this.instructions()
-                .stream()
-                .map(XmlBytecodeEntry::bytecode)
-                .collect(Collectors.toList()),
-            this.annotations(),
-            this.properties(),
-            this.defvalue()
-                .map(XmlDefaultValue::bytecode)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .map(Collections::singletonList)
-                .orElse(Collections.emptyList()),
-            this.maxs().map(XmlMaxs::bytecode)
-                .orElse(new BytecodeMaxs(0, 0))
-        );
+        try {
+            return new BytecodeMethod(
+                this.trycatchEntries()
+                    .stream()
+                    .map(XmlTryCatchEntry::bytecode)
+                    .collect(Collectors.toList()),
+                this.instructions()
+                    .stream()
+                    .map(XmlBytecodeEntry::bytecode)
+                    .collect(Collectors.toList()),
+                this.annotations(),
+                this.properties(),
+                this.defvalue()
+                    .map(XmlDefaultValue::bytecode)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .map(Collections::singletonList)
+                    .orElse(Collections.emptyList()),
+                this.maxs().map(XmlMaxs::bytecode)
+                    .orElse(new BytecodeMaxs(0, 0))
+            );
+        } catch (final IllegalStateException exception) {
+            throw new XmirParsingException(
+                String.format(
+                    "Unexpected exception during parsing the method '%s'",
+                    this.name()
+                ),
+                exception
+            );
+        }
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -138,6 +138,14 @@ public final class XmlMethod {
                 ),
                 exception
             );
+        } catch (final IllegalArgumentException exception){
+            throw new ParsingException(
+                String.format(
+                    "Can't transform method '%s' to bytecode",
+                    this.name()
+                ),
+                exception
+            );
         }
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -138,7 +138,7 @@ public final class XmlMethod {
                 ),
                 exception
             );
-        } catch (final IllegalArgumentException exception){
+        } catch (final IllegalArgumentException exception) {
             throw new ParsingException(
                 String.format(
                     "Can't transform method '%s' to bytecode",

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -105,7 +105,7 @@ public final class XmlProgram {
         try {
             return new BytecodeProgram(this.pckg(), this.top().bytecode());
         } catch (final IllegalStateException exception) {
-            throw new XmirParsingException(
+            throw new ParsingException(
                 String.format(
                     "Unexpected exception during parsing the program in package '%s'",
                     this.pckg()

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -102,7 +102,17 @@ public final class XmlProgram {
      * @return Bytecode program.
      */
     public BytecodeProgram bytecode() {
-        return new BytecodeProgram(this.pckg(), this.top().bytecode());
+        try {
+            return new BytecodeProgram(this.pckg(), this.top().bytecode());
+        } catch (final IllegalStateException exception) {
+            throw new XmirParsingException(
+                String.format(
+                    "Unexpected exception during parsing the program in package '%s'",
+                    this.pckg()
+                ),
+                exception
+            );
+        }
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
@@ -26,10 +26,14 @@ package org.eolang.jeo.representation.xmir;
 import org.eolang.jeo.representation.bytecode.BytecodeMaxs;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodProperties;
+import org.eolang.jeo.representation.directives.DirectivesBytes;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
+import org.xembly.Directives;
+import org.xembly.Xembler;
 
 /**
  * Test case for {@link XmlMethod}.
@@ -89,6 +93,28 @@ final class XmlMethodTest {
             "We expect that max stack and max locals will be correctly parsed",
             new XmlMethod(1, 2).bytecode(),
             Matchers.equalTo(new BytecodeMethod("foo", new BytecodeMaxs(1, 2)))
+        );
+    }
+
+    @Test
+    void catchesMethodParsingException() {
+        MatcherAssert.assertThat(
+            "Exception message doesn't contain the expected text related to the method parsing",
+            Assertions.assertThrows(
+                ParsingException.class,
+                () -> new XmlMethod(
+                    new XmlNode(new Xembler(
+                        new Directives(
+                            new BytecodeMethod(
+                                "someMethodName"
+                            ).directives(false)
+                        ).xpath(".//o[@name='exceptions']").append(new DirectivesBytes("???"))
+                    ).xmlQuietly())
+                ).bytecode()
+            ).getMessage(),
+            Matchers.containsString(
+                "Unexpected exception during parsing the method 'someMethodName'"
+            )
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
@@ -103,13 +103,15 @@ final class XmlMethodTest {
             Assertions.assertThrows(
                 ParsingException.class,
                 () -> new XmlMethod(
-                    new XmlNode(new Xembler(
-                        new Directives(
-                            new BytecodeMethod(
-                                "someMethodName"
-                            ).directives(false)
-                        ).xpath(".//o[@name='exceptions']").append(new DirectivesBytes("???"))
-                    ).xmlQuietly())
+                    new XmlNode(
+                        new Xembler(
+                            new Directives(
+                                new BytecodeMethod(
+                                    "someMethodName"
+                                ).directives(false)
+                            ).xpath(".//o[@name='exceptions']").append(new DirectivesBytes("???"))
+                        ).xmlQuietly()
+                    )
                 ).bytecode()
             ).getMessage(),
             Matchers.containsString(

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlProgramTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlProgramTest.java
@@ -33,8 +33,10 @@ import org.eolang.jeo.representation.directives.DirectivesMethodProperties;
 import org.eolang.jeo.representation.directives.DirectivesProgram;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
+import org.xembly.Directives;
 import org.xembly.Xembler;
 
 /**
@@ -74,6 +76,28 @@ final class XmlProgramTest {
             "Can't convert method with exception into bytecode",
             new XmlProgram(XmlProgramTest.classWithException()).bytecode().bytecode(),
             Matchers.notNullValue()
+        );
+    }
+
+    @Test
+    void catchesProgramParsingException() {
+        MatcherAssert.assertThat(
+            "Exception message doesn't contain the expected text",
+            Assertions.assertThrows(
+                ParsingException.class,
+                () -> new XmlProgram(
+                    new Xembler(
+                        new Directives(
+                            new BytecodeProgram(
+                                "com.example", new BytecodeClass("Foo", 0)
+                            ).directives("")
+                        ).xpath(".//objects").remove()
+                    ).xmlQuietly()
+                ).bytecode()
+            ).getMessage(),
+            Matchers.containsString(
+                "Unexpected exception during parsing the program in package 'com.example'"
+            )
         );
     }
 


### PR DESCRIPTION
In this PR I added `ParsingException` and used it inside `XmlProgram`, `XmlClass`, `XmlMethod` classes. 
This changes should add much more context to unexpected exceptions.

Closes: #757.
- **feat(#757): add more informative messages during the XMIR parsing phase**
- **feat(#757): add safe checks to the method properties parsing**
- **feat(#757): add a unit test for the parsing exception**
- **feat(#757): add one more unit test**
- **feat(#757): fix all the code offences**


<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on improving error handling in the `XMIR` parsing process by introducing `ParsingException` for better clarity on issues during bytecode transformation and adding tests to ensure exceptions are thrown as expected.

### Detailed summary
- Changed `DirectivesBytes` constructor from package-private to `public`.
- Added `try-catch` blocks in `XmlProgram`, `XmlClass`, `XmlMethod`, and `ParsingException` to handle `IllegalStateException`.
- Introduced `ParsingException` class for clearer error messaging.
- Added tests in `XmlProgramTest` and `XmlMethodTest` to verify exception handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->