### PR TITLE
feat(#757): Exclude `roll-data.xsl` Transformation From Unrolling

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/CanonicalXmir.java
+++ b/src/main/java/org/eolang/jeo/representation/CanonicalXmir.java
@@ -149,8 +149,7 @@ public final class CanonicalXmir {
                 ),
                 new TrClasspath<>(
                     "/org/eolang/parser/add-refs.xsl",
-                    "/org/eolang/parser/vars-float-down.xsl",
-                    "/org/eolang/parser/roll-data.xsl"
+                    "/org/eolang/parser/vars-float-down.xsl"
                 ).back()
             )
         ).pass(parsed);

--- a/src/test/java/org/eolang/jeo/representation/CanonicalXmirTest.java
+++ b/src/test/java/org/eolang/jeo/representation/CanonicalXmirTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation;
 
+import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
 import java.util.Collections;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
@@ -34,6 +35,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.xembly.Directives;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
@@ -71,6 +73,55 @@ final class CanonicalXmirTest {
                 ).plain()
             ).bytecode(),
             Matchers.equalTo(initial)
+        );
+    }
+
+    @Test
+    void unrollsSequenceOfValuesCorrectly() {
+        MatcherAssert.assertThat(
+            "We expect that after the unrolling we will get correct sequence of string values.",
+            new CanonicalXmir(
+                new XMLDocument(
+                    new Xembler(
+                        new Directives()
+                            .add("program")
+                            .add("objects")
+                            .append(
+                                new XMLDocument(
+                                    String.join(
+                                        "\n",
+                                        "<o base='.seq1' name='interfaces'> ",
+                                        " <o base='.eolang'> ",
+                                        "  <o base='.org'> ",
+                                        "   <o base='Q'/></o> ",
+                                        " </o> ",
+                                        " <o as='0' base='.string'> ",
+                                        "  <o base='.jeo'> ",
+                                        "   <o base='.eolang'> ",
+                                        "    <o base='.org'> ",
+                                        "     <o base='Q'/></o> ",
+                                        "   </o> ",
+                                        "  </o> ",
+                                        "  <o as='0' base='.bytes'> ",
+                                        "   <o base='.eolang'> ",
+                                        "    <o base='.org'> ",
+                                        "     <o base='Q'/></o> ",
+                                        "   </o> ",
+                                        "   <o base='org.eolang.bytes' data='bytes'>6A 61 76 61 2F 69 6F 2F 43 6C 6F 73 65 61 62 6C 65</o> ",
+                                        "  </o> ",
+                                        " </o> ",
+                                        "</o>"
+                                    )
+                                ).node()
+                            )
+                            .up()
+                            .up()
+                    ).xmlQuietly()
+                )
+            ).plain().toString(),
+            XhtmlMatchers.hasXPath(
+                ".//o[@base='org.eolang.seq1']/o[@base='org.eolang.jeo.string']/o[@base='bytes']"
+            )
         );
     }
 }


### PR DESCRIPTION
In this PR I excluded `roll-data.xsl` from the suggested unrolling train.

Related to #757


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `CanonicalXmir` functionality by modifying the transformation process and adding a new test case to ensure correct unrolling of sequences in an XML representation.

### Detailed summary
- Updated the `TrClasspath` in `CanonicalXmir.java` to include a new file and remove two others.
- Added imports for `Directives`, `ImpossibleModificationException`, and `Xembly` in `CanonicalXmirTest.java`.
- Introduced a new test method `unrollsSequenceOfValuesCorrectly` to validate the unrolling of values in XML.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->