### PR TITLE
feat(#765): Unroll Annotations Correctly

### DIFF
--- a/src/it/phi-unphi/src/main/java/org/eolang/hone/App.java
+++ b/src/it/phi-unphi/src/main/java/org/eolang/hone/App.java
@@ -27,7 +27,11 @@ package org.eolang.hone;
  * App.
  * @since 0.1
  */
+
 public class App {
+
+    @Deprecated
+    @SuppressWarnings("unchecked")
     public static void main(String[] args) {
         double angle = 42.0;
         double sin = Math.sin(angle);

--- a/src/it/phi-unphi/src/main/java/org/eolang/hone/Parameter.java
+++ b/src/it/phi-unphi/src/main/java/org/eolang/hone/Parameter.java
@@ -23,18 +23,13 @@
  */
 package org.eolang.hone;
 
-/**
- * App.
- * @since 0.1
- */
-@Parameter("some-parameter")
-public class App {
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-    @Deprecated
-    @SuppressWarnings("unchecked")
-    public static void main(String[] args) {
-        double angle = 42.0;
-        double sin = Math.sin(angle);
-        System.out.printf("sin(%f) = %f\n", angle, sin);
-    }
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Parameter {
+    String value();
 }

--- a/src/main/java/org/eolang/jeo/representation/CanonicalXmir.java
+++ b/src/main/java/org/eolang/jeo/representation/CanonicalXmir.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
+import com.yegor256.xsline.Shift;
 import com.yegor256.xsline.StClasspath;
 import com.yegor256.xsline.StEndless;
 import com.yegor256.xsline.TrClasspath;
@@ -135,29 +136,29 @@ public final class CanonicalXmir {
      */
     private static XML unroll(final XML parsed) {
         return new Xsline(
-            new TrJoined<>(
-                new TrClasspath<>(
+            new TrJoined<Shift>(
+                new TrClasspath<Shift>(
                     "/org/eolang/parser/wrap-method-calls.xsl"
                 ).back(),
-                new TrDefault<>(
+                new TrDefault<Shift>(
                     new StEndless(
                         new StClasspath(
                             "/org/eolang/parser/roll-bases.xsl"
                         )
                     )
                 ),
-                new TrClasspath<>(
+                new TrClasspath<Shift>(
                     "/org/eolang/parser/add-refs.xsl",
                     "/org/eolang/parser/add-cuts.xsl"
                 ).back(),
-                new TrDefault<>(
+                new TrDefault<Shift>(
                     new StEndless(
                         new StClasspath(
                             "/org/eolang/parser/vars-float-down.xsl"
                         )
                     )
                 ),
-                new TrClasspath<>(
+                new TrClasspath<Shift>(
                     "/org/eolang/parser/remove-cuts.xsl"
                 ).back()
             )

--- a/src/main/java/org/eolang/jeo/representation/CanonicalXmir.java
+++ b/src/main/java/org/eolang/jeo/representation/CanonicalXmir.java
@@ -136,7 +136,7 @@ public final class CanonicalXmir {
      */
     private static XML unroll(final XML parsed) {
         return new Xsline(
-            new TrJoined<Shift>(
+            new TrJoined<>(
                 new TrClasspath<>(
                     "/org/eolang/parser/wrap-method-calls.xsl"
                 ).back(),
@@ -149,7 +149,17 @@ public final class CanonicalXmir {
                 ),
                 new TrClasspath<>(
                     "/org/eolang/parser/add-refs.xsl",
-                    "/org/eolang/parser/vars-float-down.xsl"
+                    "/org/eolang/parser/add-cuts.xsl"
+                ).back(),
+                new TrDefault<>(
+                    new StEndless(
+                        new StClasspath(
+                            "/org/eolang/parser/vars-float-down.xsl"
+                        )
+                    )
+                ),
+                new TrClasspath<>(
+                    "/org/eolang/parser/remove-cuts.xsl"
                 ).back()
             )
         ).pass(parsed);

--- a/src/main/java/org/eolang/jeo/representation/CanonicalXmir.java
+++ b/src/main/java/org/eolang/jeo/representation/CanonicalXmir.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
-import com.yegor256.xsline.Shift;
 import com.yegor256.xsline.StClasspath;
 import com.yegor256.xsline.StEndless;
 import com.yegor256.xsline.TrClasspath;

--- a/src/main/java/org/eolang/jeo/representation/xmir/Parameter.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/Parameter.java
@@ -21,20 +21,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.eolang.hone;
+package org.eolang.jeo.representation.xmir;
 
-/**
- * App.
- * @since 0.1
- */
-@Parameter("some-parameter")
-public class App {
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-    @Deprecated
-    @SuppressWarnings("unchecked")
-    public static void main(String[] args) {
-        double angle = 42.0;
-        double sin = Math.sin(angle);
-        System.out.printf("sin(%f) = %f\n", angle, sin);
-    }
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Parameter {
+    String value();
 }

--- a/src/main/resources/org/eolang/parser/add-cuts.xsl
+++ b/src/main/resources/org/eolang/parser/add-cuts.xsl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2016-2024 Objectionary.com
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included
+  ~ in all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="add-refs" version="2.0">
+  <!--
+  Here we go through all objects which 'line' attribute value
+  exists as value of 'ref' attribute in some other object.
+  If the object is found, it gets 'cut' attribute to identify the
+  object to be removed later.
+  -->
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="o[@name and @line=//o[@ref]/@ref]">
+    <xsl:copy>
+      <xsl:attribute name="cut"/>
+      <xsl:copy-of select="@*"/>
+      <xsl:copy-of select="node()"/>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/parser/add-cuts.xsl
+++ b/src/main/resources/org/eolang/parser/add-cuts.xsl
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The MIT License (MIT)
-  ~
-  ~ Copyright (c) 2016-2024 Objectionary.com
-  ~
-  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the "Software"), to deal
-  ~ in the Software without restriction, including without limitation the rights
-  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  ~ copies of the Software, and to permit persons to whom the Software is
-  ~ furnished to do so, subject to the following conditions:
-  ~
-  ~ The above copyright notice and this permission notice shall be included
-  ~ in all copies or substantial portions of the Software.
-  ~
-  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  ~ FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
-  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  ~ SOFTWARE.
-  -->
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="add-refs" version="2.0">
   <!--
   Here we go through all objects which 'line' attribute value

--- a/src/main/resources/org/eolang/parser/remove-cuts.xsl
+++ b/src/main/resources/org/eolang/parser/remove-cuts.xsl
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2016-2024 Objectionary.com
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included
+  ~ in all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="add-refs" version="2.0">
+  <!--
+  Here we go through all objects with 'cut' attribute and
+  remove them.
+  -->
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="o[@cut]"/>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/eolang/parser/remove-cuts.xsl
+++ b/src/main/resources/org/eolang/parser/remove-cuts.xsl
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The MIT License (MIT)
-  ~
-  ~ Copyright (c) 2016-2024 Objectionary.com
-  ~
-  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the "Software"), to deal
-  ~ in the Software without restriction, including without limitation the rights
-  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  ~ copies of the Software, and to permit persons to whom the Software is
-  ~ furnished to do so, subject to the following conditions:
-  ~
-  ~ The above copyright notice and this permission notice shall be included
-  ~ in all copies or substantial portions of the Software.
-  ~
-  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  ~ FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
-  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  ~ SOFTWARE.
-  -->
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="add-refs" version="2.0">
   <!--
   Here we go through all objects with 'cut' attribute and


### PR DESCRIPTION
Update the unrolling train according with the following suggestions:
https://github.com/objectionary/jeo-maven-plugin/issues/765#issuecomment-2414477132

Related to #765.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new features and improvements, including the addition of `@Parameter` annotations, updates to transformation XSL files, and the inclusion of copyright notices. It enhances the code structure and clarifies the handling of specific XML transformations.

### Detailed summary
- Added `@Parameter` annotation in `App.java` and `Parameter.java`.
- Marked `main` method as `@Deprecated` in `App.java`.
- Updated `CanonicalXmir.java` to use `Shift` type with `TrClasspath` and `TrDefault`.
- Added `remove-cuts.xsl` and `add-cuts.xsl` with MIT License.
- Modified `vars-float-down.xsl` to improve template matching logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->