### PR TITLE
feat(#769): Add j$ Prefix For All Method Names

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.MethodName;
+import org.eolang.jeo.representation.PrefixedName;
 import org.eolang.jeo.representation.Signature;
 import org.xembly.Directive;
 import org.xembly.Directives;
@@ -170,7 +171,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
     @Override
     public Iterator<Directive> iterator() {
         return new DirectivesAbstractObject(
-            this.name.encoded(),
+            new PrefixedName(this.name.encoded()).encode(),
             Stream.concat(
                 Stream.of(
                     this.properties,

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.MethodName;
+import org.eolang.jeo.representation.PrefixedName;
 import org.eolang.jeo.representation.Signature;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.eolang.jeo.representation.bytecode.BytecodeMaxs;
@@ -163,12 +164,15 @@ public final class XmlMethod {
      */
     private String name() {
         return new MethodName(
-            new Signature(
-                this.node.attribute("name")
-                    .orElseThrow(
-                        () -> new IllegalStateException("Method 'name' attribute is not present")
-                    )
-            ).name()
+            new PrefixedName(
+                new Signature(
+                    this.node.attribute("name")
+                        .orElseThrow(
+                            () -> new IllegalStateException(
+                                "Method 'name' attribute is not present")
+                        )
+                ).name()
+            ).decode()
         ).bytecode();
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -169,7 +169,8 @@ public final class XmlMethod {
                     this.node.attribute("name")
                         .orElseThrow(
                             () -> new IllegalStateException(
-                                "Method 'name' attribute is not present")
+                                "Method 'name' attribute is not present"
+                            )
                         )
                 ).name()
             ).decode()

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.directives;
 
+import com.jcabi.matchers.XhtmlMatchers;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.eolang.jeo.representation.bytecode.BytecodeMaxs;
@@ -92,6 +93,15 @@ final class DirectivesMethodTest {
                     )
                 )
             )
+        );
+    }
+
+    @Test
+    void addsSuffixToTheMethodName() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect that 'j$' suffix will be added to the method name",
+            new Xembler(new BytecodeMethod("φTerm").directives(false)).xml(),
+            XhtmlMatchers.hasXPaths("./o[contains(@name, j$φTerm)]")
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -97,11 +97,11 @@ final class DirectivesMethodTest {
     }
 
     @Test
-    void addsSuffixToTheMethodName() throws ImpossibleModificationException {
+    void addsPrefixToTheMethodName() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
-            "We expect that 'j$' suffix will be added to the method name",
+            "We expect that 'j$' prefix will be added to the method name",
             new Xembler(new BytecodeMethod("φTerm").directives(false)).xml(),
-            XhtmlMatchers.hasXPaths("./o[contains(@name, j$φTerm)]")
+            XhtmlMatchers.hasXPaths("./o[contains(@name, 'j$φTerm')]")
         );
     }
 }


### PR DESCRIPTION
In this PR I added the `j$` prefix for all method names. This prevents some problems in EO and PHI naming. 
For example, the `$φTerm` java method will be converted to the `j$φTerm`.
During the back transformation `jeo` removes this prefix and saves pure `φTerm` to bytecode.

Related to: #769.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `PrefixedName` class to enhance method name handling by adding a prefix to method names in the `DirectivesMethod` and `XmlMethod` classes. It also includes a test to verify that the prefix is correctly applied.

### Detailed summary
- Updated `DirectivesMethod` to use `PrefixedName` for encoding method names.
- Added a test in `DirectivesMethodTest` to confirm the prefixing of method names.
- Updated `XmlMethod` to use `PrefixedName` for decoding method names.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->