### PR TITLE
cosmetic changes

### DIFF
--- a/src/main/java/org/eolang/jeo/Assembler.java
+++ b/src/main/java/org/eolang/jeo/Assembler.java
@@ -66,7 +66,7 @@ final class Assembler {
             assembled,
             this.input,
             this.output,
-            new BachedTranslator(
+            new BatchedTranslator(
                 new LoggedTranslation(
                     assembling,
                     assembled,

--- a/src/main/java/org/eolang/jeo/BatchedTranslator.java
+++ b/src/main/java/org/eolang/jeo/BatchedTranslator.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
  *
  * @since 0.2
  */
-public final class BachedTranslator implements Translator {
+public final class BatchedTranslator implements Translator {
 
     /**
      * Original translation.
@@ -46,7 +46,7 @@ public final class BachedTranslator implements Translator {
      * Constructor.
      * @param translation Original translation.
      */
-    BachedTranslator(final Translation translation) {
+    BatchedTranslator(final Translation translation) {
         this.translation = translation;
         this.loader = Thread.currentThread().getContextClassLoader();
     }

--- a/src/main/java/org/eolang/jeo/Disassembler.java
+++ b/src/main/java/org/eolang/jeo/Disassembler.java
@@ -70,7 +70,7 @@ public class Disassembler {
             disassembled,
             this.classes,
             this.target,
-            new BachedTranslator(
+            new BatchedTranslator(
                 new LoggedTranslation(
                     process,
                     disassembled,
@@ -81,7 +81,8 @@ public class Disassembler {
         stream.forEach(
             terminated -> Logger.info(
                 this,
-                "Dissembling of '%s.xmir' (%[size]s) finished successfully.",
+                "%s of '%s.xmir' (%[size]s) finished successfully.",
+                process,
                 terminated.details().name(),
                 terminated.size()
             )

--- a/src/main/java/org/eolang/jeo/LoggedTranslation.java
+++ b/src/main/java/org/eolang/jeo/LoggedTranslation.java
@@ -93,7 +93,7 @@ public final class LoggedTranslation implements Translation {
      * @param source Initial path.
      */
     private void logStartWithSize(final Path source) {
-        Logger.info(
+        Logger.debug(
             this,
             "%s '%[file]s' (%[size]s)",
             this.process,

--- a/src/test/java/org/eolang/jeo/BatchedTranslatorTest.java
+++ b/src/test/java/org/eolang/jeo/BatchedTranslatorTest.java
@@ -39,11 +39,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Test case for {@link BachedTranslator}.
+ * Test case for {@link BatchedTranslator}.
  *
  * @since 0.1.0
  */
-final class BachedTranslatorTest {
+final class BatchedTranslatorTest {
 
     /**
      * Where the XML file is expected to be saved.
@@ -66,7 +66,7 @@ final class BachedTranslatorTest {
                 .toString()
                 .getBytes(StandardCharsets.UTF_8)
         );
-        new BachedTranslator(new Disassemble(temp))
+        new BatchedTranslator(new Disassemble(temp))
             .apply(Stream.of(new XmirRepresentation(clazz))).collect(Collectors.toList());
         MatcherAssert.assertThat(
             "XML file was not saved",
@@ -77,7 +77,7 @@ final class BachedTranslatorTest {
 
     @Test
     void overwritesXml(@TempDir final Path temp) {
-        final BachedTranslator footprint = new BachedTranslator(
+        final BatchedTranslator footprint = new BatchedTranslator(
             new Disassemble(temp)
         );
         final Representation repr = new XmirRepresentation(
@@ -98,7 +98,7 @@ final class BachedTranslatorTest {
     @Test
     void assemblesSuccessfully(@TempDir final Path temp) {
         final String fake = "Fake";
-        new BachedTranslator(new Assemble(temp)).apply(
+        new BatchedTranslator(new Assemble(temp)).apply(
             Stream.of(
                 new XmirRepresentation(
                     new BytecodeProgram("jeo/xmir", new BytecodeClass(fake)).xml()


### PR DESCRIPTION
A bit of logging improvement

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming the `BachedTranslator` class to `BatchedTranslator` across multiple files and adjusting related references, along with changing a logging level from `info` to `debug`.

### Detailed summary
- Renamed `BachedTranslator` to `BatchedTranslator` in:
  - `Assembler.java`
  - `Disassembler.java`
  - `BachedTranslator.java` (file name changed)
  - `BachedTranslatorTest.java` (file name changed)
- Changed logging level from `info` to `debug` in `LoggedTranslation.java`.
- Updated log message format in `Disassembler.java`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->