### PR TITLE
feat(#785): Add Prefix To All Elements In The Package Name

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/PrefixedName.java
+++ b/src/main/java/org/eolang/jeo/representation/PrefixedName.java
@@ -30,10 +30,9 @@ import lombok.ToString;
 /**
  * Java name.
  * This class is used to represent any java class or method name and to avoid
- * naming conflicts with EO reserved words.
+ * naming conflicts with EO-reserved words.
  * You can read more about the problem
  * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/276">here</a>
- * In the first implementation of this class it just added a 'j' prefix to any name.
  *
  * @since 0.1
  */

--- a/src/test/java/org/eolang/jeo/representation/PrefixedNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/PrefixedNameTest.java
@@ -43,7 +43,9 @@ final class PrefixedNameTest {
         "someLongName, j$someLongName",
         "j$j, j$j$j",
         "jeo/xmir/Fake, j$jeo/j$xmir/j$Fake",
-        "EOorg.EOeolang, j$EOorg.j$EOeolang"
+        "EOorg.EOeolang, j$EOorg.j$EOeolang",
+        "org.eolang, j$org.j$eolang",
+        "org.eolang.Fake, j$org.j$eolang.j$Fake"
     })
     void encodesName(final String origin, final String encoded) {
         MatcherAssert.assertThat(
@@ -61,7 +63,9 @@ final class PrefixedNameTest {
         "j$j$j, j$j",
         "someName, someName",
         "j$jeo/j$xmir/j$Fake, jeo/xmir/Fake",
-        "j$EOorg.j$EOeolang, EOorg.EOeolang"
+        "j$EOorg.j$EOeolang, EOorg.EOeolang",
+        "j$org.j$eolang, org.eolang",
+        "j$org.j$eolang.j$Fake, org.eolang.Fake"
     })
     void decodesName(final String encoded, final String origin) {
         MatcherAssert.assertThat(

--- a/src/test/java/org/eolang/jeo/representation/PrefixedNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/PrefixedNameTest.java
@@ -42,7 +42,8 @@ final class PrefixedNameTest {
         "ClassName, j$ClassName",
         "someLongName, j$someLongName",
         "j$j, j$j$j",
-        "jeo/xmir/Fake, j$jeo/j$xmir/j$Fake"
+        "jeo/xmir/Fake, j$jeo/j$xmir/j$Fake",
+        "EOorg.EOeolang, j$EOorg.j$EOeolang"
     })
     void encodesName(final String origin, final String encoded) {
         MatcherAssert.assertThat(
@@ -59,7 +60,8 @@ final class PrefixedNameTest {
         "j$someLongName, someLongName",
         "j$j$j, j$j",
         "someName, someName",
-        "j$jeo/j$xmir/j$Fake, jeo/xmir/Fake"
+        "j$jeo/j$xmir/j$Fake, jeo/xmir/Fake",
+        "j$EOorg.j$EOeolang, EOorg.EOeolang"
     })
     void decodesName(final String encoded, final String origin) {
         MatcherAssert.assertThat(

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -47,7 +47,7 @@ final class XmirRepresentationTest {
     @Test
     void retrievesName() {
         final String name = "Math";
-        final String expected = "j$org/eolang/foo/j$Math";
+        final String expected = "j$org/j$eolang/j$foo/j$Math";
         final String actual = new XmirRepresentation(
             new BytecodeProgram(
                 "org/eolang/foo",

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
@@ -94,8 +94,8 @@ final class DirectivesMetasTest {
             ).xmlQuietly(),
             Matchers.allOf(
                 XhtmlMatchers.hasXPath("/metas/meta/head[text()='package']"),
-                XhtmlMatchers.hasXPath("/metas/meta/tail[text()='j$path.to']"),
-                XhtmlMatchers.hasXPath("/metas/meta/part[text()='j$path.to']"),
+                XhtmlMatchers.hasXPath("/metas/meta/tail[text()='j$path.j$to']"),
+                XhtmlMatchers.hasXPath("/metas/meta/part[text()='j$path.j$to']"),
                 Matchers.not(
                     XhtmlMatchers.hasXPath("/metas/meta/tail[text()='org.eolang.jeo.label']")
                 ),

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
@@ -47,8 +47,8 @@ final class DirectivesMetasTest {
             ).xmlQuietly(),
             Matchers.allOf(
                 XhtmlMatchers.hasXPath("/metas/meta/head[text()='package']"),
-                XhtmlMatchers.hasXPath("/metas/meta/tail[text()='j$path.to']"),
-                XhtmlMatchers.hasXPath("/metas/meta/part[text()='j$path.to']")
+                XhtmlMatchers.hasXPath("/metas/meta/tail[text()='j$path.j$to']"),
+                XhtmlMatchers.hasXPath("/metas/meta/part[text()='j$path.j$to']")
             )
         );
     }


### PR DESCRIPTION
In this PR I fixed a bug with package names that contain dot instead of slash.
Now `PrefixedName` can handle both delimiters.
Moreover, I added lookbehind patterns to siplify the solution.

Related to #785.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refining the handling of names in the `XmirRepresentation` and `PrefixedName` classes. It updates expected values in tests and enhances the regex patterns for encoding and decoding names, ensuring better compliance with naming conventions.

### Detailed summary
- Updated expected names in `retrievesName` method of `XmirRepresentationTest`.
- Enhanced name encoding in `encodesName` method of `PrefixedNameTest`.
- Adjusted XPath checks in `DirectivesMetasTest` for tail and part elements.
- Improved regex patterns in `PrefixedName` class for blank and prefixed names.
- Simplified `encode` and `decode` methods in `PrefixedName` class by using regex.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->