### PR TITLE
feat(#787): Empty Annotation Values"

### DIFF
--- a/src/it/annotations/src/main/java/org/eolang/jeo/annotations/AnnotationsApplication.java
+++ b/src/it/annotations/src/main/java/org/eolang/jeo/annotations/AnnotationsApplication.java
@@ -23,7 +23,8 @@ import java.util.Arrays;
     nestedArray = {
         @NestedAnnotation(name = "nested1"),
         @NestedAnnotation(name = "nested2")
-    }
+    },
+    nestedEmpty = @NestedAnnotation
 )
 public class AnnotationsApplication {
 
@@ -83,6 +84,9 @@ public class AnnotationsApplication {
             }
             if (annotation.nestedArray().length != 2) {
                 throw new IllegalStateException("nestedArray length is not 2");
+            }
+            if (annotation.nestedEmpty() == null) {
+                throw new IllegalStateException("nestedEmpty is null");
             }
             if (annotation.innerEnum() != JeoAnnotation.InnerEnum.TWO) {
                 throw new IllegalStateException("innerEnum is not TWO");

--- a/src/it/annotations/src/main/java/org/eolang/jeo/annotations/JeoAnnotation.java
+++ b/src/it/annotations/src/main/java/org/eolang/jeo/annotations/JeoAnnotation.java
@@ -34,6 +34,7 @@ public @interface JeoAnnotation {
 
     InnerEnum innerEnum() default InnerEnum.ONE;
 
+    NestedAnnotation nestedEmpty();
     enum InnerEnum {
         ONE, TWO, THREE
     }

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
@@ -599,7 +599,10 @@ public final class AsmProgram {
             result = new BytecodeAnnotationAnnotationValue(
                 name,
                 cast.desc,
-                cast.values.stream().map(val -> AsmProgram.annotationProperty("", val))
+                Optional.ofNullable(cast.values)
+                    .map(Collection::stream)
+                    .orElseGet(Stream::empty)
+                    .map(val -> AsmProgram.annotationProperty("", val))
                     .collect(Collectors.toList())
             );
         } else if (value instanceof List) {


### PR DESCRIPTION
In this PR I fixed the NPE related to annotations that don't have any value set.
Also I added one more test case to the `annotations` integration test.

Closes: #787.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `NestedAnnotation` field in the `JeoAnnotation` class and updates the `AnnotationsApplication` class to handle this new field. It also modifies how `cast.values` are processed in the `AsmProgram` class.

### Detailed summary
- Added `NestedAnnotation nestedEmpty();` to `JeoAnnotation`.
- Updated `AnnotationsApplication` to include `nestedEmpty = @NestedAnnotation`.
- Added a null check for `nestedEmpty` in `AnnotationsApplication`.
- Changed processing of `cast.values` to use `Optional` and `orElseGet(Stream::empty)` in `AsmProgram`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->