### PR TITLE
feat(#790): Compute MaxStack and MaxLocals For Abstract Methods

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/InstructionsFlow.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/InstructionsFlow.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.eolang.jeo.representation.xmir.AllLabels;
@@ -70,7 +71,7 @@ public final class InstructionsFlow<T extends InstructionsFlow.Reducible<T>> {
      * @return Maximum value.
      */
     @SuppressWarnings("PMD.CognitiveComplexity")
-    public T max(final T initial, final Function<BytecodeInstruction, T> generator) {
+    public Optional<T> max(final T initial, final Function<BytecodeInstruction, T> generator) {
         final Map<Integer, T> visited = new HashMap<>(0);
         final Map<Integer, T> worklist = new HashMap<>(0);
         worklist.put(0, initial);
@@ -130,8 +131,7 @@ public final class InstructionsFlow<T extends InstructionsFlow.Reducible<T>> {
         }
         return visited.values()
             .stream()
-            .max(T::compareTo)
-            .orElseThrow(() -> new IllegalStateException("Cannot find max value"));
+            .max(T::compareTo);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/MaxLocals.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/MaxLocals.java
@@ -90,7 +90,7 @@ final class MaxLocals {
                     }
                     return result;
                 }
-            ).size();
+            ).orElse(new Variables()).size();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/MaxStack.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/MaxStack.java
@@ -64,6 +64,7 @@ final class MaxStack {
     public int value() {
         return new InstructionsFlow<Stack>(this.instructions, this.blocks)
             .max(new Stack(0), Stack::new)
+            .orElse(new Stack(0))
             .integer();
     }
 

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -458,8 +458,25 @@ final class BytecodeMethodTest {
     }
 
     @ParameterizedTest(name = "Computing maxs for method {1}, expected  {2}")
-    @MethodSource("methods")
-    void computesMaxsCorrectly(
+    @MethodSource("implementedMethods")
+    void computesMaxsCorrectlyForImplementedMethods(
+        final BytecodeMethod method,
+        final String name,
+        final BytecodeMaxs expected
+    ) {
+        MatcherAssert.assertThat(
+            String.format(
+                "Maxs weren't computed correctly for method %s",
+                name
+            ),
+            method.computeMaxs(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @ParameterizedTest(name = "Computing maxs for method {1}, expected  {2}")
+    @MethodSource("abstractMethods")
+    void computesMaxsCorrectlyForAbstractMethods(
         final BytecodeMethod method,
         final String name,
         final BytecodeMaxs expected
@@ -475,13 +492,33 @@ final class BytecodeMethodTest {
     }
 
     /**
-     * Provides methods for testing.
-     * Used in {@link #computesMaxsCorrectly(BytecodeMethod, String, BytecodeMaxs)}.
+     * Provides implemented methods for testing.
+     * These methods contain different number of local variables and stack elements.
+     * Used in {@link #computesMaxsCorrectlyForImplementedMethods(BytecodeMethod, String, BytecodeMaxs)}.
      * @return Stream of arguments.
      */
-    static Stream<Arguments> methods() {
+    static Stream<Arguments> implementedMethods() {
+        return BytecodeMethodTest.methods("maxs/Maxs.java");
+    }
+
+    /**
+     * Provides methods for testing.
+     * These methods are abstract.
+     * Used in {@link #computesMaxsCorrectlyForImplementedMethods(BytecodeMethod, String, BytecodeMaxs)}.
+     * @return Stream of arguments.
+     */
+    static Stream<Arguments> abstractMethods() {
+        return BytecodeMethodTest.methods("maxs/MaxInterface.java");
+    }
+
+    /**
+     * Provides methods for testing.
+     * @param clazz Resource class name.
+     * @return Stream of arguments.
+     */
+    static Stream<Arguments> methods(final String clazz) {
         return new AsmProgram(
-            new JavaSourceClass("maxs/Maxs.java").compile().bytes()
+            new JavaSourceClass(clazz).compile().bytes()
         ).bytecode().top().methods().stream().map(
             method -> Arguments.of(method, method.name(), method.currentMaxs())
         );

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -494,7 +494,8 @@ final class BytecodeMethodTest {
     /**
      * Provides implemented methods for testing.
      * These methods contain different number of local variables and stack elements.
-     * Used in {@link #computesMaxsCorrectlyForImplementedMethods(BytecodeMethod, String, BytecodeMaxs)}.
+     * Used in
+     * {@link #computesMaxsCorrectlyForImplementedMethods(BytecodeMethod, String, BytecodeMaxs)}.
      * @return Stream of arguments.
      */
     static Stream<Arguments> implementedMethods() {
@@ -504,7 +505,8 @@ final class BytecodeMethodTest {
     /**
      * Provides methods for testing.
      * These methods are abstract.
-     * Used in {@link #computesMaxsCorrectlyForImplementedMethods(BytecodeMethod, String, BytecodeMaxs)}.
+     * Used in
+     * {@link #computesMaxsCorrectlyForImplementedMethods(BytecodeMethod, String, BytecodeMaxs)}.
      * @return Stream of arguments.
      */
     static Stream<Arguments> abstractMethods() {

--- a/src/test/resources/maxs/MaxInterface.java
+++ b/src/test/resources/maxs/MaxInterface.java
@@ -53,13 +53,22 @@ import java.util.ArrayList;
 public interface MaxInterface {
 
     /**
-     * Method with no local variables and no stack elements.
+     * Method with one local variable (this) and no stack elements.
+     * Attention! Abstract methods don't have local variables and stack elements.
      */
     void noVariablesNoStack();
 
     /**
-     * Method with one local variable and no stack elements.
+     * Method without local variables and with one stack element.
+     * Attention! Abstract methods don't have local variables and stack elements.
      */
     void oneVariableNoStack(int var);
+
+    /**
+     * Method with one local variable (this) and two stack elements.
+     */
+    default void noVariablesNoStackDefault() {
+        System.out.println("Hello, world!");
+    }
 
 }

--- a/src/test/resources/maxs/MaxInterface.java
+++ b/src/test/resources/maxs/MaxInterface.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.net.HttpURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.ArrayList;
+
+
+/**
+ * This class contains many different methods with different number of local
+ * variables and stack elements.
+ * Primarly this class is used in {@link BytecodeMethodTest} to test how the
+ * {@link BytecodeMethod} class counts the maxs.
+ * @since 0.6
+ */
+public interface MaxInterface {
+
+    /**
+     * Method with no local variables and no stack elements.
+     */
+    void noVariablesNoStack();
+
+    /**
+     * Method with one local variable and no stack elements.
+     */
+    void oneVariableNoStack(int var);
+
+}


### PR DESCRIPTION
In this PR I handle the corner case for `max_stack` and `max_locals` computation.
All abstract methods has `max_stack==0` and `max_locals==0`. I added unit tests that cover this problem.

Related to #790.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of maximum local variables and stack elements in the `BytecodeMethod` class. It introduces new methods for testing and updates existing functionality to improve the computation of maximum values.

### Detailed summary
- Updated `max` method in `InstructionsFlow` to return `Optional<T>`.
- Modified `MaxLocals` to handle empty cases with `orElse(new Variables())`.
- Added tests for implemented and abstract methods in `BytecodeMethodTest`.
- Created `MaxInterface` with methods for testing local variables and stack elements.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->