### PR TITLE
feat(#768): Try To Load Classes For Analisys From All The Possible Places"

### DIFF
--- a/src/main/java/org/eolang/jeo/JeoClassLoader.java
+++ b/src/main/java/org/eolang/jeo/JeoClassLoader.java
@@ -28,8 +28,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -72,7 +72,7 @@ public final class JeoClassLoader extends ClassLoader {
      * @param parent Parent class loader.
      * @param classes Classes as file paths.
      */
-    JeoClassLoader(final ClassLoader parent, final List<String> classes) {
+    JeoClassLoader(final ClassLoader parent, final Collection<String> classes) {
         this(parent, JeoClassLoader.prestructor(classes));
     }
 
@@ -119,7 +119,7 @@ public final class JeoClassLoader extends ClassLoader {
      * @param classes File paths.
      * @return Map of classes.
      */
-    private static Map<String, byte[]> prestructor(final List<String> classes) {
+    private static Map<String, byte[]> prestructor(final Collection<String> classes) {
         return classes.stream()
             .parallel()
             .map(Paths::get)

--- a/src/main/java/org/eolang/jeo/PluginStartup.java
+++ b/src/main/java/org/eolang/jeo/PluginStartup.java
@@ -26,7 +26,6 @@ package org.eolang.jeo;
 import com.jcabi.log.Logger;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;

--- a/src/main/java/org/eolang/jeo/PluginStartup.java
+++ b/src/main/java/org/eolang/jeo/PluginStartup.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo;
 
+import java.util.Arrays;
 import java.util.List;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.project.MavenProject;
@@ -43,12 +44,25 @@ public final class PluginStartup {
     /**
      * Constructor.
      * @param project Maven project.
+     * @throws DependencyResolutionRequiredException If a problem happened during loading classes.
      */
     PluginStartup(final MavenProject project) throws DependencyResolutionRequiredException {
         this(project.getRuntimeClasspathElements());
     }
 
-    public PluginStartup(final List<String> folders) {
+    /**
+     * Constructor.
+     * @param folders Folders with classes.
+     */
+    PluginStartup(final String... folders) {
+        this(Arrays.asList(folders));
+    }
+
+    /**
+     * Constructor.
+     * @param folders Folders with classes.
+     */
+    private PluginStartup(final List<String> folders) {
         this.folders = folders;
     }
 
@@ -62,10 +76,8 @@ public final class PluginStartup {
      * We need this to solve the problem with computing maxs in ASM library:
      * - https://gitlab.ow2.org/asm/asm/-/issues/317918
      * - https://stackoverflow.com/questions/11292701/error-while-instrumenting-class-files-asm-classwriter-getcommonsuperclass
-     *
-     * @throws DependencyResolutionRequiredException If a problem happened during loading classes.
      */
-    void init() throws DependencyResolutionRequiredException {
+    void init() {
         Thread.currentThread().setContextClassLoader(
             new JeoClassLoader(
                 Thread.currentThread().getContextClassLoader(),

--- a/src/main/java/org/eolang/jeo/PluginStartup.java
+++ b/src/main/java/org/eolang/jeo/PluginStartup.java
@@ -25,6 +25,8 @@ package org.eolang.jeo;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.project.MavenProject;
 
@@ -47,7 +49,15 @@ public final class PluginStartup {
      * @throws DependencyResolutionRequiredException If a problem happened during loading classes.
      */
     PluginStartup(final MavenProject project) throws DependencyResolutionRequiredException {
-        this(project.getRuntimeClasspathElements());
+        this(
+            Stream.concat(
+                Stream.concat(
+                    project.getRuntimeClasspathElements().stream(),
+                    project.getCompileClasspathElements().stream()
+                ),
+                project.getTestClasspathElements().stream()
+            ).collect(Collectors.toList())
+        );
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/PluginStartup.java
+++ b/src/main/java/org/eolang/jeo/PluginStartup.java
@@ -23,7 +23,9 @@
  */
 package org.eolang.jeo;
 
+import com.jcabi.log.Logger;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -41,7 +43,7 @@ public final class PluginStartup {
     /**
      * All the folders with classes.
      */
-    private final List<String> folders;
+    private final Collection<String> folders;
 
     /**
      * Constructor.
@@ -56,7 +58,7 @@ public final class PluginStartup {
                     project.getCompileClasspathElements().stream()
                 ),
                 project.getTestClasspathElements().stream()
-            ).collect(Collectors.toList())
+            ).collect(Collectors.toSet())
         );
     }
 
@@ -72,7 +74,7 @@ public final class PluginStartup {
      * Constructor.
      * @param folders Folders with classes.
      */
-    private PluginStartup(final List<String> folders) {
+    private PluginStartup(final Collection<String> folders) {
         this.folders = folders;
     }
 
@@ -88,6 +90,13 @@ public final class PluginStartup {
      * - https://stackoverflow.com/questions/11292701/error-while-instrumenting-class-files-asm-classwriter-getcommonsuperclass
      */
     void init() {
+        Logger.info(
+            this,
+            String.format(
+                "Trying to load assembled classes from %s",
+                this.folders.stream().collect(Collectors.joining(", ", "[", "]"))
+            )
+        );
         Thread.currentThread().setContextClassLoader(
             new JeoClassLoader(
                 Thread.currentThread().getContextClassLoader(),

--- a/src/main/java/org/eolang/jeo/PluginStartup.java
+++ b/src/main/java/org/eolang/jeo/PluginStartup.java
@@ -23,11 +23,12 @@
  */
 package org.eolang.jeo;
 
+import java.util.List;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.project.MavenProject;
 
 /**
- * All mojos initialization step.
+ * All mojo's initialization step.
  * This class is responsible for initializing classloader.
  *
  * @since 0.1
@@ -35,16 +36,20 @@ import org.apache.maven.project.MavenProject;
 public final class PluginStartup {
 
     /**
-     * Maven project.
+     * All the folders with classes.
      */
-    private final MavenProject project;
+    private final List<String> folders;
 
     /**
      * Constructor.
      * @param project Maven project.
      */
-    PluginStartup(final MavenProject project) {
-        this.project = project;
+    PluginStartup(final MavenProject project) throws DependencyResolutionRequiredException {
+        this(project.getRuntimeClasspathElements());
+    }
+
+    public PluginStartup(final List<String> folders) {
+        this.folders = folders;
     }
 
     /**
@@ -64,7 +69,7 @@ public final class PluginStartup {
         Thread.currentThread().setContextClassLoader(
             new JeoClassLoader(
                 Thread.currentThread().getContextClassLoader(),
-                this.project.getRuntimeClasspathElements()
+                this.folders
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/PluginStartupTest.java
+++ b/src/test/java/org/eolang/jeo/PluginStartupTest.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.jeo;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;

--- a/src/test/java/org/eolang/jeo/PluginStartupTest.java
+++ b/src/test/java/org/eolang/jeo/PluginStartupTest.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.eolang.jeo.representation.bytecode.BytecodeClass;
+import org.eolang.jeo.representation.bytecode.BytecodeProgram;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test case for {@link PluginStartup}.
+ *
+ * @since 0.6
+ */
+final class PluginStartupTest {
+
+    @Test
+    void loadsClassesDynamically(@TempDir final Path dir) throws Exception {
+        final String name = "SomeClassCompiledDynamically";
+        Files.write(
+            dir.resolve("SomeClassCompiledDynamically.class"),
+            new BytecodeProgram(new BytecodeClass(name)).bytecode().bytes()
+        );
+        new PluginStartup(dir.toString()).init();
+        MatcherAssert.assertThat(
+            "We expect the class to be loaded",
+            Thread.currentThread().getContextClassLoader().loadClass(name),
+            Matchers.notNullValue()
+        );
+    }
+}


### PR DESCRIPTION
In this PR I added several more folders to get classes from (test classpath and compile classpath). 
Also I added a log entry that will monitor the folders where we try to find classes.
Also I added one more unit test to prove that `PluginStartup` class works as expected.

Related to: #768.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `JeoClassLoader` and `PluginStartup` classes to support a broader collection type for class paths, improving flexibility. It also introduces a new test class, `PluginStartupTest`, to verify dynamic class loading.

### Detailed summary
- Changed the parameter type from `List<String>` to `Collection<String>` in `JeoClassLoader` and `prestructor` methods.
- Added `PluginStartupTest` class to test dynamic loading of classes.
- Updated `PluginStartup` constructors to accept `Collection<String>` for class folders.
- Enhanced logging in the `init` method of `PluginStartup`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->