### PR TITLE
feat(#801): Correctly Map String Values With Unicode Characters

### DIFF
--- a/src/it/phi-unphi/src/main/java/org/eolang/hone/App.java
+++ b/src/it/phi-unphi/src/main/java/org/eolang/hone/App.java
@@ -32,7 +32,7 @@ import org.eolang.hone.param.Parameter;
 @Parameter("some-parameter")
 public class App {
 
-    private static final String Φ = "We have the field with the unicaode character 'Φ'";
+    private static final String Φ = "We have the field with the unicode character 'Φ'";
 
     @Deprecated
     @SuppressWarnings("unchecked")

--- a/src/it/phi-unphi/src/main/java/org/eolang/hone/App.java
+++ b/src/it/phi-unphi/src/main/java/org/eolang/hone/App.java
@@ -32,11 +32,14 @@ import org.eolang.hone.param.Parameter;
 @Parameter("some-parameter")
 public class App {
 
+    private static final String Φ = "We have the field with the unicaode character 'Φ'";
+
     @Deprecated
     @SuppressWarnings("unchecked")
     public static void main(String[] args) {
         double angle = 42.0;
         double sin = Math.sin(angle);
         System.out.printf("sin(%f) = %f\n", angle, sin);
+        System.out.println(Φ);
     }
 }

--- a/src/it/phi-unphi/verify.groovy
+++ b/src/it/phi-unphi/verify.groovy
@@ -26,7 +26,7 @@ import java.nio.file.Files
 String log = new File(basedir, 'build.log').text;
 assert log.contains("BUILD SUCCESS"): assertionMessage("BUILD FAILED")
 assert log.contains("sin(42.000000) = -0.916522"): assertionMessage("sin(42.000000) = -0.916522 not found")
-assert log.contains("We have the field with the unicaode character 'Φ'"): assertionMessage("We can't find the field with the unicode character 'Φ'")
+assert log.contains("We have the field with the unicode character 'Φ'"): assertionMessage("We can't find the field with the unicode character 'Φ'")
 
 private String assertionMessage(String message) {
     generateGitHubIssue()

--- a/src/it/phi-unphi/verify.groovy
+++ b/src/it/phi-unphi/verify.groovy
@@ -26,6 +26,7 @@ import java.nio.file.Files
 String log = new File(basedir, 'build.log').text;
 assert log.contains("BUILD SUCCESS"): assertionMessage("BUILD FAILED")
 assert log.contains("sin(42.000000) = -0.916522"): assertionMessage("sin(42.000000) = -0.916522 not found")
+assert log.contains("We have the field with the unicaode character 'Φ'"): assertionMessage("We can't find the field with the unicode character 'Φ'")
 
 private String assertionMessage(String message) {
     generateGitHubIssue()

--- a/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
@@ -123,7 +123,9 @@ enum DataType {
      * String.
      */
     STRING("string", String.class,
-        value -> Optional.ofNullable(value).map(String::valueOf).map(String::getBytes).orElse(null),
+        value -> Optional.ofNullable(value).map(String::valueOf)
+            .map(unicode -> unicode.getBytes(StandardCharsets.UTF_8))
+            .orElse(null),
         bytes -> new String(bytes, StandardCharsets.UTF_8)
     ),
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -70,10 +71,17 @@ public final class XmlValue {
             if (hex.isEmpty()) {
                 result = "";
             } else {
-                result = Arrays.stream(hex.split("(?<=\\G.{2})"))
-                    .map(ch -> (char) Integer.parseInt(ch, XmlValue.RADIX))
-                    .map(String::valueOf)
-                    .collect(Collectors.joining());
+                final String[] split = hex.split("(?<=\\G.{2})");
+                byte[] bytes = new byte[split.length];
+                for (int i = 0; i < split.length; i++) {
+                    bytes[i] = (byte) Integer.parseInt(split[i], XmlValue.RADIX);
+                }
+                result = new String(bytes, StandardCharsets.UTF_8);
+
+//                result = Arrays.stream(hex.split("(?<=\\G.{2})"))
+//                    .map(ch -> (char) Integer.parseInt(ch, XmlValue.RADIX))
+//                    .map(String::valueOf)
+//                    .collect(Collectors.joining());
             }
             return result;
         } catch (final NumberFormatException exception) {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
@@ -24,9 +24,7 @@
 package org.eolang.jeo.representation.xmir;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.eolang.jeo.representation.bytecode.BytecodeValue;
 
 /**
@@ -71,17 +69,13 @@ public final class XmlValue {
             if (hex.isEmpty()) {
                 result = "";
             } else {
-                final String[] split = hex.split("(?<=\\G.{2})");
-                byte[] bytes = new byte[split.length];
-                for (int i = 0; i < split.length; i++) {
-                    bytes[i] = (byte) Integer.parseInt(split[i], XmlValue.RADIX);
+                final String[] chars = hex.split("(?<=\\G.{2})");
+                final int length = chars.length;
+                final byte[] bytes = new byte[length];
+                for (int index = 0; index < length; ++index) {
+                    bytes[index] = (byte) Integer.parseInt(chars[index], XmlValue.RADIX);
                 }
                 result = new String(bytes, StandardCharsets.UTF_8);
-
-//                result = Arrays.stream(hex.split("(?<=\\G.{2})"))
-//                    .map(ch -> (char) Integer.parseInt(ch, XmlValue.RADIX))
-//                    .map(String::valueOf)
-//                    .collect(Collectors.joining());
             }
             return result;
         } catch (final NumberFormatException exception) {

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesFieldTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesFieldTest.java
@@ -24,8 +24,11 @@
 package org.eolang.jeo.representation.directives;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import org.eolang.jeo.representation.bytecode.BytecodeField;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.objectweb.asm.Opcodes;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
@@ -78,6 +81,33 @@ final class DirectivesFieldTest {
                 "/o/o[@name='descriptor-serialVersionUID']/o[text()='4A']",
                 "/o/o[@name='signature-serialVersionUID']",
                 "/o/o[@name='value-serialVersionUID']/o[text()='62 84 EB 5F 88 47 CD E1']"
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "Φ", "Ψ", "Ω", "Δ", "Σ", "Θ", "Λ", "Ξ", "Π", "Υ", "\u03A3", "\u03A6", "\u03A8", "\u03A9"
+    })
+    void convertsDirectivesFieldWithUnicodeName(
+        final String original
+    ) throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect the field name with unicode characters to be successfully converted to directives",
+            new Xembler(
+                new BytecodeField(
+                    original,
+                    "I",
+                    "",
+                    0,
+                    Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL
+                ).directives()
+            ).xml(),
+            XhtmlMatchers.hasXPaths(
+                String.format(
+                    "/o[contains(@base,'field') and contains(@name,'%s')]",
+                    original
+                )
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlFieldTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlFieldTest.java
@@ -34,6 +34,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.objectweb.asm.Opcodes;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
@@ -131,6 +132,26 @@ final class XmlFieldTest {
                     )
                 )
             )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "Φ", "Ψ", "Ω", "Δ", "Σ", "Θ", "Λ", "Ξ", "Π", "Υ", "\u03A3", "\u03A6", "\u03A8", "\u03A9"
+    })
+    void parsesXmirFieldWithUnicodeCharacterInTheName(final String original)
+        throws ImpossibleModificationException {
+        final BytecodeField expected = new BytecodeField(
+            original,
+            "I",
+            null,
+            0,
+            Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL
+        );
+        MatcherAssert.assertThat(
+            "We expect the field name with unicode characters to be successfully parsed from directives",
+            new XmlField(new XmlNode(new Xembler(expected.directives()).xml())).bytecode(),
+            Matchers.equalTo(expected)
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlValueTest.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
 /**
@@ -65,6 +67,24 @@ final class XmlValueTest {
                 new XmlNode(new Xembler(new DirectivesValue(origin)).xmlQuietly())
             ).object(),
             Matchers.equalTo(origin)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "Φ", "Ψ", "Ω", "Ϊ", "Ϋ", "ά", "έ", "ή", "ί", "ΰ", "α", "β", "γ", "δ", "ε", "ζ", "η", "θ", "ι", "κ", "λ", "μ",
+    })
+    void decodesUnicodeCharacters(final String unicode) throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "Can't decode unicode characters",
+            new XmlValue(
+                new XmlNode(
+                    new Xembler(
+                        new DirectivesValue(unicode)
+                    ).xml()
+                )
+            ).string(),
+            Matchers.equalTo(unicode)
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlValueTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.directives.DirectivesValue;
 import org.hamcrest.MatcherAssert;
@@ -75,17 +76,27 @@ final class XmlValueTest {
         "Φ", "Ψ", "Ω", "Ϊ", "Ϋ", "ά", "έ", "ή", "ί", "ΰ", "α", "β", "γ", "δ", "ε", "ζ", "η", "θ", "ι", "κ", "λ", "μ",
     })
     void decodesUnicodeCharacters(final String unicode) throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesValue(unicode)
+        ).xml();
+        System.out.println(xml);
         MatcherAssert.assertThat(
             "Can't decode unicode characters",
             new XmlValue(
                 new XmlNode(
-                    new Xembler(
-                        new DirectivesValue(unicode)
-                    ).xml()
+                    xml
                 )
             ).string(),
             Matchers.equalTo(unicode)
         );
+    }
+
+    @Test
+    void test() {
+        System.out.println(
+            new String(new byte[]{(byte) 0xCE, (byte) 0xA6}, StandardCharsets.UTF_8));
+//        CEA6
+//        new String({ce, a6});
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlValueTest.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.directives.DirectivesValue;
 import org.hamcrest.MatcherAssert;
@@ -73,30 +72,20 @@ final class XmlValueTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
-        "Φ", "Ψ", "Ω", "Ϊ", "Ϋ", "ά", "έ", "ή", "ί", "ΰ", "α", "β", "γ", "δ", "ε", "ζ", "η", "θ", "ι", "κ", "λ", "μ",
+        "Φ", "Ψ", "Ω", "Ϊ", "Ϋ", "ά", "έ", "ή", "ί", "ΰ", "α", "β", "γ", "δ", "ε", "ζ", "η", "θ", "ι", "κ", "λ", "μ"
     })
     void decodesUnicodeCharacters(final String unicode) throws ImpossibleModificationException {
-        final String xml = new Xembler(
-            new DirectivesValue(unicode)
-        ).xml();
-        System.out.println(xml);
         MatcherAssert.assertThat(
             "Can't decode unicode characters",
             new XmlValue(
                 new XmlNode(
-                    xml
+                    new Xembler(
+                        new DirectivesValue(unicode)
+                    ).xml()
                 )
             ).string(),
             Matchers.equalTo(unicode)
         );
-    }
-
-    @Test
-    void test() {
-        System.out.println(
-            new String(new byte[]{(byte) 0xCE, (byte) 0xA6}, StandardCharsets.UTF_8));
-//        CEA6
-//        new String({ce, a6});
     }
 
     /**


### PR DESCRIPTION
In this PR I successfully fixed the bug related to transformation of String values with unicode characters.

Related to #801.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of Unicode characters in the `Eolang` project, particularly in the `App`, `DataType`, and `XmlValue` classes, while also adding tests to ensure proper encoding and decoding of these characters.

### Detailed summary
- Added a static final `String` `Φ` in the `App` class.
- Modified the `DataType` class to use `StandardCharsets.UTF_8` for byte conversion.
- Updated `XmlValue` class to decode hex values into a UTF-8 string.
- Added parameterized tests for Unicode character handling in `XmlValueTest` and `XmlFieldTest`.
- Implemented a test for converting directives field names with Unicode in `DirectivesFieldTest`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->