### PR TITLE
feat(#768): Add Output Folder to Bytecode Verification

### DIFF
--- a/src/it/phi-unphi/pom.xml
+++ b/src/it/phi-unphi/pom.xml
@@ -43,7 +43,7 @@ SOFTWARE.
     <eo.phi>${project.build.directory}/generated-sources/eo-phi</eo.phi>
     <eo.unphi>${project.build.directory}/generated-sources/eo-unphi</eo.unphi>
     <jeo.unroll>${project.build.directory}/generated-sources/jeo-unroll</jeo.unroll>
-    <jeo.assemble>${project.build.directory}/generated-sources/jeo-assemble</jeo.assemble>
+    <jeo.assemble>jeo-assemble</jeo.assemble>
   </properties>
   <build>
     <plugins>

--- a/src/it/phi-unphi/pom.xml
+++ b/src/it/phi-unphi/pom.xml
@@ -43,6 +43,7 @@ SOFTWARE.
     <eo.phi>${project.build.directory}/generated-sources/eo-phi</eo.phi>
     <eo.unphi>${project.build.directory}/generated-sources/eo-unphi</eo.unphi>
     <jeo.unroll>${project.build.directory}/generated-sources/jeo-unroll</jeo.unroll>
+    <jeo.assemble>${project.build.directory}/generated-sources/jeo-assemble</jeo.assemble>
   </properties>
   <build>
     <plugins>
@@ -77,6 +78,7 @@ SOFTWARE.
             <phase>package</phase>
             <configuration>
               <sourcesDir>${jeo.unroll}</sourcesDir>
+              <outputDir>${jeo.assemble}</outputDir>
             </configuration>
             <goals>
               <goal>assemble</goal>
@@ -131,11 +133,37 @@ SOFTWARE.
           <executable>java</executable>
           <arguments>
             <argument>-classpath</argument>
-            <argument>${project.build.outputDirectory}</argument>
+            <argument>${jeo.assemble}</argument>
             <argument>org.eolang.hone.App</argument>
           </arguments>
         </configuration>
       </plugin>
+            <!--
+              We clean target/classes directory to be sure
+              that bytecode verification works without old
+              class files.
+            -->
+            <plugin>
+              <artifactId>maven-clean-plugin</artifactId>
+              <version>3.4.0</version>
+              <executions>
+                <execution>
+                  <id>clean target</id>
+                  <phase>process-classes</phase>
+                  <goals>
+                    <goal>clean</goal>
+                  </goals>
+                  <configuration>
+                    <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                    <filesets>
+                      <fileset>
+                        <directory>target/classes</directory>
+                      </fileset>
+                    </filesets>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
     </plugins>
   </build>
 </project>

--- a/src/it/phi-unphi/pom.xml
+++ b/src/it/phi-unphi/pom.xml
@@ -138,32 +138,32 @@ SOFTWARE.
           </arguments>
         </configuration>
       </plugin>
-            <!--
-              We clean target/classes directory to be sure
-              that bytecode verification works without old
-              class files.
-            -->
-            <plugin>
-              <artifactId>maven-clean-plugin</artifactId>
-              <version>3.4.0</version>
-              <executions>
-                <execution>
-                  <id>clean target</id>
-                  <phase>process-classes</phase>
-                  <goals>
-                    <goal>clean</goal>
-                  </goals>
-                  <configuration>
-                    <excludeDefaultDirectories>true</excludeDefaultDirectories>
-                    <filesets>
-                      <fileset>
-                        <directory>target/classes</directory>
-                      </fileset>
-                    </filesets>
-                  </configuration>
-                </execution>
-              </executions>
-            </plugin>
+      <!--
+        We clean target/classes directory to be sure
+        that bytecode verification works without old
+        class files.
+      -->
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.4.0</version>
+        <executions>
+          <execution>
+            <id>clean target</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+            <configuration>
+              <excludeDefaultDirectories>true</excludeDefaultDirectories>
+              <filesets>
+                <fileset>
+                  <directory>target/classes</directory>
+                </fileset>
+              </filesets>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/main/java/org/eolang/jeo/AssembleMojo.java
+++ b/src/main/java/org/eolang/jeo/AssembleMojo.java
@@ -117,7 +117,7 @@ public final class AssembleMojo extends AbstractMojo {
                     Logger.info(this, "Verification is disabled. Skipping.");
                 } else {
                     Logger.info(this, "Verification of all the generated classes.");
-                    new PluginStartup(this.project).init();
+                    new PluginStartup(this.project, this.outputDir.toPath()).init();
                     new BytecodeDirectory(this.outputDir.toPath()).verify();
                 }
             }

--- a/src/main/java/org/eolang/jeo/BytecodeDirectory.java
+++ b/src/main/java/org/eolang/jeo/BytecodeDirectory.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo;
 
+import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -129,5 +130,9 @@ final class BytecodeDirectory {
                 );
             }
         }
+        Logger.info(
+            BytecodeDirectory.class,
+            String.format("Bytecode verification passed for the class '%s'", clazz.name)
+        );
     }
 }

--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -95,7 +95,7 @@ public final class DisassembleMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException {
         try {
-            new PluginStartup(this.project).init();
+            new PluginStartup(this.project, this.sourcesDir.toPath()).init();
             if (this.disabled) {
                 Logger.info(this, "Disassemble mojo is disabled. Skipping.");
             } else {

--- a/src/main/java/org/eolang/jeo/JeoClassLoader.java
+++ b/src/main/java/org/eolang/jeo/JeoClassLoader.java
@@ -125,7 +125,9 @@ public final class JeoClassLoader extends ClassLoader {
             .map(Paths::get)
             .filter(Files::exists)
             .flatMap(JeoClassLoader::clazzes)
-            .collect(Collectors.toMap(MapEntry::getKey, MapEntry::getValue));
+            .collect(
+                Collectors.toMap(MapEntry::getKey, MapEntry::getValue, (first, second) -> first)
+            );
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/PluginStartup.java
+++ b/src/main/java/org/eolang/jeo/PluginStartup.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo;
 
 import com.jcabi.log.Logger;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
@@ -47,16 +48,22 @@ public final class PluginStartup {
     /**
      * Constructor.
      * @param project Maven project.
+     * @param additional Additional folders with classes.
      * @throws DependencyResolutionRequiredException If a problem happened during loading classes.
      */
-    PluginStartup(final MavenProject project) throws DependencyResolutionRequiredException {
+    PluginStartup(
+        final MavenProject project, final Path... additional
+    ) throws DependencyResolutionRequiredException {
         this(
             Stream.concat(
                 Stream.concat(
                     project.getRuntimeClasspathElements().stream(),
                     project.getCompileClasspathElements().stream()
                 ),
-                project.getTestClasspathElements().stream()
+                Stream.concat(
+                    project.getTestClasspathElements().stream(),
+                    Arrays.stream(additional).map(Path::toString)
+                )
             ).collect(Collectors.toSet())
         );
     }

--- a/src/main/java/org/eolang/jeo/PluginStartup.java
+++ b/src/main/java/org/eolang/jeo/PluginStartup.java
@@ -99,7 +99,7 @@ public final class PluginStartup {
         Logger.info(
             this,
             String.format(
-                "Trying to load assembled classes from %s",
+                "Trying to load classes for bytecode verification from %s",
                 this.folders.stream().collect(Collectors.joining(", ", "[", "]"))
             )
         );

--- a/src/test/java/org/eolang/jeo/PluginStartupTest.java
+++ b/src/test/java/org/eolang/jeo/PluginStartupTest.java
@@ -25,6 +25,7 @@ package org.eolang.jeo;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.apache.maven.project.MavenProject;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.eolang.jeo.representation.bytecode.BytecodeProgram;
 import org.hamcrest.MatcherAssert;
@@ -46,7 +47,7 @@ final class PluginStartupTest {
             dir.resolve("SomeClassCompiledDynamically.class"),
             new BytecodeProgram(new BytecodeClass(name)).bytecode().bytes()
         );
-        new PluginStartup(dir.toString()).init();
+        new PluginStartup(new MavenProject(), dir).init();
         MatcherAssert.assertThat(
             "We expect the class to be loaded",
             Thread.currentThread().getContextClassLoader().loadClass(name),


### PR DESCRIPTION
In this PR I explicitly specify the output directory where to look for classes for bytecode verification.
Also I changed `phi/unphi` integration test to prove that this additional folder works well.
Moreover, I improved verification logging.

Related to #768.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the functionality of the `PluginStartup` class by allowing it to accept additional class paths, improving logging for bytecode verification, and updating various classes to utilize these changes. It also modifies the Maven configuration for better build management.

### Detailed summary
- Updated `PluginStartup` to accept an additional `Path...` parameter for class paths.
- Changed logging message to specify bytecode verification.
- Modified `JeoClassLoader` to prevent duplicate keys in the collected map.
- Enhanced `AssembleMojo` and `DisassembleMojo` to pass new directory paths.
- Added Maven configuration for `jeo.assemble` output directory and a clean plugin to remove old class files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->