### PR TITLE
feat(#803): Add Context To The XML Parsing Failure

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
@@ -168,7 +168,10 @@ public final class XmirRepresentation implements Representation {
             );
         } catch (final IllegalArgumentException broken) {
             throw new IllegalStateException(
-                String.format("Can't parse XML from the file '%s'", path),
+                String.format(
+                    "Can't parse XML from the file '%s'",
+                    path
+                ),
                 broken
             );
         }

--- a/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
@@ -166,6 +166,11 @@ public final class XmirRepresentation implements Representation {
                 String.format("Can't find file '%s'", path),
                 exception
             );
+        } catch (final IllegalArgumentException broken) {
+            throw new IllegalStateException(
+                String.format("Can't parse XML from the file '%s'", path),
+                broken
+            );
         }
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -24,7 +24,6 @@
 package org.eolang.jeo.representation;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import com.jcabi.xml.XML;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -130,19 +129,25 @@ final class XmirRepresentationTest {
 
     @Test
     void failsToOpenBrokenXmirRepresentationFromFile(@TempDir final Path dir) throws IOException {
-        final BytecodeProgram program = new BytecodeProgram(
-            new BytecodeClass("org/eolang/foo/Math")
-        );
         final Path xmir = dir.resolve("Math.xmir");
-        Files.write(xmir, program.xml().toString()
-            .substring(42)
-            .getBytes(StandardCharsets.UTF_8));
+        Files.write(
+            xmir,
+            new BytecodeProgram(
+                new BytecodeClass("org/eolang/foo/Math")
+            ).xml().toString().substring(42).getBytes(StandardCharsets.UTF_8)
+        );
         MatcherAssert.assertThat(
+            "We expect that the error message will be easily understandable by developers",
             Assertions.assertThrows(
                 IllegalStateException.class,
                 () -> new XmirRepresentation(xmir).toBytecode()
             ).getMessage(),
-            Matchers.containsString(String.format("Can't parse XML from the file '%s'", xmir))
+            Matchers.containsString(
+                String.format(
+                    "Can't parse XML from the file '%s'",
+                    xmir
+                )
+            )
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -24,12 +24,19 @@
 package org.eolang.jeo.representation;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XML;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.eolang.jeo.representation.bytecode.BytecodeProgram;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test case for {@link XmirRepresentation}.
@@ -118,6 +125,24 @@ final class XmirRepresentationTest {
             String.format(XmirRepresentationTest.MESSAGE, expected, actual),
             actual,
             Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    void failsToOpenBrokenXmirRepresentationFromFile(@TempDir final Path dir) throws IOException {
+        final BytecodeProgram program = new BytecodeProgram(
+            new BytecodeClass("org/eolang/foo/Math")
+        );
+        final Path xmir = dir.resolve("Math.xmir");
+        Files.write(xmir, program.xml().toString()
+            .substring(42)
+            .getBytes(StandardCharsets.UTF_8));
+        MatcherAssert.assertThat(
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> new XmirRepresentation(xmir).toBytecode()
+            ).getMessage(),
+            Matchers.containsString(String.format("Can't parse XML from the file '%s'", xmir))
         );
     }
 }


### PR DESCRIPTION
In this PR I successfully added context to the XML document parsing exception.
Now, if an XML file is corrupted, we will see the comprehensive error message with the file name.

Related to #803


<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances error handling in the `XmirRepresentation` class by catching `IllegalArgumentException` and throwing a more descriptive `IllegalStateException`. Additionally, it introduces a new test case to verify the handling of broken `.xmir` files.

### Detailed summary
- Added a `catch` block for `IllegalArgumentException` in `XmirRepresentation` to throw an `IllegalStateException` with a clear error message.
- Introduced a new test method `failsToOpenBrokenXmirRepresentationFromFile` in `XmirRepresentationTest` to validate error handling for invalid `.xmir` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->