### PR TITLE
feat(#750): Compute Stack Map Frames

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -174,7 +174,7 @@ public final class BytecodeInstruction implements BytecodeEntry {
                 break;
             case Opcodes.ALOAD:
             case Opcodes.ASTORE:
-                result = Opcodes.NULL;
+                result = Opcodes.TOP;
                 break;
             default:
                 throw new IllegalStateException(

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -141,8 +141,50 @@ public final class BytecodeInstruction implements BytecodeEntry {
         return this.varIndex();
     }
 
-    public Object localType() {
-        return 1;
+    /**
+     *   // Standard stack map frame element types.
+     *
+     *   Integer TOP = Frame.ITEM_TOP;
+     *   Integer INTEGER = Frame.ITEM_INTEGER;
+     *   Integer FLOAT = Frame.ITEM_FLOAT;
+     *   Integer DOUBLE = Frame.ITEM_DOUBLE;
+     *   Integer LONG = Frame.ITEM_LONG;
+     *   Integer NULL = Frame.ITEM_NULL;
+     *   Integer UNINITIALIZED_THIS = Frame.ITEM_UNINITIALIZED_THIS;
+     * @return
+     */
+    public Object elementType() {
+        final Object result;
+        switch (this.opcode) {
+            case Opcodes.ILOAD:
+            case Opcodes.ISTORE:
+                result = Opcodes.INTEGER;
+                break;
+            case Opcodes.LLOAD:
+            case Opcodes.LSTORE:
+                result = Opcodes.LONG;
+                break;
+            case Opcodes.FLOAD:
+            case Opcodes.FSTORE:
+                result = Opcodes.FLOAT;
+                break;
+            case Opcodes.DLOAD:
+            case Opcodes.DSTORE:
+                result = Opcodes.DOUBLE;
+                break;
+            case Opcodes.ALOAD:
+            case Opcodes.ASTORE:
+                result = Opcodes.NULL;
+                break;
+            default:
+                throw new IllegalStateException(
+                    String.format(
+                        "Unexpected opcode for local variable instruction: %s",
+                        new OpcodeName(this.opcode).simplified()
+                    )
+                );
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -136,6 +136,15 @@ public final class BytecodeInstruction implements BytecodeEntry {
         return true;
     }
 
+
+    public int localIndex() {
+        return this.varIndex();
+    }
+
+    public Object localType() {
+        return 1;
+    }
+
     /**
      * Impact of each instruction on the stack.
      * @return Stack impact.

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.bytecode;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
@@ -359,6 +360,25 @@ public final class BytecodeMethod {
      */
     BytecodeMaxs currentMaxs() {
         return this.maxs;
+    }
+
+    /**
+     * Compute frames.
+     * @return Frames.
+     */
+    List<BytecodeFrame> computeFrames() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Current frames.
+     * @return Frames.
+     */
+    List<BytecodeFrame> currentFrames() {
+        return this.instructions.stream()
+            .filter(BytecodeFrame.class::isInstance)
+            .map(BytecodeFrame.class::cast)
+            .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -382,6 +382,7 @@ public final class BytecodeMethod {
      */
     List<BytecodeFrame> computeFrames() {
         return new StackMapFrames(
+            this.properties,
             this.instructions,
             this.tryblocks.stream()
                 .filter(BytecodeTryCatchBlock.class::isInstance)

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -367,7 +367,13 @@ public final class BytecodeMethod {
      * @return Frames.
      */
     List<BytecodeFrame> computeFrames() {
-        return Collections.emptyList();
+        return new StackMapFrames(
+            this.instructions,
+            this.tryblocks.stream()
+                .filter(BytecodeTryCatchBlock.class::isInstance)
+                .map(BytecodeTryCatchBlock.class::cast)
+                .collect(Collectors.toList())
+        ).frames();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
@@ -186,7 +186,13 @@ public final class BytecodeTryCatchBlock implements BytecodeEntry {
      * @return Type.
      */
     String descriptor() {
-        return this.type;
+        final String result;
+        if (this.type == null) {
+            result = "java/lang/Throwable";
+        } else {
+            result = this.type;
+        }
+        return result;
     }
 
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
@@ -181,4 +181,12 @@ public final class BytecodeTryCatchBlock implements BytecodeEntry {
         return this.handler;
     }
 
+    /**
+     * Exception type.
+     * @return Type.
+     */
+    String descriptor() {
+        return this.type;
+    }
+
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/StackMapFrames.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/StackMapFrames.java
@@ -106,6 +106,11 @@ final class StackMapFrames {
                         worklist.push(updated.join(this.index(instr.jumps().get(0))));
                         res.put(index, updated);
                         break;
+                    } else if (instr.isSwitch()) {
+                        instr.jumps()
+                            .forEach(jump -> worklist.push(updated.join(this.index(jump))));
+                        res.put(index, updated);
+                        break;
                     } else if (instr.isReturn() || instr.isThrow()) {
                         res.put(index, updated);
                         break;

--- a/src/main/java/org/eolang/jeo/representation/bytecode/StackMapFrames.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/StackMapFrames.java
@@ -23,8 +23,18 @@
  */
 package org.eolang.jeo.representation.bytecode;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Opcodes;
 
 /**
  * This class knows how to compute the stack map frames from the bytecode entries.
@@ -35,7 +45,7 @@ final class StackMapFrames {
     /**
      * The instructions.
      */
-    private final List<BytecodeEntry> instructions;
+    private final List<BytecodeEntry> entries;
 
     /**
      * The try-catch blocks.
@@ -46,7 +56,7 @@ final class StackMapFrames {
         final List<BytecodeEntry> entries,
         final List<BytecodeTryCatchBlock> blocks
     ) {
-        this.instructions = entries;
+        this.entries = entries;
         this.blocks = blocks;
     }
 
@@ -55,6 +65,137 @@ final class StackMapFrames {
      * @return The list of frames.
      */
     List<BytecodeFrame> frames() {
-        return Collections.emptyList();
+        Deque<Entry> worklist = new ArrayDeque<>(0);
+        // todo: parameters? static?
+        Entry initial = new Entry(0);
+        worklist.push(initial);
+        final int size = this.entries.size();
+        List<BytecodeFrame> res = new ArrayList<>(0);
+        Set<Integer> visited = new HashSet<>(0);
+
+        while (!worklist.isEmpty()) {
+            Entry current = worklist.pop();
+            if (visited.contains(current.indx)) {
+                continue;
+            }
+            for (int index = current.indx(); index < size; ++index) {
+                final BytecodeEntry entry = this.entries.get(index);
+                if (!(entry instanceof BytecodeInstruction)) {
+                    continue;
+                }
+                final BytecodeInstruction instr = (BytecodeInstruction) entry;
+                final Entry updated = current.append(index, instr);
+                if (instr.isIf()) {
+                    final Label label = instr.jumps().get(0);
+                    final int jump = this.index(label);
+                    final Entry next = updated.copy(jump);
+                    res.add(next.toFrame());
+                    visited.add(jump);
+                    worklist.push(next);
+                } else if (instr.isJump()) {
+                    final Label label = instr.jumps().get(0);
+                    final int jump = this.index(label);
+                    final Entry next = updated.copy(jump);
+                    res.add(next.toFrame());
+                    visited.add(jump);
+                    worklist.push(next);
+                    break;
+                } else if (instr.isReturn() || instr.isThrow()) {
+                    break;
+                }
+                current = updated;
+            }
+        }
+        return res;
+    }
+
+    /**
+     * Index of the label.
+     * @param label Label.
+     * @return Index.
+     */
+    private int index(final Label label) {
+        for (int index = 0; index < this.entries.size(); ++index) {
+            if (this.entries.get(index).equals(new BytecodeLabel(label))) {
+                return index;
+            }
+        }
+        throw new IllegalStateException(String.format("Label %s not found", label));
+    }
+
+
+    /**
+     * Entry in the worklist.
+     * @since 0.6
+     */
+    private static class Entry {
+        /**
+         * Bytecode instruction index.
+         */
+        private final int indx;
+
+        private final Map<Integer, Object> locals;
+
+        private final Map<Integer, Object> stack;
+
+        public Entry(final int indx) {
+            this(indx, new LinkedHashMap<>(0), new LinkedHashMap<>(0));
+        }
+
+        private Entry(
+            final int indx, final Map<Integer, Object> locals, final Map<Integer, Object> stack
+        ) {
+            this.indx = indx;
+            this.locals = locals;
+            this.stack = stack;
+        }
+
+        Entry copy(final int indx) {
+            return new Entry(
+                indx,
+                this.locals,
+                this.stack
+            );
+        }
+
+        int indx() {
+            return this.indx;
+        }
+
+        int nlocals() {
+            return this.locals.size();
+        }
+
+        int nstack() {
+            return this.stack.size();
+        }
+
+        Entry append(final int indx, final BytecodeInstruction instruction) {
+            if (instruction.isVarInstruction()) {
+                final LinkedHashMap<Integer, Object> copy = new LinkedHashMap<>(this.locals);
+                copy.put(instruction.localIndex(), instruction.localType());
+                return new Entry(
+                    indx,
+                    copy,
+                    this.stack
+                );
+            } else {
+                return new Entry(
+                    indx,
+                    this.locals,
+                    this.stack
+                );
+            }
+        }
+
+        BytecodeFrame toFrame() {
+            return new BytecodeFrame(
+                Opcodes.F_NEW,
+                this.nlocals(),
+                this.locals.values().toArray(),
+                this.nstack(),
+                this.stack.values().toArray()
+            );
+        }
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/StackMapFrames.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/StackMapFrames.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.bytecode;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This class knows how to compute the stack map frames from the bytecode entries.
+ * @since 0.6
+ */
+final class StackMapFrames {
+
+    /**
+     * The instructions.
+     */
+    private final List<BytecodeEntry> instructions;
+
+    /**
+     * The try-catch blocks.
+     */
+    private final List<BytecodeTryCatchBlock> blocks;
+
+    StackMapFrames(
+        final List<BytecodeEntry> entries,
+        final List<BytecodeTryCatchBlock> blocks
+    ) {
+        this.instructions = entries;
+        this.blocks = blocks;
+    }
+
+    /**
+     * Compute the frames.
+     * @return The list of frames.
+     */
+    List<BytecodeFrame> frames() {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/bytecode/StackMapFrames.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/StackMapFrames.java
@@ -194,7 +194,7 @@ final class StackMapFrames {
         for (final Entry entry : all) {
             final BytecodeFrame difference = this.difference(previous, entry);
             res.add(difference);
-            previous = difference;
+            previous = entry.toFrame();
         }
         return res;
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -26,6 +26,7 @@ package org.eolang.jeo.representation.bytecode;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
 import it.JavaSourceClass;
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.cactoos.bytes.BytesOf;
@@ -462,7 +463,7 @@ final class BytecodeMethodTest {
     }
 
     @ParameterizedTest(name = "Computing maxs for method {1}, expected  {2}")
-    @MethodSource("implementedMethods")
+    @MethodSource("implementedMaxs")
     void computesMaxsCorrectlyForImplementedMethods(
         final BytecodeMethod method,
         final String name,
@@ -479,7 +480,7 @@ final class BytecodeMethodTest {
     }
 
     @ParameterizedTest(name = "Computing maxs for method {1}, expected  {2}")
-    @MethodSource("abstractMethods")
+    @MethodSource("abstractMaxs")
     void computesMaxsCorrectlyForAbstractMethods(
         final BytecodeMethod method,
         final String name,
@@ -496,7 +497,7 @@ final class BytecodeMethodTest {
     }
 
     @ParameterizedTest(name = "Computing maxs for method {1}, expected  {2}")
-    @MethodSource("realMethods")
+    @MethodSource("realMaxs")
     void computesMaxForRealClassAfterAllTransformations(
         final BytecodeMethod method,
         final String name,
@@ -513,6 +514,33 @@ final class BytecodeMethodTest {
         );
     }
 
+    @ParameterizedTest
+    @MethodSource("implementedFrames")
+    void computesStackMapFramesForSomeMethods(
+        final BytecodeMethod method,
+        final String name,
+        final List<BytecodeFrame> expected
+    ) {
+        MatcherAssert.assertThat(
+            String.format(
+                "Stack map frames weren't computed correctly for method %s",
+                name
+            ),
+            method.computeFrames(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    /**
+     * Provides implemented methods for testing.
+     * These methods contain different stack map frames.
+     * Used in {@link #computesStackMapFramesForSomeMethods(BytecodeMethod, String, List)}.
+     * @return Stream of argumentsForTesting().
+     */
+    static Stream<Arguments> implementedFrames() {
+        return BytecodeMethodTest.methodFrames("maxs/Maxs.java");
+    }
+
     /**
      * Provides implemented methods for testing.
      * These methods contain different number of local variables and stack elements.
@@ -520,8 +548,8 @@ final class BytecodeMethodTest {
      * {@link #computesMaxsCorrectlyForImplementedMethods(BytecodeMethod, String, BytecodeMaxs)}.
      * @return Stream of arguments.
      */
-    static Stream<Arguments> implementedMethods() {
-        return BytecodeMethodTest.methods("maxs/Maxs.java");
+    static Stream<Arguments> implementedMaxs() {
+        return BytecodeMethodTest.methodMaxs("maxs/Maxs.java");
     }
 
     /**
@@ -531,8 +559,8 @@ final class BytecodeMethodTest {
      * {@link #computesMaxsCorrectlyForImplementedMethods(BytecodeMethod, String, BytecodeMaxs)}.
      * @return Stream of arguments.
      */
-    static Stream<Arguments> abstractMethods() {
-        return BytecodeMethodTest.methods("maxs/MaxInterface.java");
+    static Stream<Arguments> abstractMaxs() {
+        return BytecodeMethodTest.methodMaxs("maxs/MaxInterface.java");
     }
 
     /**
@@ -540,12 +568,12 @@ final class BytecodeMethodTest {
      * Before that, we disassemble and assemble the compiled class.
      * @return Stream of arguments.
      */
-    static Stream<Arguments> realMethods() {
+    static Stream<Arguments> realMaxs() {
         return Stream.of(
             "AbstractEndpoint.class",
             "FastHttpDateFormat.class",
             "ByteArrayClassLoader$ChildFirst$PrependingEnumeration.class"
-        ).flatMap(BytecodeMethodTest::disassembleAssemble);
+        ).flatMap(BytecodeMethodTest::realMaxs);
     }
 
     /**
@@ -555,7 +583,7 @@ final class BytecodeMethodTest {
      * @checkstyle IllegalCatchCheck (25 lines)
      */
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    static Stream<Arguments> disassembleAssemble(final String compiled) {
+    static Stream<Arguments> realMaxs(final String compiled) {
         try {
             return new XmlProgram(
                 new BytecodeRepresentation(
@@ -581,11 +609,24 @@ final class BytecodeMethodTest {
      * @param clazz Resource class name.
      * @return Stream of arguments.
      */
-    static Stream<Arguments> methods(final String clazz) {
+    static Stream<Arguments> methodMaxs(final String clazz) {
         return new AsmProgram(
             new JavaSourceClass(clazz).compile().bytes()
         ).bytecode().top().methods().stream().map(
             method -> Arguments.of(method, method.name(), method.currentMaxs())
+        );
+    }
+
+    /**
+     * Provides method frames for testing.
+     * @param clazz Resource class name.
+     * @return Stream of arguments.
+     */
+    static Stream<Arguments> methodFrames(final String clazz) {
+        return new AsmProgram(
+            new JavaSourceClass(clazz).compile().bytes()
+        ).bytecode().top().methods().stream().map(
+            method -> Arguments.of(method, method.name(), method.currentFrames())
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -523,8 +523,9 @@ final class BytecodeMethodTest {
     ) {
         MatcherAssert.assertThat(
             String.format(
-                "Stack map frames weren't computed correctly for method %s",
-                name
+                "Stack map frames weren't computed correctly for method '%s', with the following instructions: %n%s%n",
+                name,
+                method.instructionsView()
             ),
             method.computeFrames(),
             Matchers.equalTo(expected)

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -523,8 +523,10 @@ final class BytecodeMethodTest {
     ) {
         MatcherAssert.assertThat(
             String.format(
-                "Stack map frames weren't computed correctly for method '%s', with the following instructions: %n%s%n",
+                "Stack map frames weren't computed correctly for method '%s' with 'max_stack=%d' and 'max_locals=%d, with the following instructions: %n%s%n",
                 name,
+                method.currentMaxs().stack(),
+                method.currentMaxs().locals(),
                 method.instructionsView()
             ),
             method.computeFrames(),


### PR DESCRIPTION
In this PR we sucessfully compute stack map frames for the generated bytecode.

Closes: #750.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of stack map frames and exception types in the bytecode representation of the Eolang language. It introduces new methods for computing frames and improves the management of local variables and stack elements.

### Detailed summary
- Added `descriptor()` method in `BytecodeTryCatchBlock` to return the exception type.
- Introduced `computeFrames()` and `currentFrames()` methods in `BytecodeMethod` for frame computations.
- Enhanced `elementType()` method in `BytecodeInstruction` to determine local variable types.
- Updated `view()` method in `BytecodeFrame` to improve frame representation.
- Added methods in `BytecodeFrame` for stack and local variable comparisons.
- Created `StackMapFrames` class for computing stack map frames.
- Implemented test methods for verifying stack map frame calculations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->