### PR TITLE
feat(#833): feat(#833): Method Param Names Transformation

### DIFF
--- a/src/it/variable-names/README.md
+++ b/src/it/variable-names/README.md
@@ -1,0 +1,8 @@
+# Variable Names
+
+In this integration test, we verify that all the transformations preserve
+variable names. To run this test, execute the command below:
+
+```shell
+mvn clean integration-test invoker:run -Dinvoker.test=variable-names -DskipTests
+```

--- a/src/it/variable-names/README.md
+++ b/src/it/variable-names/README.md
@@ -4,5 +4,5 @@ In this integration test, we verify that all the transformations preserve
 variable names. To run this test, execute the command below:
 
 ```shell
-mvn clean integration-test invoker:run -Dinvoker.test=variable-names -DskipTests
+mvn clean integration-test -Dinvoker.test=variable-names -DskipTests
 ```

--- a/src/it/variable-names/invoker.properties
+++ b/src/it/variable-names/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean process-classes -e

--- a/src/it/variable-names/pom.xml
+++ b/src/it/variable-names/pom.xml
@@ -40,6 +40,16 @@ SOFTWARE.
   </properties>
   <build>
     <plugins>
+    <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>jeo-maven-plugin</artifactId>
@@ -59,6 +69,7 @@ SOFTWARE.
 <!--          </execution>-->
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/src/it/variable-names/pom.xml
+++ b/src/it/variable-names/pom.xml
@@ -45,18 +45,18 @@ SOFTWARE.
         <artifactId>jeo-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>
-          <execution>
-            <id>bytecode-to-eo</id>
-            <goals>
-              <goal>disassemble</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>eo-to-bytecode</id>
-            <goals>
-              <goal>assemble</goal>
-            </goals>
-          </execution>
+<!--          <execution>-->
+<!--            <id>bytecode-to-eo</id>-->
+<!--            <goals>-->
+<!--              <goal>disassemble</goal>-->
+<!--            </goals>-->
+<!--          </execution>-->
+<!--          <execution>-->
+<!--            <id>eo-to-bytecode</id>-->
+<!--            <goals>-->
+<!--              <goal>assemble</goal>-->
+<!--            </goals>-->
+<!--          </execution>-->
         </executions>
       </plugin>
       <plugin>

--- a/src/it/variable-names/pom.xml
+++ b/src/it/variable-names/pom.xml
@@ -40,36 +40,35 @@ SOFTWARE.
   </properties>
   <build>
     <plugins>
-    <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <compilerArgs>
-                        <arg>-parameters</arg>
-                    </compilerArgs>
-                </configuration>
-            </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>jeo-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>
-<!--          <execution>-->
-<!--            <id>bytecode-to-eo</id>-->
-<!--            <goals>-->
-<!--              <goal>disassemble</goal>-->
-<!--            </goals>-->
-<!--          </execution>-->
-<!--          <execution>-->
-<!--            <id>eo-to-bytecode</id>-->
-<!--            <goals>-->
-<!--              <goal>assemble</goal>-->
-<!--            </goals>-->
-<!--          </execution>-->
+          <execution>
+            <id>bytecode-to-eo</id>
+            <goals>
+              <goal>disassemble</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>eo-to-bytecode</id>
+            <goals>
+              <goal>assemble</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
-
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/src/it/variable-names/pom.xml
+++ b/src/it/variable-names/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License (MIT)
+
+Copyright (c) 2016-2024 Objectionary.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eolang</groupId>
+  <artifactId>jeo-it</artifactId>
+  <version>@project.version@</version>
+  <packaging>jar</packaging>
+  <description>
+    In this integration test, we verify that all the transformations preserve
+    variable names.
+  </description>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <stack-size>256M</stack-size>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>jeo-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>bytecode-to-eo</id>
+            <goals>
+              <goal>disassemble</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>eo-to-bytecode</id>
+            <goals>
+              <goal>assemble</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <phase>
+              process-classes
+            </phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>org.eolang.jeo.variables.Application</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/variable-names/src/main/java/org/eolang/jeo/variables/Application.java
+++ b/src/it/variable-names/src/main/java/org/eolang/jeo/variables/Application.java
@@ -54,6 +54,7 @@ public class Application {
             throw new Exception(
                 "Expected parameter 'secondParam' not found. All found methods: " + names);
         }
+        someMethod("firstParam", "secondParam");
     }
 
     public static void someMethod(final String firstParam, final String secondParam) {

--- a/src/it/variable-names/src/main/java/org/eolang/jeo/variables/Application.java
+++ b/src/it/variable-names/src/main/java/org/eolang/jeo/variables/Application.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.variables;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Set;
+import java.util.HashSet;
+
+/**
+ *  Application Entry Point.
+ * @since 0.1
+ */
+public class Application {
+    public static void main(String[] args) throws Exception {
+        Method someMethod = Application.class.getMethods()[1];
+        Set<String> names = new HashSet(0);
+        for (Parameter parameter : someMethod.getParameters()) {
+            names.add(parameter.getName());
+        }
+        if (names.size() != 2) {
+            throw new Exception(
+                "Expected 2 parameters, but got " + names.size() + " instead. All found methods: " + names);
+        }
+        if (!names.contains("firstParam")) {
+            throw new Exception(
+                "Expected parameter 'firstParam' not found. All found methods: " + names);
+        }
+        if (!names.contains("secondParam")) {
+            throw new Exception(
+                "Expected parameter 'secondParam' not found. All found methods: " + names);
+        }
+    }
+
+    public static void someMethod(final String firstParam, final String secondParam) {
+        System.out.println("First param: " + firstParam);
+        System.out.println("Second param: " + secondParam);
+    }
+
+}

--- a/src/it/variable-names/src/main/java/org/eolang/jeo/variables/Application.java
+++ b/src/it/variable-names/src/main/java/org/eolang/jeo/variables/Application.java
@@ -34,10 +34,13 @@ import java.util.HashSet;
  */
 public class Application {
     public static void main(String[] args) throws Exception {
-        Method someMethod = Application.class.getMethods()[1];
         Set<String> names = new HashSet(0);
-        for (Parameter parameter : someMethod.getParameters()) {
-            names.add(parameter.getName());
+        for (Method someMethod : Application.class.getMethods()) {
+            if (someMethod.getName().equals("someMethod")) {
+                for (Parameter parameter : someMethod.getParameters()) {
+                    names.add(parameter.getName());
+                }
+            }
         }
         if (names.size() != 2) {
             throw new Exception(

--- a/src/it/variable-names/verify.groovy
+++ b/src/it/variable-names/verify.groovy
@@ -1,0 +1,29 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+//Check logs first.
+String log = new File(basedir, 'build.log').text;
+assert log.contains("BUILD SUCCESS")
+assert log.contains("First param: firstParam")
+assert log.contains("Second param: secondParam")
+true

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
@@ -254,6 +254,7 @@ public final class AsmProgram {
                     AsmProgram.safe(invisible[index], false).collect(Collectors.toList())
                 );
             }
+//            node.parameters.get(index).name;
             params.add(
                 new BytecodeMethodParameter(
                     index,

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
@@ -254,16 +254,32 @@ public final class AsmProgram {
                     AsmProgram.safe(invisible[index], false).collect(Collectors.toList())
                 );
             }
-//            node.parameters.get(index).name;
             params.add(
                 new BytecodeMethodParameter(
                     index,
+                    AsmProgram.paramName(node, index),
                     types[index],
                     new BytecodeAnnotations(annotations)
                 )
             );
         }
         return new BytecodeMethodParameters(params);
+    }
+
+    /**
+     * Retrieve method parameter name from asm method.
+     * @param node Asm method node.
+     * @param index Parameter index.
+     * @return Parameter name.
+     */
+    private static String paramName(final MethodNode node, final int index) {
+        final String result;
+        if (node.parameters != null && node.parameters.size() > index) {
+            result = node.parameters.get(index).name;
+        } else {
+            result = String.format("arg%d", index);
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
@@ -258,12 +258,29 @@ public final class AsmProgram {
                 new BytecodeMethodParameter(
                     index,
                     AsmProgram.paramName(node, index),
+                    AsmProgram.paramAccess(node, index),
                     types[index],
                     new BytecodeAnnotations(annotations)
                 )
             );
         }
         return new BytecodeMethodParameters(params);
+    }
+
+    /**
+     * Retrieve method parameter access from asm method.
+     * @param node Asm method node.
+     * @param index Parameter index.
+     * @return Parameter access.
+     */
+    private static int paramAccess(final MethodNode node, final int index) {
+        final int result;
+        if (node.parameters != null && node.parameters.size() > index) {
+            result = node.parameters.get(index).access;
+        } else {
+            result = 0;
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameter.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameter.java
@@ -92,6 +92,7 @@ public final class BytecodeMethodParameter {
      * @param name Name of the parameter.
      * @param type Type of the parameter.
      * @param annotations Annotations of the parameter.
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     public BytecodeMethodParameter(
         final int index,
@@ -109,6 +110,7 @@ public final class BytecodeMethodParameter {
      * @param access Method parameter access.
      * @param type Type of the parameter.
      * @param annotations Annotations of the parameter.
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     public BytecodeMethodParameter(
         final int index,

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameter.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameter.java
@@ -49,6 +49,11 @@ public final class BytecodeMethodParameter {
     private final String name;
 
     /**
+     * Method parameter access.
+     */
+    private final int access;
+
+    /**
      * Type of the parameter.
      */
     private final Type type;
@@ -94,8 +99,27 @@ public final class BytecodeMethodParameter {
         final Type type,
         final BytecodeAnnotations annotations
     ) {
+        this(index, name, 0, type, annotations);
+    }
+
+    /**
+     * Constructor.
+     * @param index Index of the parameter.
+     * @param name Name of the parameter.
+     * @param access Method parameter access.
+     * @param type Type of the parameter.
+     * @param annotations Annotations of the parameter.
+     */
+    public BytecodeMethodParameter(
+        final int index,
+        final String name,
+        final int access,
+        final Type type,
+        final BytecodeAnnotations annotations
+    ) {
         this.index = index;
         this.name = name;
+        this.access = access;
         this.type = type;
         this.annotations = annotations;
     }
@@ -105,7 +129,7 @@ public final class BytecodeMethodParameter {
      * @param visitor Method visitor.
      */
     public void write(final MethodVisitor visitor) {
-        visitor.visitParameter(this.name, 0);
+        visitor.visitParameter(this.name, this.access);
         this.annotations.write(this.index, visitor);
     }
 
@@ -117,6 +141,7 @@ public final class BytecodeMethodParameter {
         return new DirectivesMethodParam(
             this.index,
             this.name,
+            this.access,
             this.type,
             this.annotations.directives(String.format("param-annotations-%d", this.index))
         );

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameter.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameter.java
@@ -44,6 +44,11 @@ public final class BytecodeMethodParameter {
     private final int index;
 
     /**
+     * Name of the parameter.
+     */
+    private final String name;
+
+    /**
      * Type of the parameter.
      */
     private final Type type;
@@ -73,7 +78,24 @@ public final class BytecodeMethodParameter {
         final Type type,
         final BytecodeAnnotations annotations
     ) {
+        this(index, String.format("arg%d", index), type, annotations);
+    }
+
+    /**
+     * Constructor.
+     * @param index Index of the parameter.
+     * @param name Name of the parameter.
+     * @param type Type of the parameter.
+     * @param annotations Annotations of the parameter.
+     */
+    public BytecodeMethodParameter(
+        final int index,
+        final String name,
+        final Type type,
+        final BytecodeAnnotations annotations
+    ) {
         this.index = index;
+        this.name = name;
         this.type = type;
         this.annotations = annotations;
     }
@@ -93,6 +115,7 @@ public final class BytecodeMethodParameter {
     public Iterable<Directive> directives() {
         return new DirectivesMethodParam(
             this.index,
+            this.name,
             this.type,
             this.annotations.directives(String.format("param-annotations-%d", this.index))
         );

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameter.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameter.java
@@ -105,6 +105,7 @@ public final class BytecodeMethodParameter {
      * @param visitor Method visitor.
      */
     public void write(final MethodVisitor visitor) {
+        visitor.visitParameter(this.name, 0);
         this.annotations.write(this.index, visitor);
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParam.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParam.java
@@ -51,6 +51,11 @@ public final class DirectivesMethodParam implements Iterable<Directive> {
     private final String name;
 
     /**
+     * Method parameter access modifier.
+     */
+    private final int access;
+
+    /**
      * Type of the parameter.
      */
     private final Type type;
@@ -69,11 +74,13 @@ public final class DirectivesMethodParam implements Iterable<Directive> {
     public DirectivesMethodParam(
         final int index,
         final String name,
+        final int access,
         final Type type,
         final DirectivesAnnotations annotations
     ) {
         this.index = index;
         this.name = name;
+        this.access = access;
         this.type = type;
         this.annotations = annotations;
     }
@@ -83,11 +90,12 @@ public final class DirectivesMethodParam implements Iterable<Directive> {
         return new DirectivesJeoObject(
             "param",
             String.format(
-                "param-%s-%s-%d",
+                "param-%s-%s-%d-%d",
                 DirectivesMethodParam.ENCODER.encodeToString(
                     this.type.toString().getBytes(StandardCharsets.UTF_8)
                 ),
                 this.name,
+                this.access,
                 this.index
             ),
             this.annotations

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParam.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParam.java
@@ -68,8 +68,11 @@ public final class DirectivesMethodParam implements Iterable<Directive> {
     /**
      * Constructor.
      * @param index Index of the parameter.
+     * @param name Name of the parameter.
+     * @param access Access modifier of the parameter.
      * @param type Type of the parameter.
      * @param annotations Annotations of the parameter.
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     public DirectivesMethodParam(
         final int index,

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParam.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParam.java
@@ -46,6 +46,11 @@ public final class DirectivesMethodParam implements Iterable<Directive> {
     private final int index;
 
     /**
+     * Name of the parameter.
+     */
+    private final String name;
+
+    /**
      * Type of the parameter.
      */
     private final Type type;
@@ -63,10 +68,12 @@ public final class DirectivesMethodParam implements Iterable<Directive> {
      */
     public DirectivesMethodParam(
         final int index,
+        final String name,
         final Type type,
         final DirectivesAnnotations annotations
     ) {
         this.index = index;
+        this.name = name;
         this.type = type;
         this.annotations = annotations;
     }
@@ -76,10 +83,11 @@ public final class DirectivesMethodParam implements Iterable<Directive> {
         return new DirectivesJeoObject(
             "param",
             String.format(
-                "param-%s-%d",
+                "param-%s-%s-%d",
                 DirectivesMethodParam.ENCODER.encodeToString(
                     this.type.toString().getBytes(StandardCharsets.UTF_8)
                 ),
+                this.name,
                 this.index
             ),
             this.annotations

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java
@@ -61,17 +61,20 @@ public final class XmlParam {
         return new BytecodeMethodParameter(
             this.index(),
             this.pure(),
+            this.access(),
             this.type(),
             this.annotations()
         );
     }
 
     /**
-     * Index of the parameter in the method.
-     * @return Index.
+     * Type of the parameter.
+     * @return Type.
      */
-    private int index() {
-        return Integer.parseInt(this.suffix(3));
+    private Type type() {
+        return Type.getType(
+            new String(XmlParam.DECODER.decode(this.suffix(1)), StandardCharsets.UTF_8)
+        );
     }
 
     /**
@@ -83,13 +86,19 @@ public final class XmlParam {
     }
 
     /**
-     * Type of the parameter.
-     * @return Type.
+     * Access modifier of the parameter.
+     * @return Access.
      */
-    private Type type() {
-        return Type.getType(
-            new String(XmlParam.DECODER.decode(this.suffix(1)), StandardCharsets.UTF_8)
-        );
+    private int access() {
+        return Integer.parseInt(this.suffix(3));
+    }
+
+    /**
+     * Index of the parameter in the method.
+     * @return Index.
+     */
+    private int index() {
+        return Integer.parseInt(this.suffix(4));
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java
@@ -60,6 +60,7 @@ public final class XmlParam {
     public BytecodeMethodParameter bytecode() {
         return new BytecodeMethodParameter(
             this.index(),
+            this.pure(),
             this.type(),
             this.annotations()
         );
@@ -70,7 +71,15 @@ public final class XmlParam {
      * @return Index.
      */
     private int index() {
-        return Integer.parseInt(this.suffix(2));
+        return Integer.parseInt(this.suffix(3));
+    }
+
+    /**
+     * Pure name of the parameter.
+     * @return Name.
+     */
+    private String pure() {
+        return this.suffix(2);
     }
 
     /**

--- a/src/test/java/it/JavaSourceCompilationIT.java
+++ b/src/test/java/it/JavaSourceCompilationIT.java
@@ -90,7 +90,7 @@ final class JavaSourceCompilationIT {
             System.err,
             "-g:none",
             "-source", "11",
-            "-target", "11",
+            "-parameters",
             src.toString()
         );
         return new Bytecode(

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
@@ -60,10 +60,12 @@ final class BytecodeMethodParameterTest {
     @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static Stream<Arguments> parameters() {
         return Stream.of(
-            Arguments.of(0, Type.INT_TYPE, "/o[contains(@base,'param') and @name='param-SQ==-0']"),
-            Arguments.of(1, Type.INT_TYPE, "/o[contains(@base,'param') and @name='param-SQ==-1']"),
             Arguments.of(
-                2, Type.DOUBLE_TYPE, "/o[contains(@base,'param') and @name='param-RA==-2']"
+                0, Type.INT_TYPE, "/o[contains(@base,'param') and @name='param-SQ==-arg0-0']"),
+            Arguments.of(
+                1, Type.INT_TYPE, "/o[contains(@base,'param') and @name='param-SQ==-arg1-1']"),
+            Arguments.of(
+                2, Type.DOUBLE_TYPE, "/o[contains(@base,'param') and @name='param-RA==-arg2-2']"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
@@ -61,11 +61,11 @@ final class BytecodeMethodParameterTest {
     private static Stream<Arguments> parameters() {
         return Stream.of(
             Arguments.of(
-                0, Type.INT_TYPE, "/o[contains(@base,'param') and @name='param-SQ==-arg0-0']"),
+                0, Type.INT_TYPE, "/o[contains(@base,'param') and @name='param-SQ==-arg0-0-0']"),
             Arguments.of(
-                1, Type.INT_TYPE, "/o[contains(@base,'param') and @name='param-SQ==-arg1-1']"),
+                1, Type.INT_TYPE, "/o[contains(@base,'param') and @name='param-SQ==-arg1-0-1']"),
             Arguments.of(
-                2, Type.DOUBLE_TYPE, "/o[contains(@base,'param') and @name='param-RA==-arg2-2']"
+                2, Type.DOUBLE_TYPE, "/o[contains(@base,'param') and @name='param-RA==-arg2-0-2']"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
@@ -61,9 +61,11 @@ final class BytecodeMethodParameterTest {
     private static Stream<Arguments> parameters() {
         return Stream.of(
             Arguments.of(
-                0, Type.INT_TYPE, "/o[contains(@base,'param') and @name='param-SQ==-arg0-0-0']"),
+                0, Type.INT_TYPE, "/o[contains(@base,'param') and @name='param-SQ==-arg0-0-0']"
+            ),
             Arguments.of(
-                1, Type.INT_TYPE, "/o[contains(@base,'param') and @name='param-SQ==-arg1-0-1']"),
+                1, Type.INT_TYPE, "/o[contains(@base,'param') and @name='param-SQ==-arg1-0-1']"
+            ),
             Arguments.of(
                 2, Type.DOUBLE_TYPE, "/o[contains(@base,'param') and @name='param-RA==-arg2-0-2']"
             )

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParametersTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParametersTest.java
@@ -53,5 +53,4 @@ final class BytecodeMethodParametersTest {
             )
         );
     }
-
 }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParametersTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParametersTest.java
@@ -48,8 +48,8 @@ final class BytecodeMethodParametersTest {
             ).xml(),
             XhtmlMatchers.hasXPaths(
                 "/o[contains(@base,'params')]",
-                "/o[contains(@base,'params')]/o[contains(@base,'param') and @name='param-SQ==-0']",
-                "/o[contains(@base,'params')]/o[contains(@base,'param') and @name='param-SQ==-1']"
+                "/o[contains(@base,'params')]/o[contains(@base,'param') and @name='param-SQ==-arg0-0']",
+                "/o[contains(@base,'params')]/o[contains(@base,'param') and @name='param-SQ==-arg1-1']"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParametersTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParametersTest.java
@@ -48,8 +48,8 @@ final class BytecodeMethodParametersTest {
             ).xml(),
             XhtmlMatchers.hasXPaths(
                 "/o[contains(@base,'params')]",
-                "/o[contains(@base,'params')]/o[contains(@base,'param') and @name='param-SQ==-arg0-0']",
-                "/o[contains(@base,'params')]/o[contains(@base,'param') and @name='param-SQ==-arg1-1']"
+                "/o[contains(@base,'params')]/o[contains(@base,'param') and @name='param-SQ==-arg0-0-0']",
+                "/o[contains(@base,'params')]/o[contains(@base,'param') and @name='param-SQ==-arg1-0-1']"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -146,8 +146,8 @@ final class BytecodeMethodTest {
             xml,
             new HasMethod(method)
                 .inside(clazz)
-                .withParameter("param-SQ==-0")
-                .withParameter("param-SQ==-1")
+                .withParameter("param-SQ==-arg0-0")
+                .withParameter("param-SQ==-arg1-1")
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -146,8 +146,8 @@ final class BytecodeMethodTest {
             xml,
             new HasMethod(method)
                 .inside(clazz)
-                .withParameter("param-SQ==-arg0-0")
-                .withParameter("param-SQ==-arg1-1")
+                .withParameter("param-SQ==-arg0-0-0")
+                .withParameter("param-SQ==-arg1-0-1")
         );
     }
 


### PR DESCRIPTION
In this PR I successfully added `name` and `access` fields to `BytecodeMethodParameter`. This means that we can transfom
parameter names into XMIR and back. However, in order to add param names to compiled classes one might need to add `-parameters` flag
to the `javac`.

Related to #833.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of method parameters in the codebase, particularly by introducing new functionality to preserve parameter names and access modifiers, improving the integration test for variable name transformations.

### Detailed summary
- Added `invoker.goals` in `invoker.properties`.
- Updated `JavaSourceCompilationIT.java` to include `-parameters` flag.
- Modified parameter handling in `BytecodeMethodTest.java` and `BytecodeMethodParametersTest.java` to use new naming conventions.
- Introduced `pure()` and `access()` methods in `XmlParam.java`.
- Enhanced `DirectivesMethodParam` to include parameter names and access modifiers.
- Implemented `paramAccess()` and `paramName()` methods in `AsmProgram.java` for retrieving parameter details.
- Added a new `Application` class to demonstrate parameter name retrieval.
- Updated `pom.xml` for integration test setup with necessary licenses and configurations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->