### PR TITLE
feat(#833): Preserve Method Local Variables

### DIFF
--- a/src/it/variable-names/README.md
+++ b/src/it/variable-names/README.md
@@ -4,5 +4,4 @@ In this integration test, we verify that all the transformations preserve
 variable names. To run this test, execute the command below:
 
 ```shell
-mvn clean integration-test -Dinvoker.test=variable-names -DskipTests
-```
+mvn clean integration-test -Dinvoker.test=variable-names -DskipTests```

--- a/src/it/variable-names/verify.groovy
+++ b/src/it/variable-names/verify.groovy
@@ -26,4 +26,21 @@ String log = new File(basedir, 'build.log').text;
 assert log.contains("BUILD SUCCESS")
 assert log.contains("First param: firstParam")
 assert log.contains("Second param: secondParam")
+// Verify that the generated class names contain attributes
+// Run `javap` on the compiled class file to inspect LocalVariableTable
+String clazz = new File(basedir, "target/classes/org/eolang/jeo/variables/Application").toString()
+println "Running javap on ${clazz}..."
+def javap = "javap -v ${clazz}".execute()
+javap.waitFor()
+if (javap.exitValue() != 0) {
+    println "javap failed:"
+    println javap.err.text
+    false
+}
+// Step 3: Capture and process the output of javap
+def output = javap.in.text
+println "javap output:\n$output"
+// Optional: Check for the presence of LocalVariableTable and parameter names
+assert output.contains('LocalVariableTable'): "LocalVariableTable is missing in ${clazz}"
+
 true

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
@@ -59,7 +59,6 @@ import org.eolang.jeo.representation.bytecode.BytecodeProgram;
 import org.eolang.jeo.representation.bytecode.BytecodeTryCatchBlock;
 import org.eolang.jeo.representation.bytecode.InnerClass;
 import org.eolang.jeo.representation.bytecode.LocalVariable;
-import org.objectweb.asm.Attribute;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
@@ -231,12 +230,15 @@ public final class AsmProgram {
      */
     private static BytecodeAttributes attributes(final MethodNode node) {
         final List<LocalVariableNode> variables = node.localVariables;
+        final BytecodeAttributes result;
         if (variables == null) {
-            return new BytecodeAttributes();
+            result = new BytecodeAttributes();
+        } else {
+            result = new BytecodeAttributes(
+                variables.stream().map(LocalVariable::new).toArray(BytecodeAttribute[]::new)
+            );
         }
-        return new BytecodeAttributes(
-            variables.stream().map(LocalVariable::new).toArray(BytecodeAttribute[]::new)
-        );
+        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
@@ -58,6 +58,7 @@ import org.eolang.jeo.representation.bytecode.BytecodePlainAnnotationValue;
 import org.eolang.jeo.representation.bytecode.BytecodeProgram;
 import org.eolang.jeo.representation.bytecode.BytecodeTryCatchBlock;
 import org.eolang.jeo.representation.bytecode.InnerClass;
+import org.eolang.jeo.representation.bytecode.LocalVariable;
 import org.objectweb.asm.Attribute;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Type;
@@ -230,14 +231,12 @@ public final class AsmProgram {
      */
     private static BytecodeAttributes attributes(final MethodNode node) {
         final List<LocalVariableNode> variables = node.localVariables;
-        if (node.attrs == null) {
+        if (variables == null) {
             return new BytecodeAttributes();
         }
-        for (final Attribute attr : node.attrs) {
-            final String type = attr.type;
-            System.out.println(type);
-        }
-        return new BytecodeAttributes();
+        return new BytecodeAttributes(
+            variables.stream().map(LocalVariable::new).toArray(BytecodeAttribute[]::new)
+        );
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
@@ -356,10 +356,12 @@ public final class AsmProgram {
      * @param node Asm class node.
      * @return Domain attributes.
      */
-    private static List<BytecodeAttribute> innerClasses(final ClassNode node) {
-        return node.innerClasses.stream()
-            .map(AsmProgram::innerClass)
-            .collect(Collectors.toList());
+    private static BytecodeAttributes innerClasses(final ClassNode node) {
+        return new BytecodeAttributes(
+            node.innerClasses.stream()
+                .map(AsmProgram::innerClass)
+                .collect(Collectors.toList())
+        );
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
@@ -38,6 +38,7 @@ import org.eolang.jeo.representation.bytecode.BytecodeAnnotationValue;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.eolang.jeo.representation.bytecode.BytecodeArrayAnnotationValue;
 import org.eolang.jeo.representation.bytecode.BytecodeAttribute;
+import org.eolang.jeo.representation.bytecode.BytecodeAttributes;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.eolang.jeo.representation.bytecode.BytecodeClassProperties;
 import org.eolang.jeo.representation.bytecode.BytecodeDefaultValue;
@@ -57,6 +58,7 @@ import org.eolang.jeo.representation.bytecode.BytecodePlainAnnotationValue;
 import org.eolang.jeo.representation.bytecode.BytecodeProgram;
 import org.eolang.jeo.representation.bytecode.BytecodeTryCatchBlock;
 import org.eolang.jeo.representation.bytecode.InnerClass;
+import org.objectweb.asm.Attribute;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AbstractInsnNode;
@@ -72,6 +74,7 @@ import org.objectweb.asm.tree.InvokeDynamicInsnNode;
 import org.objectweb.asm.tree.JumpInsnNode;
 import org.objectweb.asm.tree.LabelNode;
 import org.objectweb.asm.tree.LdcInsnNode;
+import org.objectweb.asm.tree.LocalVariableNode;
 import org.objectweb.asm.tree.LookupSwitchInsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
@@ -215,8 +218,26 @@ public final class AsmProgram {
                 node.exceptions.toArray(new String[0])
             ),
             AsmProgram.defvalues(node),
-            AsmProgram.maxs(node)
+            AsmProgram.maxs(node),
+            AsmProgram.attributes(node)
         );
+    }
+
+    /**
+     * Convert asm method to domain method attributes.
+     * @param node Asm method node.
+     * @return Domain method attributes.
+     */
+    private static BytecodeAttributes attributes(final MethodNode node) {
+        final List<LocalVariableNode> variables = node.localVariables;
+        if (node.attrs == null) {
+            return new BytecodeAttributes();
+        }
+        for (final Attribute attr : node.attrs) {
+            final String type = attr.type;
+            System.out.println(type);
+        }
+        return new BytecodeAttributes();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttribute.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.bytecode;
 
 import org.eolang.jeo.representation.directives.DirectivesAttribute;
 import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
 
 /**
  * Bytecode attribute.
@@ -33,10 +34,16 @@ import org.objectweb.asm.ClassVisitor;
 public interface BytecodeAttribute {
 
     /**
-     * Write to bytecode.
-     * @param bytecode Bytecode where to write.
+     * Write to class.
+     * @param clazz Bytecode where to write.
      */
-    void write(ClassVisitor bytecode);
+    void write(ClassVisitor clazz);
+
+    /**
+     * Write to method.
+     * @param method Bytecode where to write.
+     */
+    void write(MethodVisitor method);
 
     /**
      * Converts to directives.

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttributes.java
@@ -62,22 +62,6 @@ public final class BytecodeAttributes {
     }
 
     /**
-     * Write to class.
-     * @param clazz Bytecode where to write.
-     */
-    void write(ClassVisitor clazz) {
-        this.all.forEach(attr -> attr.write(clazz));
-    }
-
-    /**
-     * Write to method.
-     * @param method Bytecode where to write.
-     */
-    void write(MethodVisitor method) {
-        this.all.forEach(attr -> attr.write(method));
-    }
-
-    /**
      * Convert to directives.
      * @param name Name of the attributes in EO representation.
      * @return Directives.
@@ -87,5 +71,21 @@ public final class BytecodeAttributes {
             name,
             this.all.stream().map(BytecodeAttribute::directives).collect(Collectors.toList())
         );
+    }
+
+    /**
+     * Write to class.
+     * @param clazz Bytecode where to write.
+     */
+    void write(final ClassVisitor clazz) {
+        this.all.forEach(attr -> attr.write(clazz));
+    }
+
+    /**
+     * Write to method.
+     * @param method Bytecode where to write.
+     */
+    void write(final MethodVisitor method) {
+        this.all.forEach(attr -> attr.write(method));
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttributes.java
@@ -29,6 +29,8 @@ import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.directives.DirectivesAttributes;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
 
 /**
  * Bytecode attributes.
@@ -55,9 +57,26 @@ public final class BytecodeAttributes {
      * Constructor.
      * @param all All attributes.
      */
-    private BytecodeAttributes(final List<BytecodeAttribute> all) {
+    public BytecodeAttributes(final List<BytecodeAttribute> all) {
         this.all = all;
     }
+
+    /**
+     * Write to class.
+     * @param clazz Bytecode where to write.
+     */
+    void write(ClassVisitor clazz) {
+        this.all.forEach(attr -> attr.write(clazz));
+    }
+
+    /**
+     * Write to method.
+     * @param method Bytecode where to write.
+     */
+    void write(MethodVisitor method) {
+        this.all.forEach(attr -> attr.write(method));
+    }
+
 
     /**
      * Convert to directives.

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttributes.java
@@ -26,6 +26,8 @@ package org.eolang.jeo.representation.bytecode;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.eolang.jeo.representation.directives.DirectivesSeq;
 import org.xembly.Directive;
 
@@ -33,6 +35,8 @@ import org.xembly.Directive;
  * Bytecode attributes.
  * @since 0.6
  */
+@ToString
+@EqualsAndHashCode
 public final class BytecodeAttributes {
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttributes.java
@@ -28,8 +28,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.eolang.jeo.representation.directives.DirectivesSeq;
-import org.xembly.Directive;
+import org.eolang.jeo.representation.directives.DirectivesAttributes;
 
 /**
  * Bytecode attributes.
@@ -65,8 +64,8 @@ public final class BytecodeAttributes {
      * @param name Name of the attributes in EO representation.
      * @return Directives.
      */
-    public Iterable<Directive> directives(final String name) {
-        return new DirectivesSeq(
+    public DirectivesAttributes directives(final String name) {
+        return new DirectivesAttributes(
             name,
             this.all.stream().map(BytecodeAttribute::directives).collect(Collectors.toList())
         );

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttributes.java
@@ -77,7 +77,6 @@ public final class BytecodeAttributes {
         this.all.forEach(attr -> attr.write(method));
     }
 
-
     /**
      * Convert to directives.
      * @param name Name of the attributes in EO representation.

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -68,7 +68,7 @@ public final class BytecodeClass {
     /**
      * Attributes.
      */
-    private final List<BytecodeAttribute> attributes;
+    private final BytecodeAttributes attributes;
 
     /**
      * Class properties (access, signature, supername, interfaces).
@@ -133,7 +133,7 @@ public final class BytecodeClass {
             methods,
             new ArrayList<>(0),
             new BytecodeAnnotations(),
-            new ArrayList<>(0),
+            new BytecodeAttributes(),
             properties
         );
     }
@@ -153,7 +153,7 @@ public final class BytecodeClass {
         final List<BytecodeMethod> methods,
         final List<BytecodeField> fields,
         final BytecodeAnnotations annotations,
-        final List<BytecodeAttribute> attributes,
+        final BytecodeAttributes attributes,
         final BytecodeClassProperties props
     ) {
         this.name = name;
@@ -314,11 +314,7 @@ public final class BytecodeClass {
             this.cmethods.stream().map(method -> method.directives(counting))
                 .collect(Collectors.toList()),
             this.annotations.directives(),
-            new DirectivesAttributes(
-                this.attributes.stream()
-                    .map(BytecodeAttribute::directives)
-                    .collect(Collectors.toList())
-            )
+            this.attributes.directives("attributes")
         );
     }
 
@@ -340,7 +336,7 @@ public final class BytecodeClass {
             this.annotations.write(visitor);
             this.fields.forEach(field -> field.write(visitor));
             this.cmethods.forEach(method -> method.write(visitor));
-            this.attributes.forEach(attr -> attr.write(visitor));
+            this.attributes.write(visitor);
             visitor.visitEnd();
         } catch (final IllegalArgumentException exception) {
             throw new IllegalArgumentException(

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -31,7 +31,6 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.PrefixedName;
-import org.eolang.jeo.representation.directives.DirectivesAttributes;
 import org.eolang.jeo.representation.directives.DirectivesClass;
 import org.objectweb.asm.Opcodes;
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -319,6 +319,7 @@ public final class BytecodeMethod {
                 final BytecodeMaxs computed = this.computeMaxs();
                 mvisitor.visitMaxs(computed.stack(), computed.locals());
             }
+            this.attributes.write(mvisitor);
             mvisitor.visitEnd();
         } catch (final NegativeArraySizeException exception) {
             throw new IllegalStateException(

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -82,6 +82,11 @@ public final class BytecodeMethod {
     private final AllLabels labels;
 
     /**
+     * Bytecode method attributes.
+     */
+    private final BytecodeAttributes attributes;
+
+    /**
      * Constructor for tests.
      */
     public BytecodeMethod() {
@@ -107,7 +112,8 @@ public final class BytecodeMethod {
             new BytecodeAnnotations(),
             new BytecodeMethodProperties("foo", "()V", "", Opcodes.ACC_PUBLIC),
             new ArrayList<>(0),
-            new BytecodeMaxs(0, 0)
+            new BytecodeMaxs(0, 0),
+            new BytecodeAttributes()
         );
     }
 
@@ -123,7 +129,8 @@ public final class BytecodeMethod {
             annotations,
             new BytecodeMethodProperties(name, "()V", "", Opcodes.ACC_PUBLIC),
             new ArrayList<>(0),
-            new BytecodeMaxs(0, 0)
+            new BytecodeMaxs(0, 0),
+            new BytecodeAttributes()
         );
     }
 
@@ -171,7 +178,8 @@ public final class BytecodeMethod {
             new BytecodeAnnotations(),
             properties,
             new ArrayList<>(0),
-            maxs
+            maxs,
+            new BytecodeAttributes()
         );
     }
 
@@ -191,7 +199,8 @@ public final class BytecodeMethod {
         final BytecodeAnnotations annotations,
         final BytecodeMethodProperties properties,
         final List<BytecodeDefaultValue> defvalues,
-        final BytecodeMaxs maxs
+        final BytecodeMaxs maxs,
+        final BytecodeAttributes attributes
     ) {
         this.tryblocks = tryblocks;
         this.instructions = instructions;
@@ -199,6 +208,7 @@ public final class BytecodeMethod {
         this.properties = properties;
         this.defvalues = defvalues;
         this.maxs = maxs;
+        this.attributes = attributes;
         this.labels = new AllLabels();
     }
 
@@ -213,7 +223,8 @@ public final class BytecodeMethod {
             this.annotations,
             this.properties,
             this.defvalues,
-            new BytecodeMaxs()
+            new BytecodeMaxs(),
+            this.attributes
         );
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -191,6 +191,7 @@ public final class BytecodeMethod {
      * @param properties Method properties.
      * @param defvalues Default values.
      * @param maxs Max stack and locals.
+     * @param attributes Method attributes.
      * @checkstyle ParameterNumberCheck (10 lines)
      */
     public BytecodeMethod(

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -294,6 +294,7 @@ public final class BytecodeMethod {
             this.defvalues.stream()
                 .map(BytecodeDefaultValue::directives)
                 .collect(Collectors.toList()),
+            this.attributes.directives("local-variable-table"),
             counting
         );
     }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/InnerClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/InnerClass.java
@@ -28,6 +28,7 @@ import lombok.ToString;
 import org.eolang.jeo.representation.directives.DirectivesAttribute;
 import org.eolang.jeo.representation.directives.DirectivesValue;
 import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
 
 /**
  * Inner class attribute.
@@ -79,8 +80,18 @@ public final class InnerClass implements BytecodeAttribute {
     }
 
     @Override
-    public void write(final ClassVisitor bytecode) {
-        bytecode.visitInnerClass(this.name, this.outer, this.inner, this.access);
+    public void write(final ClassVisitor clazz) {
+        clazz.visitInnerClass(this.name, this.outer, this.inner, this.access);
+    }
+
+    @Override
+    public void write(final MethodVisitor method) {
+        throw new UnsupportedOperationException(
+            String.format(
+                "Inner class '%s' cannot be written to method attributes",
+                this
+            )
+        );
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/bytecode/LocalVariable.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/LocalVariable.java
@@ -1,0 +1,150 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.bytecode;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.eolang.jeo.representation.directives.DirectivesAttribute;
+import org.eolang.jeo.representation.directives.DirectivesLabel;
+import org.eolang.jeo.representation.directives.DirectivesValue;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.tree.LocalVariableNode;
+
+/**
+ * Local variable attribute.
+ * Represents `LocalVariableTable` entry from bytecode attributes.
+ * @since 0.6
+ */
+@ToString
+@EqualsAndHashCode
+public final class LocalVariable implements BytecodeAttribute {
+
+    /**
+     * Index of the local variable in the local variable array.
+     */
+    private final int index;
+
+    /**
+     * Name of the local variable.
+     */
+    private final String name;
+
+    /**
+     * Descriptor of the local variable.
+     */
+    private final String descriptor;
+
+    /**
+     * Signature of the local variable.
+     */
+    private final String signature;
+
+    /**
+     * Start label.
+     */
+    private final Label start;
+
+    /**
+     * End label.
+     */
+    private final Label end;
+
+    /**
+     * Constructor.
+     * @param variable Local variable node.
+     */
+    public LocalVariable(final LocalVariableNode variable) {
+        this(
+            variable.index,
+            variable.name,
+            variable.desc,
+            variable.signature,
+            variable.start.getLabel(),
+            variable.end.getLabel()
+        );
+    }
+
+    /**
+     * Constructor.
+     * @param index Index of the local variable in the local variable array.
+     * @param name Name of the local variable.
+     * @param descriptor Descriptor of the local variable.
+     * @param signature Signature of the local variable.
+     * @param start Start label.
+     * @param end End label.
+     * @checkstyle ParameterNumberCheck (10 lines)
+     */
+    public LocalVariable(
+        final int index,
+        final String name,
+        final String descriptor,
+        final String signature,
+        final Label start,
+        final Label end
+    ) {
+        this.index = index;
+        this.name = name;
+        this.descriptor = descriptor;
+        this.signature = signature;
+        this.start = start;
+        this.end = end;
+    }
+
+    @Override
+    public void write(final ClassVisitor clazz) {
+        throw new UnsupportedOperationException(
+            String.format(
+                "Local variable '%s' cannot be written to class attributes",
+                this
+            )
+        );
+    }
+
+    @Override
+    public void write(final MethodVisitor method) {
+        method.visitLocalVariable(
+            this.name,
+            this.descriptor,
+            this.signature,
+            this.start,
+            this.end,
+            this.index
+        );
+    }
+
+    @Override
+    public DirectivesAttribute directives() {
+        return new DirectivesAttribute(
+            "local-variable",
+            new DirectivesValue("", this.index),
+            new DirectivesValue("", this.name),
+            new DirectivesValue("", this.descriptor),
+            new DirectivesValue("", this.signature),
+            new DirectivesLabel(this.start),
+            new DirectivesLabel(this.end)
+        );
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
@@ -36,6 +36,11 @@ import org.xembly.Directive;
 public final class DirectivesAttributes implements Iterable<Directive> {
 
     /**
+     * Name.
+     */
+    private final String name;
+
+    /**
      * Attributes.
      */
     private final List<DirectivesAttribute> attributes;
@@ -45,6 +50,11 @@ public final class DirectivesAttributes implements Iterable<Directive> {
      * @param attributes Separate attributes.
      */
     public DirectivesAttributes(final List<DirectivesAttribute> attributes) {
+        this("attributes", attributes);
+    }
+
+    public DirectivesAttributes(final String name, final List<DirectivesAttribute> attributes) {
+        this.name = name;
         this.attributes = attributes;
     }
 
@@ -65,6 +75,6 @@ public final class DirectivesAttributes implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        return new DirectivesSeq("attributes", this.attributes).iterator();
+        return new DirectivesSeq(this.name, this.attributes).iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -190,7 +190,10 @@ public final class DirectivesMethod implements Iterable<Directive> {
                         this.exceptions
                     )
                 ),
-                this.dvalue.stream()
+                Stream.concat(
+                    this.dvalue.stream(),
+                    Stream.of(this.attributes)
+                )
             ).map(Directives::new).collect(Collectors.toList())
         ).iterator();
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -132,6 +132,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
      * @param exceptions Method exceptions
      * @param annotations Method annotations
      * @param dvalue Annotation default value
+     * @param attributes Method attributes
      * @param counting Opcodes counting
      * @checkstyle ParameterNumberCheck (10 lines)
      */

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -75,6 +75,11 @@ public final class DirectivesMethod implements Iterable<Directive> {
     private final List<Iterable<Directive>> dvalue;
 
     /**
+     * Method attributes.
+     */
+    private final DirectivesAttributes attributes;
+
+    /**
      * Opcodes counting.
      */
     private final boolean counting;
@@ -114,6 +119,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
             new ArrayList<>(0),
             new DirectivesAnnotations(),
             new ArrayList<>(0),
+            new DirectivesAttributes(),
             counting
         );
     }
@@ -136,6 +142,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
         final List<Iterable<Directive>> exceptions,
         final DirectivesAnnotations annotations,
         final List<Iterable<Directive>> dvalue,
+        final DirectivesAttributes attributes,
         final boolean counting
     ) {
         this.name = name;
@@ -144,6 +151,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
         this.exceptions = exceptions;
         this.annotations = annotations;
         this.dvalue = dvalue;
+        this.attributes = attributes;
         this.counting = counting;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
@@ -97,6 +97,8 @@ public final class XmlAttribute {
                     .map(Integer.class::cast)
                     .orElse(0)
             );
+        } else if (new JeoFqn("local-variable").fqn().equals(base)) {
+            return new XmlLocalVariable(this.node).attribute();
         } else {
             throw new IllegalArgumentException(
                 String.format("Unknown attribute base '%s'", base)

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
@@ -71,8 +71,9 @@ public final class XmlAttribute {
                     String.format("Attribute base is missing in XML node %s", this.node)
                 )
             );
+        final BytecodeAttribute result;
         if (new JeoFqn("inner-class").fqn().equals(base)) {
-            return new InnerClass(
+            result = new InnerClass(
                 Optional.ofNullable(this.node.children().collect(Collectors.toList()).get(0))
                     .map(XmlOperand::new)
                     .map(XmlOperand::asObject)
@@ -98,11 +99,12 @@ public final class XmlAttribute {
                     .orElse(0)
             );
         } else if (new JeoFqn("local-variable").fqn().equals(base)) {
-            return new XmlLocalVariable(this.node).attribute();
+            result = new XmlLocalVariable(this.node).attribute();
         } else {
             throw new IllegalArgumentException(
                 String.format("Unknown attribute base '%s'", base)
             );
         }
+        return result;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttributes.java
@@ -23,9 +23,7 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import java.util.List;
 import java.util.stream.Collectors;
-import org.eolang.jeo.representation.bytecode.BytecodeAttribute;
 import org.eolang.jeo.representation.bytecode.BytecodeAttributes;
 
 /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttributes.java
@@ -26,6 +26,7 @@ package org.eolang.jeo.representation.xmir;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.eolang.jeo.representation.bytecode.BytecodeAttribute;
+import org.eolang.jeo.representation.bytecode.BytecodeAttributes;
 
 /**
  * Xml representation of a class attributes.
@@ -50,10 +51,12 @@ public final class XmlAttributes {
      * Get attributes.
      * @return Attributes.
      */
-    public List<BytecodeAttribute> attributes() {
-        return this.node.children()
-            .map(XmlAttribute::new)
-            .map(XmlAttribute::attribute)
-            .collect(Collectors.toList());
+    public BytecodeAttributes attributes() {
+        return new BytecodeAttributes(
+            this.node.children()
+                .map(XmlAttribute::new)
+                .map(XmlAttribute::attribute)
+                .collect(Collectors.toList())
+        );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -24,7 +24,6 @@
 package org.eolang.jeo.representation.xmir;
 
 import com.jcabi.xml.XMLDocument;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -32,6 +32,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.PrefixedName;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
+import org.eolang.jeo.representation.bytecode.BytecodeAttributes;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.eolang.jeo.representation.directives.DirectivesClass;
 import org.eolang.jeo.representation.directives.DirectivesClassProperties;
@@ -107,7 +108,7 @@ public final class XmlClass {
                     .orElse(new BytecodeAnnotations()),
                 this.attributes()
                     .map(XmlAttributes::attributes)
-                    .orElse(new ArrayList<>(0)),
+                    .orElseGet(BytecodeAttributes::new),
                 this.properties().bytecode()
             );
         } catch (final IllegalStateException exception) {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLocalVariable.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLocalVariable.java
@@ -33,6 +33,7 @@ import org.objectweb.asm.Label;
  * Xml representation of a local variable.
  * @since 0.6
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class XmlLocalVariable {
 
     /**
@@ -63,42 +64,86 @@ public final class XmlLocalVariable {
         );
     }
 
+    /**
+     * Local variable index.
+     * @return Local variable index.
+     */
     private int index() {
         return this.integer(0);
     }
 
+    /**
+     * Name.
+     * @return Name.
+     */
     private String name() {
         return this.string(1);
     }
 
+    /**
+     * Descriptor.
+     * @return Descriptor.
+     */
     private String descriptor() {
         return this.string(2);
     }
 
+    /**
+     * Local variable signature.
+     * @return Signature.
+     */
     private String signature() {
         return this.string(3);
     }
 
+    /**
+     * Start label.
+     * @return Label.
+     */
     private Label start() {
         return this.label(4);
     }
 
+    /**
+     * End label.
+     * @return Label.
+     */
     private Label end() {
         return this.label(5);
     }
 
+    /**
+     * Get integer by index.
+     * @param index Index.
+     * @return Integer.
+     */
     private int integer(final int index) {
         return this.operand(index).map(Integer.class::cast).orElse(0);
     }
 
+    /**
+     * Get string by index.
+     * @param index Index.
+     * @return String.
+     */
     private String string(final int index) {
         return this.operand(index).map(String.class::cast).orElse(null);
     }
 
+    /**
+     * Get label by index.
+     * @param index Index.
+     * @return Label.
+     */
     private Label label(final int index) {
         return this.operand(index).map(Label.class::cast).orElse(null);
     }
 
+    /**
+     * Get operand by index.
+     * @param index Index.
+     * @return Optional operand.
+     */
     private Optional<Object> operand(final int index) {
         return Optional.ofNullable(this.node.children().collect(Collectors.toList()).get(index))
             .map(XmlOperand::new)

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLocalVariable.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLocalVariable.java
@@ -1,0 +1,107 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.xmir;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.eolang.jeo.representation.bytecode.BytecodeAttribute;
+import org.eolang.jeo.representation.bytecode.LocalVariable;
+import org.objectweb.asm.Label;
+
+/**
+ * Xml representation of a local variable.
+ * @since 0.6
+ */
+public final class XmlLocalVariable {
+
+    /**
+     * XML node of local variable.
+     */
+    private final XmlNode node;
+
+    /**
+     * Constructor.
+     * @param node XML node.
+     */
+    XmlLocalVariable(final XmlNode node) {
+        this.node = node;
+    }
+
+    /**
+     * Convert to domain attribute.
+     * @return Attribute.
+     */
+    public BytecodeAttribute attribute() {
+        return new LocalVariable(
+            this.index(),
+            this.name(),
+            this.descriptor(),
+            this.signature(),
+            this.start(),
+            this.end()
+        );
+    }
+
+    private int index() {
+        return this.integer(0);
+    }
+
+    private String name() {
+        return this.string(1);
+    }
+
+    private String descriptor() {
+        return this.string(2);
+    }
+
+    private String signature() {
+        return this.string(3);
+    }
+
+    private Label start() {
+        return this.label(4);
+    }
+
+    private Label end() {
+        return this.label(5);
+    }
+
+    private int integer(final int index) {
+        return this.operand(index).map(Integer.class::cast).orElse(0);
+    }
+
+    private String string(final int index) {
+        return this.operand(index).map(String.class::cast).orElse(null);
+    }
+
+    private Label label(final int index) {
+        return this.operand(index).map(Label.class::cast).orElse(null);
+    }
+
+    private Optional<Object> operand(final int index) {
+        return Optional.ofNullable(this.node.children().collect(Collectors.toList()).get(index))
+            .map(XmlOperand::new)
+            .map(XmlOperand::asObject);
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -160,6 +160,10 @@ public final class XmlMethod {
         }
     }
 
+    /**
+     * Method attributes.
+     * @return Attributes.
+     */
     private BytecodeAttributes attrs() {
         return this.node.children()
             .filter(element -> element.hasAttribute("name", "local-variable-table"))
@@ -167,9 +171,6 @@ public final class XmlMethod {
             .map(XmlAttributes::new)
             .map(XmlAttributes::attributes)
             .orElseGet(BytecodeAttributes::new);
-
-        //todo!
-//        return new BytecodeAttributes();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -33,6 +33,7 @@ import org.eolang.jeo.representation.MethodName;
 import org.eolang.jeo.representation.PrefixedName;
 import org.eolang.jeo.representation.Signature;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
+import org.eolang.jeo.representation.bytecode.BytecodeAttributes;
 import org.eolang.jeo.representation.bytecode.BytecodeMaxs;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodParameters;
@@ -129,7 +130,8 @@ public final class XmlMethod {
                     .map(Collections::singletonList)
                     .orElse(Collections.emptyList()),
                 this.maxs().map(XmlMaxs::bytecode)
-                    .orElse(new BytecodeMaxs(0, 0))
+                    .orElse(new BytecodeMaxs(0, 0)),
+                this.attrs()
             );
         } catch (final IllegalStateException exception) {
             throw new ParsingException(
@@ -156,6 +158,11 @@ public final class XmlMethod {
                 exception
             );
         }
+    }
+
+    private BytecodeAttributes attrs() {
+        //todo!
+        return new BytecodeAttributes();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -161,8 +161,15 @@ public final class XmlMethod {
     }
 
     private BytecodeAttributes attrs() {
+        return this.node.children()
+            .filter(element -> element.hasAttribute("name", "local-variable-table"))
+            .findFirst()
+            .map(XmlAttributes::new)
+            .map(XmlAttributes::attributes)
+            .orElseGet(BytecodeAttributes::new);
+
         //todo!
-        return new BytecodeAttributes();
+//        return new BytecodeAttributes();
     }
 
     /**
@@ -258,6 +265,11 @@ public final class XmlMethod {
         return new XmlValue(this.child(2)).string();
     }
 
+    /**
+     * Get child by index.
+     * @param index Index.
+     * @return Child.
+     */
     private XmlNode child(final int index) {
         return this.node.children().collect(Collectors.toList()).get(index);
     }

--- a/src/test/java/it/JavaSourceCompilationIT.java
+++ b/src/test/java/it/JavaSourceCompilationIT.java
@@ -24,6 +24,7 @@
 package it;
 
 import com.github.lombrozo.jsmith.RandomJavaClass;
+import com.jcabi.xml.XML;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;

--- a/src/test/java/it/JavaSourceCompilationIT.java
+++ b/src/test/java/it/JavaSourceCompilationIT.java
@@ -24,7 +24,6 @@
 package it;
 
 import com.github.lombrozo.jsmith.RandomJavaClass;
-import com.jcabi.xml.XML;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;

--- a/src/test/java/it/JavaSourceCompilationIT.java
+++ b/src/test/java/it/JavaSourceCompilationIT.java
@@ -88,7 +88,7 @@ final class JavaSourceCompilationIT {
             System.in,
             System.out,
             System.err,
-            "-g:none",
+            "-g:vars",
             "-source", "11",
             "-parameters",
             src.toString()

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlAttributesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlAttributesTest.java
@@ -39,17 +39,15 @@ final class XmlAttributesTest {
 
     @Test
     void convertsToBytecode() throws ImpossibleModificationException {
-        final InnerClass expected = new InnerClass("name", "outer", "inner", 0);
+        final BytecodeAttributes expected = new BytecodeAttributes(
+            new InnerClass("name", "outer", "inner", 0)
+        );
         MatcherAssert.assertThat(
             "We expect the attributes to be converted to a correct bytecode domain class",
             new XmlAttributes(
-                new XmlNode(
-                    new Xembler(
-                        new BytecodeAttributes(expected).directives("attributes")
-                    ).xml()
-                )
+                new XmlNode(new Xembler(expected.directives("attributes")).xml())
             ).attributes(),
-            Matchers.contains(expected)
+            Matchers.equalTo(expected)
         );
     }
 }


### PR DESCRIPTION
In this PR I implemented `LocalVariableTable` translation into XMIR and back to bytecode.

Related to #833.



<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the handling of bytecode attributes, particularly local variables, by introducing new classes and methods to better manage and represent these attributes in the code.

### Detailed summary
- Changed `-g:none` to `-g:vars` in compilation options.
- Updated `BytecodeAttribute` interface to include a method for writing to `MethodVisitor`.
- Introduced `XmlLocalVariable` for XML representation of local variables.
- Created `LocalVariable` class to represent `LocalVariableTable` entries.
- Modified `BytecodeAttributes` to manage collections of attributes.
- Refactored methods to utilize the new `BytecodeAttributes` class.
- Adjusted tests to verify proper handling of local variable attributes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->