### PR TITLE
feat(#834): Run 'unroll' In Parallel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,12 @@ SOFTWARE.
       <version>0.56.1</version>
     </dependency>
     <dependency>
+      <groupId>net.sf.saxon</groupId>
+      <artifactId>Saxon-HE</artifactId>
+      <version>12.5</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>4.0.0-alpha-7</version>

--- a/src/it/phi-unphi/src/main/java/org/eolang/hone/mess/A.java
+++ b/src/it/phi-unphi/src/main/java/org/eolang/hone/mess/A.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.hone.mess;
+
+/**
+ * This class was added to add more classes for phi/unphi and unroll tests.
+ * @since 0.6
+ */
+public class A {
+    public static void main(String[] args) {
+        System.out.println("Hello from A!");
+    }
+
+    public static void print() {
+        System.out.println("Hello from A!");
+    }
+
+    public static void print(String message) {
+        System.out.println(message);
+    }
+
+    public static void print(String message, String message2) {
+        System.out.println(message + " " + message2);
+    }
+}

--- a/src/it/phi-unphi/src/main/java/org/eolang/hone/mess/B.java
+++ b/src/it/phi-unphi/src/main/java/org/eolang/hone/mess/B.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.hone.mess;
+
+/**
+ * This class was added to add more classes for phi/unphi and unroll tests.
+ * @since 0.6
+ */
+public class B {
+    public static void main(String[] args) {
+        System.out.println("Hello from B!");
+    }
+
+    public static void print() {
+        System.out.println("Hello from B!");
+    }
+
+    public static void print(String message) {
+        System.out.println(message);
+    }
+
+    public static void print(String message, String message2) {
+        System.out.println(message + " " + message2);
+    }
+}

--- a/src/it/phi-unphi/src/main/java/org/eolang/hone/mess/C.java
+++ b/src/it/phi-unphi/src/main/java/org/eolang/hone/mess/C.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.hone.mess;
+
+/**
+ * This class was added to add more classes for phi/unphi and unroll tests.
+ * @since 0.6
+ */
+public class C {
+    public static void main(String[] args) {
+        System.out.println("Hello from C!");
+    }
+
+    public static void print() {
+        System.out.println("Hello from C!");
+    }
+
+    public static void print(String message) {
+        System.out.println(message);
+    }
+
+    public static void print(String message, String message2) {
+        System.out.println(message + " " + message2);
+    }
+}

--- a/src/it/phi-unphi/src/main/java/org/eolang/hone/mess/D.java
+++ b/src/it/phi-unphi/src/main/java/org/eolang/hone/mess/D.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.hone.mess;
+
+/**
+ * This class was added to add more classes for phi/unphi and unroll tests.
+ * @since 0.6
+ */
+public class D {
+    public static void main(String[] args) {
+        System.out.println("Hello from D!");
+    }
+
+    public static void print() {
+        System.out.println("Hello from D!");
+    }
+
+    public static void print(String message) {
+        System.out.println(message);
+    }
+
+    public static void print(String message, String message2) {
+        System.out.println(message + " " + message2);
+    }
+}

--- a/src/main/java/org/eolang/jeo/UnrollMojo.java
+++ b/src/main/java/org/eolang/jeo/UnrollMojo.java
@@ -65,7 +65,7 @@ public final class UnrollMojo extends AbstractMojo {
     @Override
     public void execute() {
         Logger.info(this, "Unrolling PHI/UNPHI transformations");
-        long start = System.currentTimeMillis();
+        final long start = System.currentTimeMillis();
         final long count = new Unroller(this.sourcesDir.toPath(), this.outputDir.toPath()).unroll();
         Logger.info(
             this,

--- a/src/main/java/org/eolang/jeo/UnrollMojo.java
+++ b/src/main/java/org/eolang/jeo/UnrollMojo.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo;
 
+import com.jcabi.log.Logger;
 import java.io.File;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -63,6 +64,14 @@ public final class UnrollMojo extends AbstractMojo {
 
     @Override
     public void execute() {
-        new Unroller(this.sourcesDir.toPath(), this.outputDir.toPath()).unroll();
+        Logger.info(this, "Unrolling PHI/UNPHI transformations");
+        long start = System.currentTimeMillis();
+        final long count = new Unroller(this.sourcesDir.toPath(), this.outputDir.toPath()).unroll();
+        Logger.info(
+            this,
+            "Total %d PHI/UNPHI transformations were unrolled in %[ms]s",
+            count,
+            System.currentTimeMillis() - start
+        );
     }
 }

--- a/src/main/java/org/eolang/jeo/UnrollMojo.java
+++ b/src/main/java/org/eolang/jeo/UnrollMojo.java
@@ -63,6 +63,7 @@ public final class UnrollMojo extends AbstractMojo {
     private File outputDir;
 
     @Override
+    @SuppressWarnings("PMD.GuardLogStatement")
     public void execute() {
         Logger.info(this, "Unrolling PHI/UNPHI transformations");
         final long start = System.currentTimeMillis();

--- a/src/main/java/org/eolang/jeo/Unroller.java
+++ b/src/main/java/org/eolang/jeo/Unroller.java
@@ -39,7 +39,7 @@ import org.eolang.jeo.representation.CanonicalXmir;
  * transformations.
  * @since 0.6
  */
-public final class Unroller {
+final class Unroller {
 
     /**
      * Source directory with XMIR files that were changed by `phi/unphi` transformations.
@@ -56,17 +56,18 @@ public final class Unroller {
      * @param source Directory with XMIR files that were changed by `phi/unphi` transformations.
      * @param target Target directory where unrolled XMIR files will be saved.
      */
-    public Unroller(final Path source, final Path target) {
+    Unroller(final Path source, final Path target) {
         this.source = source;
         this.target = target;
     }
 
     /**
      * Unrolls all the XMIR files from the source directory to the target directory.
+     * @return The number of unrolled XMIR files.
      */
-    public void unroll() {
+    long unroll() {
         try (Stream<Path> xmirs = Files.walk(this.source)) {
-            xmirs.filter(Unroller::isXmir).forEach(this::unroll);
+            return xmirs.filter(Unroller::isXmir).peek(this::unroll).count();
         } catch (final IOException exception) {
             throw new IllegalStateException(
                 String.format(

--- a/src/main/java/org/eolang/jeo/Unroller.java
+++ b/src/main/java/org/eolang/jeo/Unroller.java
@@ -30,8 +30,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.TransformerFactoryConfigurationError;
 import org.eolang.jeo.representation.CanonicalXmir;
 
 /**
@@ -129,6 +127,7 @@ final class Unroller {
      * Otherwise, the class loader won't be able to find `net.sf.saxon.TransformerFactoryImpl`.
      * This method is a workaround for the problem with class loading during the unrolling process.
      */
+    @SuppressWarnings("PMD.UseProperClassLoader")
     private void prepareThread() {
         System.setProperty(
             "javax.xml.transform.TransformerFactory",

--- a/src/main/resources/META-INF/services/javax.xml.transform.TransformerFactory
+++ b/src/main/resources/META-INF/services/javax.xml.transform.TransformerFactory
@@ -1,0 +1,1 @@
+net.sf.saxon.TransformerFactoryImpl


### PR DESCRIPTION
In this PR I made `UnrollMojo` work in parallel. It significantly speeds up the entire goal.
For example, for `phi-unphi` integration test we got the following results:

Before (sequentially): 10s, 9s, 8s
After (with parallelism): 4s, 5s, 4s

Related to #834.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `UnrollMojo` and `Unroller` classes to improve the handling of PHI/UNPHI transformations, including logging improvements and adding new test classes. It also introduces a new dependency on `Saxon-HE` for XML transformations.

### Detailed summary
- Added `net.sf.saxon.TransformerFactoryImpl` to the `META-INF/services/javax.xml.transform.TransformerFactory`.
- Introduced `Saxon-HE` dependency in `pom.xml`.
- Enhanced `UnrollMojo` with logging for transformation counts and execution time.
- Modified `Unroller`:
  - Changed constructor and method visibility from `public` to package-private.
  - Renamed `unroll()` method to return the count of unrolled files.
  - Added `prepareThread()` method for setting class loader properties.
- Created new classes `A`, `B`, `C`, and `D` in `src/it/phi-unphi/src/main/java/org/eolang/hone/mess` for testing purposes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->