### PR TITLE
feat(#849): Add Supplementary Comments For Instructions

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
@@ -103,14 +103,19 @@ public final class DirectivesInstruction implements Iterable<Directive> {
         return result;
     }
 
-
     /**
      * Instruction comment.
      * Later this message will be converted to the XML comment, like:
-     * <!-- INVOKESPECIAL 183, "java/lang/Object", "<init>", "()V", FALSE -->
+     * <!-- INVOKESPECIAL 183, "java/lang/Object", "<init>", "()V" -->
      * @return String comment.
      */
     private String comment() {
-        return "INVOKESPECIAL, 183, java/lang/Object, <init>, ()V, FALSE";
+        return String.format(
+            "#%d:%s(%s)",
+            this.opcode,
+            this.name(),
+            Arrays.stream(this.arguments).map(Object::toString)
+                .collect(Collectors.joining(", "))
+        );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
@@ -113,8 +113,9 @@ public final class DirectivesInstruction implements Iterable<Directive> {
         return String.format(
             "#%d:%s(%s)",
             this.opcode,
-            this.name(),
-            Arrays.stream(this.arguments).map(Object::toString)
+            new OpcodeName(this.opcode).simplified(),
+            Arrays.stream(this.arguments)
+                .map(Object::toString)
                 .collect(Collectors.joining(", "))
         );
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
@@ -80,7 +80,10 @@ public final class DirectivesInstruction implements Iterable<Directive> {
             "opcode",
             this.name(),
             Stream.concat(
-                Stream.of(new DirectivesOperand(this.opcode)),
+                Stream.of(
+                    new DirectivesComment(this.comment()),
+                    new DirectivesOperand(this.opcode)
+                ),
                 Arrays.stream(this.arguments).map(DirectivesOperand::new)
             ).map(Directives::new).collect(Collectors.toList())
         ).iterator();
@@ -98,5 +101,16 @@ public final class DirectivesInstruction implements Iterable<Directive> {
             result = new OpcodeName(this.opcode).simplified();
         }
         return result;
+    }
+
+
+    /**
+     * Instruction comment.
+     * Later this message will be converted to the XML comment, like:
+     * <!-- INVOKESPECIAL 183, "java/lang/Object", "<init>", "()V", FALSE -->
+     * @return String comment.
+     */
+    private String comment() {
+        return "INVOKESPECIAL, 183, java/lang/Object, <init>, ()V, FALSE";
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesInstructionTest.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.directives;
+
+import org.eolang.jeo.representation.bytecode.BytecodeInstruction;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link DirectivesInstruction}.
+ * @since 0.6
+ */
+final class DirectivesInstructionTest {
+
+    @Test
+    void addsBeautifulComment() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect, that during convertation to XML, we will get a beautiful comment for bytecode instruction",
+            new Xembler(
+                new BytecodeInstruction(
+                    Opcodes.INVOKESPECIAL,
+                    "java/lang/Object", "<init>", "()V"
+                ).directives(false)
+            ).xml(),
+            Matchers.containsString(
+                "<!--INVOKESPECIAL, 183, java/lang/Object, &lt;init&gt;, ()V, FALSE-->"
+            )
+        );
+    }
+
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesInstructionTest.java
@@ -23,12 +23,14 @@
  */
 package org.eolang.jeo.representation.directives;
 
+import java.util.stream.Stream;
 import org.eolang.jeo.representation.bytecode.BytecodeInstruction;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.objectweb.asm.Opcodes;
-import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
 /**
@@ -37,20 +39,57 @@ import org.xembly.Xembler;
  */
 final class DirectivesInstructionTest {
 
-    @Test
-    void addsBeautifulComment() throws ImpossibleModificationException {
+    @ParameterizedTest
+    @MethodSource("instructions")
+    void addsBeautifulComment(final BytecodeInstruction instr, final String comment) {
         MatcherAssert.assertThat(
             "We expect, that during convertation to XML, we will get a beautiful comment for bytecode instruction",
-            new Xembler(
-                new BytecodeInstruction(
-                    Opcodes.INVOKESPECIAL,
-                    "java/lang/Object", "<init>", "()V"
-                ).directives(false)
-            ).xml(),
-            Matchers.containsString(
-                "<!--INVOKESPECIAL, 183, java/lang/Object, &lt;init&gt;, ()V, FALSE-->"
-            )
+            new Xembler(instr.directives(false)).xmlQuietly(),
+            Matchers.containsString(comment)
         );
     }
 
+    /**
+     * Test cases.
+     * All generated cases are used in
+     * {@link DirectivesInstructionTest#addsBeautifulComment(BytecodeInstruction, String)}.
+     * @return Test cases.
+     */
+    static Stream<Arguments> instructions() {
+        return Stream.of(
+            Arguments.of(
+                new BytecodeInstruction(
+                    Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V"
+                ),
+                "<!--#183:invokespecial(java/lang/Object, &lt;init&gt;, ()V)-->"
+            ),
+            Arguments.of(
+                new BytecodeInstruction(
+                    Opcodes.INVOKEVIRTUAL, "java/lang/Object", "toString", "()Ljava/lang/String;"
+                ),
+                "<!--#182:invokevirtual(java/lang/Object, toString, ()Ljava/lang/String;)-->"
+            ),
+            Arguments.of(
+                new BytecodeInstruction(
+                    Opcodes.INVOKESTATIC, "java/lang/System", "currentTimeMillis", "()J"
+                ),
+                "<!--#184:invokestatic(java/lang/System, currentTimeMillis, ()J)-->"
+            ),
+            Arguments.of(
+                new BytecodeInstruction(
+                    Opcodes.INVOKEINTERFACE, "java/util/List", "size", "()I"
+                ),
+                "<!--#185:invokeinterface(java/util/List, size, ()I)-->"
+            ),
+            Arguments.of(
+                new BytecodeInstruction(
+                    Opcodes.INVOKEVIRTUAL, "java/lang/String", "length", "()I"
+                ),
+                "<!--#182:invokevirtual(java/lang/String, length, ()I)-->"
+            ),
+            Arguments.of(new BytecodeInstruction(Opcodes.RETURN), "<!--#177:return()-->"),
+            Arguments.of(new BytecodeInstruction(Opcodes.ARETURN), "<!--#176:areturn()-->"),
+            Arguments.of(new BytecodeInstruction(Opcodes.DUP), "<!--#89:dup()-->")
+        );
+    }
 }


### PR DESCRIPTION
In this PR I added comments for instructions in XMIR representation. 
What we used to have:
```xml
<o base="jeo.opcode" line="592032054" name="dup-277">
   <o base="jeo.int"><!--89-->
      <o base="org.eolang.bytes" data="bytes">00 00 00 00 00 00 00 59</o>
   </o>
</o>
```

What we will have when we merge this PR:
```xml
<o base="jeo.opcode" line="592032054" name="dup-277"><!--#89:dup()-->
   <o base="jeo.int"><!--89-->
      <o base="org.eolang.bytes" data="bytes">00 00 00 00 00 00 00 59</o>
   </o>
</o>
```

Related to #849.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `DirectivesInstruction` class by adding a new method to generate a comment based on the instruction's opcode and arguments. It also introduces a test case for verifying the comment generation during XML conversion.

### Detailed summary
- Added `comment()` method in `DirectivesInstruction` to format and return a comment string.
- Updated the stream in `DirectivesInstruction` to include a `DirectivesComment` object.
- Created `DirectivesInstructionTest` class with parameterized tests for various bytecode instructions.
- Implemented tests to ensure correct XML comment generation for bytecode instructions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->