### PR TITLE
feat(#849): add extra spaces for XMIR comments

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesComment.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesComment.java
@@ -92,7 +92,9 @@ public final class DirectivesComment implements Iterable<Directive> {
         if (this.comment.isEmpty()) {
             result = new Directives().iterator();
         } else {
-            result = new Directives().comment(this.escaped()).iterator();
+            result = new Directives().comment(
+                String.format(" %s ", this.escaped())
+            ).iterator();
         }
         return result;
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesCommentTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesCommentTest.java
@@ -43,7 +43,7 @@ final class DirectivesCommentTest {
             new Xembler(
                 new Directives().append(new DirectivesComment("Hello, world!"))
             ).xml(),
-            Matchers.containsString("<!--Hello, world!-->")
+            Matchers.containsString("<!-- Hello, world! -->")
         );
     }
 
@@ -54,7 +54,7 @@ final class DirectivesCommentTest {
             new Xembler(
                 new Directives().append(new DirectivesComment("Hello -- <world> ---!"))
             ).xml(),
-            Matchers.containsString("<!--Hello &#45;&#45; &lt;world&gt; &#45;&#45;&#45;!-->")
+            Matchers.containsString("<!-- Hello &#45;&#45; &lt;world&gt; &#45;&#45;&#45;! -->")
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesInstructionTest.java
@@ -61,35 +61,35 @@ final class DirectivesInstructionTest {
                 new BytecodeInstruction(
                     Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V"
                 ),
-                "<!--#183:invokespecial(java/lang/Object, &lt;init&gt;, ()V)-->"
+                "<!-- #183:invokespecial(java/lang/Object, &lt;init&gt;, ()V) -->"
             ),
             Arguments.of(
                 new BytecodeInstruction(
                     Opcodes.INVOKEVIRTUAL, "java/lang/Object", "toString", "()Ljava/lang/String;"
                 ),
-                "<!--#182:invokevirtual(java/lang/Object, toString, ()Ljava/lang/String;)-->"
+                "<!-- #182:invokevirtual(java/lang/Object, toString, ()Ljava/lang/String;) -->"
             ),
             Arguments.of(
                 new BytecodeInstruction(
                     Opcodes.INVOKESTATIC, "java/lang/System", "currentTimeMillis", "()J"
                 ),
-                "<!--#184:invokestatic(java/lang/System, currentTimeMillis, ()J)-->"
+                "<!-- #184:invokestatic(java/lang/System, currentTimeMillis, ()J) -->"
             ),
             Arguments.of(
                 new BytecodeInstruction(
                     Opcodes.INVOKEINTERFACE, "java/util/List", "size", "()I"
                 ),
-                "<!--#185:invokeinterface(java/util/List, size, ()I)-->"
+                "<!-- #185:invokeinterface(java/util/List, size, ()I) -->"
             ),
             Arguments.of(
                 new BytecodeInstruction(
                     Opcodes.INVOKEVIRTUAL, "java/lang/String", "length", "()I"
                 ),
-                "<!--#182:invokevirtual(java/lang/String, length, ()I)-->"
+                "<!-- #182:invokevirtual(java/lang/String, length, ()I) -->"
             ),
-            Arguments.of(new BytecodeInstruction(Opcodes.RETURN), "<!--#177:return()-->"),
-            Arguments.of(new BytecodeInstruction(Opcodes.ARETURN), "<!--#176:areturn()-->"),
-            Arguments.of(new BytecodeInstruction(Opcodes.DUP), "<!--#89:dup()-->")
+            Arguments.of(new BytecodeInstruction(Opcodes.RETURN), "<!-- #177:return() -->"),
+            Arguments.of(new BytecodeInstruction(Opcodes.ARETURN), "<!-- #176:areturn() -->"),
+            Arguments.of(new BytecodeInstruction(Opcodes.DUP), "<!-- #89:dup() -->")
         );
     }
 }


### PR DESCRIPTION
Add extra spaces to XMIR comments.
Was:
```xml
<!--177-->
```
Become:
```xml
<!-- 177 -->
```

Related to #849.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the formatting of comment strings in the `DirectivesComment` and related test files to ensure consistent spacing around comments.

### Detailed summary
- Updated the comment formatting in `DirectivesComment.java` to include spaces around the escaped string.
- Adjusted expected output in tests to reflect the new comment format with spaces in `DirectivesCommentTest.java`.
- Modified expected output in `DirectivesInstructionTest.java` to include spaces in various bytecode instruction comments.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->