### PR TITLE
feat(#546): POC with jcabi.xml in XmlNode#optchild(name)

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -33,7 +33,6 @@ import java.util.stream.Stream;
 import org.eolang.jeo.representation.directives.JeoFqn;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 /**
  * XML smart element.
@@ -260,12 +259,11 @@ public final class XmlNode {
      * Objects.
      * @return Stream of class objects.
      */
-    private Stream<Node> objects() {
-        final NodeList children = this.node.getChildNodes();
-        final List<Node> res = new ArrayList<>(children.getLength());
-        for (int index = 0; index < children.getLength(); ++index) {
-            final Node child = children.item(index);
-            if ("o".equals(child.getNodeName())) {
+    private Stream<XML> objects() {
+        final List<XML> nodes = new XMLDocument(this.node).nodes("node()");
+        final List<XML> res = new ArrayList<>(nodes.size());
+        for (final XML child : nodes) {
+            if ("o".equals(child.node().getNodeName())) {
                 res.add(child);
             }
         }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.util.ArrayList;
 import java.util.List;
@@ -53,6 +54,14 @@ public final class XmlNode {
      */
     public XmlNode(final String xml) {
         this(new XMLDocument(xml).node().getFirstChild());
+    }
+
+    /**
+     * Constructor.
+     * @param xml XML document
+     */
+    public XmlNode(final XML xml) {
+        this(xml.node());
     }
 
     /**
@@ -224,13 +233,10 @@ public final class XmlNode {
      */
     private Optional<XmlNode> optchild(final String name) {
         Optional<XmlNode> result = Optional.empty();
-        final NodeList children = this.node.getChildNodes();
-        for (int index = 0; index < children.getLength(); ++index) {
-            final Node current = children.item(index);
-            if (current.getNodeName().equals(name)) {
-                result = Optional.of(new XmlNode(current));
-                break;
-            }
+        final XML doc = new XMLDocument(this.node);
+        final List<XML> nodes = doc.nodes(name);
+        if (!nodes.isEmpty()) {
+            result = Optional.of(new XmlNode(nodes.get(0)));
         }
         return result;
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -233,8 +233,7 @@ public final class XmlNode {
      */
     private Optional<XmlNode> optchild(final String name) {
         Optional<XmlNode> result = Optional.empty();
-        final XML doc = new XMLDocument(this.node);
-        final List<XML> nodes = doc.nodes(name);
+        final List<XML> nodes = new XMLDocument(this.node).nodes(name);
         if (!nodes.isEmpty()) {
             result = Optional.of(new XmlNode(nodes.get(0)));
         }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -46,7 +46,7 @@ public final class XmlNode {
     /**
      * Parent node.
      */
-    private final Node node;
+    private final XML node;
 
     /**
      * Constructor.
@@ -58,17 +58,17 @@ public final class XmlNode {
 
     /**
      * Constructor.
-     * @param xml XML document
+     * @param parent XML document
      */
-    public XmlNode(final XML xml) {
-        this(xml.node());
+    public XmlNode(final Node parent) {
+        this(new XMLDocument(parent));
     }
 
     /**
      * Constructor.
      * @param parent Parent node.
      */
-    public XmlNode(final Node parent) {
+    public XmlNode(final XML parent) {
         this.node = parent;
     }
 
@@ -76,7 +76,7 @@ public final class XmlNode {
     public boolean equals(final Object obj) {
         final boolean res;
         if (obj instanceof XmlNode) {
-            res = new XMLDocument(this.node).equals(new XMLDocument(((XmlNode) obj).node));
+            res = this.node.equals(((XmlNode) obj).node);
         } else {
             res = false;
         }
@@ -90,7 +90,7 @@ public final class XmlNode {
 
     @Override
     public String toString() {
-        return new XMLDocument(this.node).toString();
+        return this.node.toString();
     }
 
     /**
@@ -106,7 +106,7 @@ public final class XmlNode {
      * @return Text content.
      */
     public String text() {
-        return this.node.getTextContent();
+        return this.node.node().getTextContent();
     }
 
     /**
@@ -116,7 +116,7 @@ public final class XmlNode {
      */
     public Optional<String> attribute(final String name) {
         final Optional<String> result;
-        final NamedNodeMap attrs = this.node.getAttributes();
+        final NamedNodeMap attrs = this.node.node().getAttributes();
         if (attrs == null) {
             result = Optional.empty();
         } else {
@@ -140,7 +140,7 @@ public final class XmlNode {
      * @return List of elements.
      */
     List<String> xpath(final String xpath) {
-        return new XMLDocument(this.node).xpath(xpath);
+        return this.node.xpath(xpath);
     }
 
     /**
@@ -182,7 +182,7 @@ public final class XmlNode {
                 () -> new IllegalStateException(
                     String.format(
                         "Can't find any child nodes in '%s'",
-                        new XMLDocument(this.node)
+                        this.node
                     )
                 )
             );
@@ -206,7 +206,7 @@ public final class XmlNode {
      * @return Class.
      */
     XmlClass toClass() {
-        return new XmlClass(this.node);
+        return new XmlClass(this.node.node());
     }
 
     /**
@@ -233,7 +233,7 @@ public final class XmlNode {
      */
     private Optional<XmlNode> optchild(final String name) {
         Optional<XmlNode> result = Optional.empty();
-        final List<XML> nodes = new XMLDocument(this.node).nodes(name);
+        final List<XML> nodes = new XMLDocument(this.node.node()).nodes(name);
         if (!nodes.isEmpty()) {
             result = Optional.of(new XmlNode(nodes.get(0)));
         }
@@ -250,7 +250,7 @@ public final class XmlNode {
             String.format(
                 "Can't find %s in '%s'",
                 name,
-                new XMLDocument(this.node)
+                this.node
             )
         );
     }
@@ -260,7 +260,7 @@ public final class XmlNode {
      * @return Stream of class objects.
      */
     private Stream<Node> objects() {
-        final NodeList children = this.node.getChildNodes();
+        final NodeList children = this.node.node().getChildNodes();
         final List<Node> res = new ArrayList<>(children.getLength());
         for (int index = 0; index < children.getLength(); ++index) {
             final Node child = children.item(index);

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -33,6 +33,7 @@ import java.util.stream.Stream;
 import org.eolang.jeo.representation.directives.JeoFqn;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
  * XML smart element.
@@ -259,11 +260,12 @@ public final class XmlNode {
      * Objects.
      * @return Stream of class objects.
      */
-    private Stream<XML> objects() {
-        final List<XML> nodes = new XMLDocument(this.node).nodes("node()");
-        final List<XML> res = new ArrayList<>(nodes.size());
-        for (final XML child : nodes) {
-            if ("o".equals(child.node().getNodeName())) {
+    private Stream<Node> objects() {
+        final NodeList children = this.node.getChildNodes();
+        final List<Node> res = new ArrayList<>(children.getLength());
+        for (int index = 0; index < children.getLength(); ++index) {
+            final Node child = children.item(index);
+            if ("o".equals(child.getNodeName())) {
                 res.add(child);
             }
         }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -233,7 +233,7 @@ public final class XmlNode {
      */
     private Optional<XmlNode> optchild(final String name) {
         Optional<XmlNode> result = Optional.empty();
-        final List<XML> nodes = new XMLDocument(this.node.node()).nodes(name);
+        final List<XML> nodes = this.node.nodes(name);
         if (!nodes.isEmpty()) {
             result = Optional.of(new XmlNode(nodes.get(0)));
         }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
@@ -23,9 +23,12 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.cactoos.list.ListOf;
 import org.eolang.jeo.representation.bytecode.BytecodeInstruction;
 import org.eolang.jeo.representation.bytecode.BytecodeLabel;
 import org.hamcrest.MatcherAssert;
@@ -108,6 +111,25 @@ final class XmlNodeTest {
             ),
             child,
             new IsEqual<>(new XmlNode(expected))
+        );
+    }
+
+    @Test
+    void retrievesChildObjects() {
+        final List<XmlNode> objects = new XmlNode(
+            "<program><o>o1</o><o>o2</o></program>"
+        ).children().collect(Collectors.toList());
+        final List<XmlNode> expected = new ListOf<>(
+            new XmlNode("<o>o1</o>"),
+            new XmlNode("<o>o2</o>")
+        );
+        MatcherAssert.assertThat(
+            String.format(
+            "Retrieved child objects: %s don't match with expected: %s",
+                objects,
+                expected
+            ),
+            objects, new IsEqual<>(expected)
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
@@ -127,7 +127,8 @@ final class XmlNodeTest {
                 objects,
                 expected
             ),
-            objects, new IsEqual<>(expected)
+            objects,
+            new IsEqual<>(expected)
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
@@ -30,6 +30,7 @@ import org.eolang.jeo.representation.bytecode.BytecodeInstruction;
 import org.eolang.jeo.representation.bytecode.BytecodeLabel;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 import org.xembly.ImpossibleModificationException;
@@ -90,6 +91,23 @@ final class XmlNodeTest {
             "Can't retrieve the text, or the text is not the expected one",
             new XmlNode("<o>text</o>").text(),
             Matchers.equalTo("text")
+        );
+    }
+
+    @Test
+    void retrievesChild() {
+        final XmlNode child = new XmlNode(
+            "<program><o>text</o></program>"
+        ).child("o");
+        final String expected = "<o>text</o>";
+        MatcherAssert.assertThat(
+            String.format(
+            "Retrieved XML: %s does not match with expected %s",
+                child,
+                expected
+            ),
+            child,
+            new IsEqual<>(new XmlNode(expected))
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
@@ -23,8 +23,6 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import com.jcabi.xml.XML;
-import com.jcabi.xml.XMLDocument;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
@@ -103,7 +103,7 @@ final class XmlNodeTest {
         final String expected = "<o>text</o>";
         MatcherAssert.assertThat(
             String.format(
-            "Retrieved XML: %s does not match with expected %s",
+                "Retrieved XML: %s does not match with expected %s",
                 child,
                 expected
             ),
@@ -123,7 +123,7 @@ final class XmlNodeTest {
         );
         MatcherAssert.assertThat(
             String.format(
-            "Retrieved child objects: %s don't match with expected: %s",
+                "Retrieved child objects: %s don't match with expected: %s",
                 objects,
                 expected
             ),


### PR DESCRIPTION
In this pull I've introduced small refactoring of `XmlNode#optchild(name)` method. Now method uses `jcabi.xml` as XML API, instead of `w3c.dom`.

ref #546
History:
- **feat(#546): retrieves child test**
- **feat(#546): opt child POC**
- **feat(#546): objects POC**
- **feat(#546): objects POC off**
- **feat(#546): clean for qulice**
- **feat(#546): redundant doc**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `XmlNode` class in the `org.eolang.jeo.representation.xmir` package by replacing the `Node` type with `XML`, improving child retrieval methods, and adding unit tests for XML node functionalities.

### Detailed summary
- Added unit tests in `XmlNodeTest` for retrieving child nodes and child objects.
- Changed `private final Node node;` to `private final XML node;` in `XmlNode`.
- Updated constructors in `XmlNode` to accept `XML` type.
- Revised methods to utilize `XML` functionalities instead of `Node`.
- Simplified equality and string representation methods in `XmlNode`.
- Modified child retrieval logic to use `XML` methods.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->