### PR TITLE
feat(#883): Add All The Required Aliases

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -255,6 +255,7 @@ public final class BytecodeClass {
             Opcodes.ACC_STATIC
         );
         return this.withMethod(properties)
+            .label()
             .opcode(Opcodes.GETSTATIC, "java/lang/System", "out", "Ljava/io/PrintStream;")
             .opcode(Opcodes.LDC, "Hello, world!")
             .opcode(
@@ -264,6 +265,7 @@ public final class BytecodeClass {
                 "(Ljava/lang/String;)V",
                 false
             )
+            .label()
             .opcode(Opcodes.RETURN)
             .up();
     }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.ClassName;
@@ -354,19 +355,14 @@ public final class BytecodeClass {
     }
 
     /**
-     * Whether the class has opcodes.
-     * @return True if it has opcodes, false otherwise.
+     * List of used objects.
+     * @return List of objects.
      */
-    boolean hasOpcodes() {
-        return this.cmethods.stream().anyMatch(BytecodeMethod::hasOpcodes);
-    }
-
-    /**
-     * Whether the class has labels.
-     * @return True if it has labels, false otherwise.
-     */
-    boolean hasLabels() {
-        return this.cmethods.stream().anyMatch(BytecodeMethod::hasLabels);
+    List<String> objects() {
+        return this.cmethods.stream()
+            .map(BytecodeMethod::objects)
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.ClassName;
@@ -354,17 +353,6 @@ public final class BytecodeClass {
                 exception
             );
         }
-    }
-
-    /**
-     * List of used objects.
-     * @return List of objects.
-     */
-    List<String> objects() {
-        return this.cmethods.stream()
-            .map(BytecodeMethod::objects)
-            .flatMap(List::stream)
-            .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -397,6 +397,14 @@ public final class BytecodeMethod {
     }
 
     /**
+     * All the Jeo objects used in the method.
+     * @return Jeo Objects.
+     */
+    public List<String> objects() {
+        return Collections.emptyList();
+    }
+
+    /**
      * Convert to directives with opcodes' counting.
      * @return Directives.
      */
@@ -441,9 +449,5 @@ public final class BytecodeMethod {
                 .map(BytecodeTryCatchBlock.class::cast)
                 .collect(Collectors.toList())
         ).value();
-    }
-
-    public List<String> objects() {
-        return Collections.emptyList();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.bytecode;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
@@ -440,5 +441,9 @@ public final class BytecodeMethod {
                 .map(BytecodeTryCatchBlock.class::cast)
                 .collect(Collectors.toList())
         ).value();
+    }
+
+    public List<String> objects() {
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation.bytecode;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
@@ -378,30 +377,6 @@ public final class BytecodeMethod {
      */
     BytecodeMethod opcode(final int opcode, final Object... args) {
         return this.entry(new BytecodeInstruction(opcode, args));
-    }
-
-    /**
-     * Whether the method has opcodes.
-     * @return True if method has opcodes.
-     */
-    boolean hasOpcodes() {
-        return this.instructions.stream().anyMatch(BytecodeEntry::isOpcode);
-    }
-
-    /**
-     * Whether the method has labels.
-     * @return True if method has labels.
-     */
-    boolean hasLabels() {
-        return this.instructions.stream().anyMatch(BytecodeEntry::isLabel);
-    }
-
-    /**
-     * All the Jeo objects used in the method.
-     * @return Jeo Objects.
-     */
-    public List<String> objects() {
-        return Collections.emptyList();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeProgram.java
@@ -143,11 +143,11 @@ public final class BytecodeProgram {
 
     /**
      * Convert to directives.
-     * @param code Program listing.
+     * @param listing Program listing.
      * @return Directives program.
      */
-    public DirectivesProgram directives(final String code) {
-        return this.directives(code, true);
+    public DirectivesProgram directives(final String listing) {
+        return this.directives(listing, true);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeProgram.java
@@ -164,8 +164,7 @@ public final class BytecodeProgram {
             top.directives(counting),
             new DirectivesMetas(
                 classname,
-                top.hasOpcodes(),
-                top.hasLabels()
+                top.objects()
             )
         );
     }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeProgram.java
@@ -33,6 +33,7 @@ import lombok.ToString;
 import org.eolang.jeo.representation.BytecodeRepresentation;
 import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.PrefixedName;
+import org.eolang.jeo.representation.directives.DirectivesClass;
 import org.eolang.jeo.representation.directives.DirectivesMetas;
 import org.eolang.jeo.representation.directives.DirectivesProgram;
 
@@ -159,12 +160,13 @@ public final class BytecodeProgram {
     public DirectivesProgram directives(final String code, final boolean counting) {
         final BytecodeClass top = this.top();
         final ClassName classname = new ClassName(this.pckg, new PrefixedName(top.name()).encode());
+        final DirectivesClass clazz = top.directives(counting);
         return new DirectivesProgram(
             code,
-            top.directives(counting),
+            clazz,
             new DirectivesMetas(
                 classname,
-                top.objects()
+                clazz
             )
         );
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -105,7 +105,6 @@ public final class DirectivesMetas implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        final String alias = "alias";
         final Directives metas = new Directives()
             .add("metas")
             .add("meta")
@@ -113,16 +112,10 @@ public final class DirectivesMetas implements Iterable<Directive> {
             .add("tail").set(this.pckg()).up()
             .add("part").set(this.pckg()).up()
             .up();
-        for (final String object : this.objects) {
-            metas.append(
-                new Directives()
-                    .add("meta")
-                    .add("head").set(alias).up()
-                    .add("tail").set(object).up()
-                    .add("part").set(object).up()
-                    .up()
-            );
-        }
+        this.objects.stream()
+            .filter(String::isEmpty)
+            .map(DirectivesMetas::alias)
+            .forEach(metas::append);
         return metas.up().iterator();
     }
 
@@ -141,5 +134,19 @@ public final class DirectivesMetas implements Iterable<Directive> {
             result = new PrefixedName(original).encode();
         }
         return result;
+    }
+
+    /**
+     * Alias directive for an object.
+     * @param object Some object name.
+     * @return Alias directive.
+     */
+    private static Directives alias(final String object) {
+        return new Directives()
+            .add("meta")
+            .add("head").set("alias").up()
+            .add("tail").set(object).up()
+            .add("part").set(object).up()
+            .up();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -49,7 +49,6 @@ public final class DirectivesMetas implements Iterable<Directive> {
      */
     private final DirectivesClass clazz;
 
-
     /**
      * Constructor.
      * @param classname Class name.
@@ -80,8 +79,8 @@ public final class DirectivesMetas implements Iterable<Directive> {
             .add("tail").set(this.pckg()).up()
             .add("part").set(this.pckg()).up()
             .up();
-        Set<String> objects = this.jeo();
-        objects.stream()
+        this.jeo()
+            .stream()
             .filter(object -> !object.isEmpty())
             .map(DirectivesMetas::alias)
             .forEach(metas::append);
@@ -116,6 +115,10 @@ public final class DirectivesMetas implements Iterable<Directive> {
     /**
      * Find all jeo objects.
      * @return Set of jeo objects.
+     * @todo #883:90min Optimize jeo.* Objects Collection for Metas.
+     *  Currently, we are required to pre-build a part of XML, find all the jeo objects
+     *  by using Xpath and then build the XML. This is not efficient.
+     *  We should find a way to collect all the jeo objects on the way.
      */
     private Set<String> jeo() {
         return new HashSet<>(

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -61,7 +61,7 @@ public final class DirectivesMetas implements Iterable<Directive> {
      * @param classname Class name.
      */
     public DirectivesMetas(final ClassName classname) {
-        this(classname, Collections.emptyList());
+        this(classname, new ArrayList<>(0));
     }
 
     /**
@@ -113,7 +113,7 @@ public final class DirectivesMetas implements Iterable<Directive> {
             .add("part").set(this.pckg()).up()
             .up();
         this.objects.stream()
-            .filter(String::isEmpty)
+            .filter(object -> !object.isEmpty())
             .map(DirectivesMetas::alias)
             .forEach(metas::append);
         return metas.up().iterator();

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -23,7 +23,10 @@
  */
 package org.eolang.jeo.representation.directives;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.PrefixedName;
@@ -42,14 +45,9 @@ public final class DirectivesMetas implements Iterable<Directive> {
     private final ClassName name;
 
     /**
-     * Whether to include "opcodes" import.
+     * Objects.
      */
-    private final AtomicBoolean opcodes;
-
-    /**
-     * Whether to include "labels" import.
-     */
-    private final AtomicBoolean labels;
+    private final List<String> objects;
 
     /**
      * Constructor.
@@ -63,23 +61,20 @@ public final class DirectivesMetas implements Iterable<Directive> {
      * @param classname Class name.
      */
     public DirectivesMetas(final ClassName classname) {
-        this(classname, false, false);
+        this(classname, Collections.emptyList());
     }
 
     /**
      * Constructor.
      * @param classname Class name.
-     * @param opcodes Whether to include opcodes.
-     * @param labels Whether to include labels.
+     * @param objects Objects used in all methods
      */
     public DirectivesMetas(
         final ClassName classname,
-        final boolean opcodes,
-        final boolean labels
+        final List<String> objects
     ) {
         this.name = classname;
-        this.opcodes = new AtomicBoolean(opcodes);
-        this.labels = new AtomicBoolean(labels);
+        this.objects = new ArrayList<>(objects);
     }
 
     /**
@@ -95,7 +90,7 @@ public final class DirectivesMetas implements Iterable<Directive> {
      * @return The same instance with opcodes.
      */
     public DirectivesMetas withOpcodes() {
-        this.opcodes.set(true);
+        this.objects.add("jeo.opcode");
         return this;
     }
 
@@ -104,42 +99,31 @@ public final class DirectivesMetas implements Iterable<Directive> {
      * @return The same instance with labels.
      */
     public DirectivesMetas withLabels() {
-        this.labels.set(true);
+        this.objects.add("jeo.label");
         return this;
     }
 
     @Override
     public Iterator<Directive> iterator() {
-        final String opcode = "jeo.opcode";
-        final String label = "jeo.label";
         final String alias = "alias";
-        final Directives opdirs = new Directives();
-        if (this.opcodes.get()) {
-            opdirs.add("meta")
-                .add("head").set(alias).up()
-                .add("tail").set(opcode).up()
-                .add("part").set(opcode).up()
-                .up();
-        }
-        final Directives labeldirs = new Directives();
-        if (this.labels.get()) {
-            labeldirs.add("meta")
-                .add("head").set(alias).up()
-                .add("tail").set(label).up()
-                .add("part").set(label).up()
-                .up();
-        }
-        return new Directives()
+        final Directives metas = new Directives()
             .add("metas")
             .add("meta")
             .add("head").set("package").up()
             .add("tail").set(this.pckg()).up()
             .add("part").set(this.pckg()).up()
-            .up()
-            .append(opdirs)
-            .append(labeldirs)
-            .up()
-            .iterator();
+            .up();
+        for (final String object : this.objects) {
+            metas.append(
+                new Directives()
+                    .add("meta")
+                    .add("head").set(alias).up()
+                    .add("tail").set(object).up()
+                    .add("part").set(object).up()
+                    .up()
+            );
+        }
+        return metas.up().iterator();
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
@@ -25,9 +25,12 @@ package org.eolang.jeo.representation.directives;
 
 import com.jcabi.matchers.XhtmlMatchers;
 import org.eolang.jeo.representation.ClassName;
+import org.eolang.jeo.representation.bytecode.BytecodeClass;
+import org.eolang.jeo.representation.bytecode.BytecodeProgram;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
 import org.xembly.Transformers;
 import org.xembly.Xembler;
 
@@ -80,6 +83,26 @@ final class DirectivesMetasTest {
             Matchers.allOf(
                 XhtmlMatchers.hasXPath("/metas/meta/tail[text()='jeo.label']"),
                 XhtmlMatchers.hasXPath("/metas/meta/part[text()='jeo.label']")
+            )
+        );
+    }
+
+    @Test
+    void addsAliasesForAllTheRequiredObjects() throws ImpossibleModificationException {
+        final DirectivesProgram directives = new BytecodeProgram(
+            new BytecodeClass().helloWorldMethod())
+            .directives("");
+        final String resulting = new Xembler(directives).xml();
+        System.out.println(resulting);
+        MatcherAssert.assertThat(
+            "Can't create corresponding xembly directives for all the required objects",
+            resulting,
+            Matchers.allOf(
+//                XhtmlMatchers.hasXPath("/program/metas/meta/head[text()='alias']"),
+//                XhtmlMatchers.hasXPath("/program/metas/meta/tail[text()='jeo.opcode']"),
+//                XhtmlMatchers.hasXPath("/program/metas/meta/part[text()='jeo.opcode']"),
+//                XhtmlMatchers.hasXPath("/program/metas/meta/tail[text()='jeo.label']"),
+//                XhtmlMatchers.hasXPath("/program/metas/meta/part[text()='jeo.label']")
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
@@ -89,20 +89,22 @@ final class DirectivesMetasTest {
 
     @Test
     void addsAliasesForAllTheRequiredObjects() throws ImpossibleModificationException {
-        final DirectivesProgram directives = new BytecodeProgram(
-            new BytecodeClass().helloWorldMethod())
-            .directives("");
-        final String resulting = new Xembler(directives).xml();
+        final String resulting = new Xembler(
+            new BytecodeProgram(new BytecodeClass().helloWorldMethod()).directives("")
+        ).xml();
         System.out.println(resulting);
         MatcherAssert.assertThat(
             "Can't create corresponding xembly directives for all the required objects",
             resulting,
             Matchers.allOf(
-//                XhtmlMatchers.hasXPath("/program/metas/meta/head[text()='alias']"),
-//                XhtmlMatchers.hasXPath("/program/metas/meta/tail[text()='jeo.opcode']"),
-//                XhtmlMatchers.hasXPath("/program/metas/meta/part[text()='jeo.opcode']"),
-//                XhtmlMatchers.hasXPath("/program/metas/meta/tail[text()='jeo.label']"),
-//                XhtmlMatchers.hasXPath("/program/metas/meta/part[text()='jeo.label']")
+                XhtmlMatchers.hasXPath("/program/metas/meta/head[text()='alias']"),
+                XhtmlMatchers.hasXPath("/program/metas/meta/tail[text()='jeo.opcode']"),
+                XhtmlMatchers.hasXPath("/program/metas/meta/tail[text()='jeo.label']"),
+                XhtmlMatchers.hasXPath("/program/metas/meta/part[text()='jeo.int']"),
+                XhtmlMatchers.hasXPath("/program/metas/meta/part[text()='jeo.string']"),
+                XhtmlMatchers.hasXPath("/program/metas/meta/part[text()='jeo.bool']"),
+                XhtmlMatchers.hasXPath("/program/metas/meta/part[text()='jeo.param']"),
+                XhtmlMatchers.hasXPath("/program/metas/meta/part[text()='jeo.params']")
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
@@ -57,45 +57,12 @@ final class DirectivesMetasTest {
     }
 
     @Test
-    void addsInitialAliasesForOpcodes() {
-        MatcherAssert.assertThat(
-            "Can't create corresponding xembly directives for opcode alias",
-            new Xembler(
-                new DirectivesMetas().withOpcodes(),
-                new Transformers.Node()
-            ).xmlQuietly(),
-            Matchers.allOf(
-                XhtmlMatchers.hasXPath("/metas/meta/head[text()='alias']"),
-                XhtmlMatchers.hasXPath("/metas/meta/tail[text()='jeo.opcode']"),
-                XhtmlMatchers.hasXPath("/metas/meta/part[text()='jeo.opcode']")
-            )
-        );
-    }
-
-    @Test
-    void addsInitalAliasesForLabels() {
-        MatcherAssert.assertThat(
-            "Can't create corresponding xembly directives for label alias",
-            new Xembler(
-                new DirectivesMetas().withLabels(),
-                new Transformers.Node()
-            ).xmlQuietly(),
-            Matchers.allOf(
-                XhtmlMatchers.hasXPath("/metas/meta/tail[text()='jeo.label']"),
-                XhtmlMatchers.hasXPath("/metas/meta/part[text()='jeo.label']")
-            )
-        );
-    }
-
-    @Test
     void addsAliasesForAllTheRequiredObjects() throws ImpossibleModificationException {
-        final String resulting = new Xembler(
-            new BytecodeProgram(new BytecodeClass().helloWorldMethod()).directives("")
-        ).xml();
-        System.out.println(resulting);
         MatcherAssert.assertThat(
             "Can't create corresponding xembly directives for all the required objects",
-            resulting,
+            new Xembler(
+                new BytecodeProgram(new BytecodeClass().helloWorldMethod()).directives("")
+            ).xml(),
             Matchers.allOf(
                 XhtmlMatchers.hasXPath("/program/metas/meta/head[text()='alias']"),
                 XhtmlMatchers.hasXPath("/program/metas/meta/tail[text()='jeo.opcode']"),


### PR DESCRIPTION
In this PR I added inefficient solution for adding all the required `alias` metas.
This solution uses `xpath` on the pre-build XML. It means that instead of generation XML once, we generate it 2 times,
which is rather suboptimal, of course. I left one more puzzle to optimize it in the future.

Related to #883.
