### PR TITLE
feat(#884): Skip Debug Labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ configuration to your `pom.xml` file:
 </build>
 ```
 
+### Include debug information
+
+In order to include debug information in the generated EO files, you can set
+`debug` option.
+
+```xml
+<configuration>
+  <mode>debug</mode>
+</configuration>
+```
+
+This option will add line numbers and local variable names to the EO files 
+together with their corresponding labels.
+
 ### Disable bytecode verification
 
 Each time the plugin converts EO back to bytecode, it verifies it. If the

--- a/src/it/spring/verify.groovy
+++ b/src/it/spring/verify.groovy
@@ -34,10 +34,8 @@ assert app.text.contains("metas")
 assert app.text.contains("<head>package</head>")
 // Check that we have "opcode" and "label" imports where they are needed
 assert app.text.contains("<tail>jeo.opcode</tail>")
-assert app.text.contains("<tail>jeo.label</tail>")
 //Check that if class doesn't have instructions, it doesn't have "opcode" imports.
 def empty = new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/spring/WithoutInstructions.xmir')
 assert empty.exists()
 assert !empty.text.contains("<tail>jeo.opcode</tail>")
-assert !empty.text.contains("<tail>jeo.label</tail>")
 true

--- a/src/it/variable-names/README.md
+++ b/src/it/variable-names/README.md
@@ -4,4 +4,5 @@ In this integration test, we verify that all the transformations preserve
 variable names. To run this test, execute the command below:
 
 ```shell
-mvn clean integration-test -Dinvoker.test=variable-names -DskipTests```
+mvn clean integration-test -Dinvoker.test=variable-names -DskipTests
+```

--- a/src/it/variable-names/pom.xml
+++ b/src/it/variable-names/pom.xml
@@ -54,6 +54,9 @@ SOFTWARE.
         <groupId>org.eolang</groupId>
         <artifactId>jeo-maven-plugin</artifactId>
         <version>@project.version@</version>
+        <configuration>
+        <mode>debug</mode>
+</configuration>
         <executions>
           <execution>
             <id>bytecode-to-eo</id>

--- a/src/it/variable-names/pom.xml
+++ b/src/it/variable-names/pom.xml
@@ -55,8 +55,8 @@ SOFTWARE.
         <artifactId>jeo-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>
-        <mode>debug</mode>
-</configuration>
+          <mode>debug</mode>
+        </configuration>
         <executions>
           <execution>
             <id>bytecode-to-eo</id>

--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -25,7 +25,6 @@ package org.eolang.jeo;
 
 import com.jcabi.log.Logger;
 import java.io.File;
-import jdk.jpackage.internal.Log;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;

--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -25,6 +25,7 @@ package org.eolang.jeo;
 
 import com.jcabi.log.Logger;
 import java.io.File;
+import jdk.jpackage.internal.Log;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -32,6 +33,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.eolang.jeo.representation.asm.DisassembleMode;
 
 /**
  * Converts bytecode to EO.
@@ -92,6 +94,22 @@ public final class DisassembleMojo extends AbstractMojo {
     )
     private boolean disabled;
 
+    /**
+     * Mode in which to disassemble the bytecode.
+     * Can be either 'plain' or 'debug':
+     * - 'short' mode will disassemble the bytecode without any additional information.
+     * - 'debug' mode will disassemble the bytecode with additional information like line numbers.
+     * Default is 'short'.
+     *
+     * @since 0.6
+     * @checkstyle MemberNameCheck (6 lines)
+     */
+    @Parameter(
+        property = "jeo.disassemble.mode",
+        defaultValue = "short"
+    )
+    private String mode;
+
     @Override
     public void execute() throws MojoExecutionException {
         try {
@@ -99,8 +117,11 @@ public final class DisassembleMojo extends AbstractMojo {
             if (this.disabled) {
                 Logger.info(this, "Disassemble mojo is disabled. Skipping.");
             } else {
+                Logger.info(this, "Disassembling is started with mode '%s'", this.mode);
                 new Disassembler(
-                    this.sourcesDir.toPath(), this.outputDir.toPath()
+                    this.sourcesDir.toPath(),
+                    this.outputDir.toPath(),
+                    DisassembleMode.fromString(this.mode)
                 ).disassemble();
             }
         } catch (final DependencyResolutionRequiredException exception) {

--- a/src/main/java/org/eolang/jeo/Disassembler.java
+++ b/src/main/java/org/eolang/jeo/Disassembler.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Stream;
+import org.eolang.jeo.representation.asm.DisassembleMode;
 
 /**
  * This class disassembles the project's compiled classes.
@@ -47,8 +48,12 @@ public class Disassembler {
     private final Path target;
 
     /**
+     * Disassemble mode.
+     */
+    private final DisassembleMode mode;
+
+    /**
      * Constructor.
-     *
      * @param classes Project compiled classes.
      * @param target Project default target directory.
      */
@@ -56,8 +61,23 @@ public class Disassembler {
         final Path classes,
         final Path target
     ) {
+        this(classes, target, DisassembleMode.SHORT);
+    }
+
+    /**
+     * Constructor.
+     * @param classes Project compiled classes.
+     * @param target Project default target directory.
+     * @param mode Disassemble mode.
+     */
+    public Disassembler(
+        final Path classes,
+        final Path target,
+        final DisassembleMode mode
+    ) {
         this.classes = classes;
         this.target = target;
+        this.mode = mode;
     }
 
     /**
@@ -87,7 +107,7 @@ public class Disassembler {
             "Disassembling",
             "disassembled",
             new Caching(
-                new Disassembling(this.target, path)
+                new Disassembling(this.target, path, this.mode)
             )
         );
         trans.transform();

--- a/src/main/java/org/eolang/jeo/Disassembling.java
+++ b/src/main/java/org/eolang/jeo/Disassembling.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import org.eolang.jeo.representation.BytecodeRepresentation;
 import org.eolang.jeo.representation.PrefixedName;
+import org.eolang.jeo.representation.asm.DisassembleMode;
 
 /**
  * Disassembling transformation.
@@ -46,13 +47,20 @@ public final class Disassembling implements Transformation {
     private final Path from;
 
     /**
+     * Disassemble mode.
+     */
+    private final DisassembleMode mode;
+
+    /**
      * Constructor.
      * @param target Target folder.
      * @param representation Representation to disassemble.
+     * @param mode Disassemble mode.
      */
-    Disassembling(final Path target, final Path representation) {
+    Disassembling(final Path target, final Path representation, final DisassembleMode mode) {
         this.folder = target;
         this.from = representation;
+        this.mode = mode;
     }
 
     @Override
@@ -75,7 +83,7 @@ public final class Disassembling implements Transformation {
     @Override
     public byte[] transform() {
         return new BytecodeRepresentation(this.from)
-            .toEO()
+            .toEO(true, this.mode)
             .toString()
             .getBytes(StandardCharsets.UTF_8);
     }

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -34,6 +34,7 @@ import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Synced;
 import org.cactoos.scalar.Unchecked;
 import org.eolang.jeo.representation.asm.AsmProgram;
+import org.eolang.jeo.representation.asm.DisassembleMode;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.directives.DirectivesProgram;
 import org.objectweb.asm.ClassReader;
@@ -103,7 +104,7 @@ public final class BytecodeRepresentation {
      * @return XML.
      */
     public XML toEO() {
-        return this.toEO(true);
+        return this.toEO(true, DisassembleMode.SHORT);
     }
 
     /**
@@ -112,8 +113,18 @@ public final class BytecodeRepresentation {
      * @return XML representation of bytecode.
      */
     public XML toEO(final boolean count) {
+        return this.toEO(count, DisassembleMode.SHORT);
+    }
+
+    /**
+     * Converts bytecode into XML.
+     * @param count Do we add number to opcode name or not?
+     * @param mode Disassemble mode.
+     * @return XML representation of bytecode.
+     */
+    public XML toEO(final boolean count, final DisassembleMode mode) {
         final DirectivesProgram directives = new AsmProgram(this.input.value())
-            .bytecode()
+            .bytecode(mode.asmOptions())
             .directives(new BytecodeListing(this.input.value()).toString(), count);
         try {
             return new VerifiedEo(directives).asXml();

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
@@ -58,8 +58,17 @@ public final class AsmProgram {
      * @return Bytecode.
      */
     public BytecodeProgram bytecode() {
+        return this.bytecode(ClassReader.SKIP_DEBUG);
+    }
+
+    /**
+     * Convert to bytecode.
+     * @param flags Flags.
+     * @return Bytecode.
+     */
+    public BytecodeProgram bytecode(final int flags) {
         final ClassNode node = new ClassNode();
-        new ClassReader(this.bytes).accept(node, ClassReader.SKIP_DEBUG);
+        new ClassReader(this.bytes).accept(node, flags);
         return new BytecodeProgram(
             new ClassName(node.name).pckg(),
             new AsmClass(node).bytecode()

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
@@ -59,7 +59,7 @@ public final class AsmProgram {
      */
     public BytecodeProgram bytecode() {
         final ClassNode node = new ClassNode();
-        new ClassReader(this.bytes).accept(node, 0);
+        new ClassReader(this.bytes).accept(node, ClassReader.SKIP_DEBUG);
         return new BytecodeProgram(
             new ClassName(node.name).pckg(),
             new AsmClass(node).bytecode()

--- a/src/main/java/org/eolang/jeo/representation/asm/DisassembleMode.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DisassembleMode.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation.asm;
+
+import org.objectweb.asm.ClassReader;
+
+/**
+ * Disassemble mode.
+ * @since 0.6
+ */
+public enum DisassembleMode {
+    /**
+     * Short mode.
+     * This mode will disassemble the bytecode without any additional information.
+     */
+    SHORT,
+    /**
+     * Assemble mode.
+     */
+    DEBUG;
+
+    /**
+     * Unknown mode message.
+     */
+    private static final String UNKNOWN = "Unknown disassemble mode: %s";
+
+    /**
+     * Convert from string.
+     * @param mode Mode.
+     * @return Disassemble mode.
+     */
+    public static DisassembleMode fromString(final String mode) {
+        switch (mode) {
+            case "short":
+                return DisassembleMode.SHORT;
+            case "debug":
+                return DisassembleMode.DEBUG;
+            default:
+                throw new IllegalArgumentException(String.format(DisassembleMode.UNKNOWN, mode));
+        }
+    }
+
+    /**
+     * Convert to ASM options.
+     * @return ASM options.
+     */
+    public int asmOptions() {
+        switch (this) {
+            case SHORT:
+                return ClassReader.SKIP_DEBUG;
+            case DEBUG:
+                return 0;
+            default:
+                throw new IllegalArgumentException(String.format(DisassembleMode.UNKNOWN, this));
+        }
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/asm/DisassembleMode.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DisassembleMode.java
@@ -28,6 +28,12 @@ import org.objectweb.asm.ClassReader;
 /**
  * Disassemble mode.
  * @since 0.6
+ * @todo #884:30min Refactor DisassembleMode Usage.
+ *  Actually, we have much more disassembling options, than mode.
+ *  Maybe it make sense to cobine them in this class.
+ *  For example, 'counting' option, that will count the number of instructions in the method.
+ *  So, let's refactor DisassembleMode to DisassembleOptions and add a new option 'counting'.
+ *  We also should simplify the code on our way.
  */
 public enum DisassembleMode {
     /**

--- a/src/main/java/org/eolang/jeo/representation/asm/DisassembleMode.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DisassembleMode.java
@@ -56,15 +56,20 @@ public enum DisassembleMode {
      * @param mode Mode.
      * @return Disassemble mode.
      */
+    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
     public static DisassembleMode fromString(final String mode) {
+        final DisassembleMode result;
         switch (mode) {
             case "short":
-                return DisassembleMode.SHORT;
+                result = DisassembleMode.SHORT;
+                break;
             case "debug":
-                return DisassembleMode.DEBUG;
+                result = DisassembleMode.DEBUG;
+                break;
             default:
                 throw new IllegalArgumentException(String.format(DisassembleMode.UNKNOWN, mode));
         }
+        return result;
     }
 
     /**
@@ -72,13 +77,17 @@ public enum DisassembleMode {
      * @return ASM options.
      */
     public int asmOptions() {
+        final int result;
         switch (this) {
             case SHORT:
-                return ClassReader.SKIP_DEBUG;
+                result = ClassReader.SKIP_DEBUG;
+                break;
             case DEBUG:
-                return 0;
+                result = 0;
+                break;
             default:
                 throw new IllegalArgumentException(String.format(DisassembleMode.UNKNOWN, this));
         }
+        return result;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -295,7 +295,7 @@ public final class BytecodeMethod {
     }
 
     /**
-     * Method instructions
+     * Method instructions.
      * @return Instructions.
      */
     public List<BytecodeEntry> intructions() {

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -25,6 +25,7 @@ package org.eolang.jeo.representation.bytecode;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
@@ -291,6 +292,14 @@ public final class BytecodeMethod {
             this.attributes.directives("local-variable-table"),
             counting
         );
+    }
+
+    /**
+     * Method instructions
+     * @return Instructions.
+     */
+    public List<BytecodeEntry> intructions() {
+        return Collections.unmodifiableList(this.instructions);
     }
 
     /**

--- a/src/test/java/it/JavaSourceCompilationIT.java
+++ b/src/test/java/it/JavaSourceCompilationIT.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import javax.tools.ToolProvider;
 import org.eolang.jeo.representation.BytecodeRepresentation;
 import org.eolang.jeo.representation.XmirRepresentation;
+import org.eolang.jeo.representation.asm.DisassembleMode;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -61,7 +62,7 @@ final class JavaSourceCompilationIT {
         MatcherAssert.assertThat(
             "Bytecode is not equal to the original one, check that transformation is correct and does not change the bytecode",
             new XmirRepresentation(
-                new BytecodeRepresentation(expected).toEO()
+                new BytecodeRepresentation(expected).toEO(true, DisassembleMode.DEBUG)
             ).toBytecode().toString(),
             Matchers.equalTo(expected.toString())
         );

--- a/src/test/java/org/eolang/jeo/representation/asm/AsmProgramTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/AsmProgramTest.java
@@ -23,10 +23,15 @@
  */
 package org.eolang.jeo.representation.asm;
 
+import java.util.List;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.io.ResourceOf;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
+import org.eolang.jeo.representation.bytecode.BytecodeEntry;
+import org.eolang.jeo.representation.bytecode.BytecodeLabel;
+import org.eolang.jeo.representation.bytecode.BytecodeLine;
+import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.eolang.jeo.representation.bytecode.BytecodeProgram;
 import org.eolang.jeo.representation.xmir.XmlProgram;
 import org.hamcrest.MatcherAssert;
@@ -52,6 +57,23 @@ final class AsmProgramTest {
             new AsmProgram(same.bytes()).bytecode().bytecode(),
             Matchers.equalTo(same)
         );
+    }
+
+    @Test
+    void skipsDebugLabels() throws Exception {
+        MatcherAssert.assertThat(
+            "We expect to skip debug labels and lines",
+            new AsmProgram(new BytesOf(new ResourceOf("MethodByte.class")).asBytes())
+                .bytecode()
+                .top()
+                .methods()
+                .get(1)
+                .intructions()
+                .stream()
+                .anyMatch(entry -> entry instanceof BytecodeLabel || entry instanceof BytecodeLine),
+            Matchers.is(false)
+        );
+
     }
 
     @Test

--- a/src/test/java/org/eolang/jeo/representation/asm/AsmProgramTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/AsmProgramTest.java
@@ -23,15 +23,12 @@
  */
 package org.eolang.jeo.representation.asm;
 
-import java.util.List;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.io.ResourceOf;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
-import org.eolang.jeo.representation.bytecode.BytecodeEntry;
 import org.eolang.jeo.representation.bytecode.BytecodeLabel;
 import org.eolang.jeo.representation.bytecode.BytecodeLine;
-import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.eolang.jeo.representation.bytecode.BytecodeProgram;
 import org.eolang.jeo.representation.xmir.XmlProgram;
 import org.hamcrest.MatcherAssert;
@@ -73,7 +70,6 @@ final class AsmProgramTest {
                 .anyMatch(entry -> entry instanceof BytecodeLabel || entry instanceof BytecodeLine),
             Matchers.is(false)
         );
-
     }
 
     @Test


### PR DESCRIPTION
In this PR I reduced the amount of labels generated by `disassemble` goal. We just exclude all the labels that are attached to line numbers.
Also, to allow this labels, I added the following option, that can be used to include line numbers and corresponding labels:

```xml
<configuration>
  <mode>debug</mode>
</configuration>
```

Related to #884.
