### PR TITLE
feat(#893): Remove 'counting' Option

### DIFF
--- a/src/main/java/org/eolang/jeo/Disassembling.java
+++ b/src/main/java/org/eolang/jeo/Disassembling.java
@@ -83,7 +83,7 @@ public final class Disassembling implements Transformation {
     @Override
     public byte[] transform() {
         return new BytecodeRepresentation(this.from)
-            .toEO(true, this.mode)
+            .toEO(this.mode)
             .toString()
             .getBytes(StandardCharsets.UTF_8);
     }

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -104,28 +104,18 @@ public final class BytecodeRepresentation {
      * @return XML.
      */
     public XML toEO() {
-        return this.toEO(true, DisassembleMode.SHORT);
+        return this.toEO(DisassembleMode.SHORT);
     }
 
     /**
      * Converts bytecode into XML.
-     * @param count Do we add number to opcode name or not?
-     * @return XML representation of bytecode.
-     */
-    public XML toEO(final boolean count) {
-        return this.toEO(count, DisassembleMode.SHORT);
-    }
-
-    /**
-     * Converts bytecode into XML.
-     * @param count Do we add number to opcode name or not?
      * @param mode Disassemble mode.
      * @return XML representation of bytecode.
      */
-    public XML toEO(final boolean count, final DisassembleMode mode) {
+    public XML toEO(final DisassembleMode mode) {
         final DirectivesProgram directives = new AsmProgram(this.input.value())
             .bytecode(mode.asmOptions())
-            .directives(new BytecodeListing(this.input.value()).toString(), count);
+            .directives(new BytecodeListing(this.input.value()).toString());
         try {
             return new VerifiedEo(directives).asXml();
         } catch (final IllegalStateException exception) {

--- a/src/main/java/org/eolang/jeo/representation/asm/DisassembleMode.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DisassembleMode.java
@@ -28,12 +28,6 @@ import org.objectweb.asm.ClassReader;
 /**
  * Disassemble mode.
  * @since 0.6
- * @todo #884:30min Refactor DisassembleMode Usage.
- *  Actually, we have much more disassembling options, than mode.
- *  Maybe it make sense to cobine them in this class.
- *  For example, 'counting' option, that will count the number of instructions in the method.
- *  So, let's refactor DisassembleMode to DisassembleOptions and add a new option 'counting'.
- *  We also should simplify the code on our way.
  */
 public enum DisassembleMode {
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -295,24 +295,15 @@ public final class BytecodeClass {
     }
 
     /**
-     * Convert to directives with opcodes' counting.
+     * Convert to directives.
      * @return Directives.
      */
     public DirectivesClass directives() {
-        return this.directives(true);
-    }
-
-    /**
-     * Convert to directives.
-     * @param counting Whether to count opcodes.
-     * @return Directives.
-     */
-    public DirectivesClass directives(final boolean counting) {
         return new DirectivesClass(
             new ClassName(new PrefixedName(this.name).encode()),
             this.props.directives(),
             this.fields.stream().map(BytecodeField::directives).collect(Collectors.toList()),
-            this.cmethods.stream().map(method -> method.directives(counting))
+            this.cmethods.stream().map(BytecodeMethod::directives)
                 .collect(Collectors.toList()),
             this.annotations.directives(),
             this.attributes.directives("attributes")

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeEntry.java
@@ -43,10 +43,9 @@ public interface BytecodeEntry {
 
     /**
      * Convert entry to directives.
-     * @param counting Do we need to add numbers to entry names?
      * @return Directives.
      */
-    Iterable<Directive> directives(boolean counting);
+    Iterable<Directive> directives();
 
     /**
      * Is this instruction a label?

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeFrame.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeFrame.java
@@ -120,7 +120,7 @@ public final class BytecodeFrame implements BytecodeEntry {
     }
 
     @Override
-    public Iterable<Directive> directives(final boolean counting) {
+    public Iterable<Directive> directives() {
         return new DirectivesFrame(
             this.type,
             this.nlocal,

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -104,8 +104,8 @@ public final class BytecodeInstruction implements BytecodeEntry {
     }
 
     @Override
-    public Iterable<Directive> directives(final boolean counting) {
-        return new DirectivesInstruction(this.opcode, counting, this.args.toArray());
+    public Iterable<Directive> directives() {
+        return new DirectivesInstruction(this.opcode, this.args.toArray());
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabel.java
@@ -80,7 +80,7 @@ public final class BytecodeLabel implements BytecodeEntry {
     }
 
     @Override
-    public Iterable<Directive> directives(final boolean counting) {
+    public Iterable<Directive> directives() {
         final Iterable<Directive> result;
         if (Objects.isNull(this.identifier)) {
             result = new DirectivesEoObject("nop");

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLine.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLine.java
@@ -47,7 +47,7 @@ public final class BytecodeLine implements BytecodeEntry {
     }
 
     @Override
-    public Iterable<Directive> directives(final boolean counting) {
+    public Iterable<Directive> directives() {
         return Collections.emptyList();
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -275,22 +275,23 @@ public final class BytecodeMethod {
      * @param counting Whether to count opcodes.
      * @return Directives.
      */
-    public DirectivesMethod directives(final boolean counting) {
+    public DirectivesMethod directives(boolean counting) {
+        final boolean count = true;
         return new DirectivesMethod(
             new Signature(
                 new MethodName(this.properties.name()).xmir(), this.properties.descriptor()
             ),
             this.properties.directives(this.maxs),
-            this.instructions.stream().map(entry -> entry.directives(counting))
+            this.instructions.stream().map(entry -> entry.directives(count))
                 .collect(Collectors.toList()),
-            this.tryblocks.stream().map(entry -> entry.directives(counting))
+            this.tryblocks.stream().map(entry -> entry.directives(count))
                 .collect(Collectors.toList()),
             this.annotations.directives(),
             this.defvalues.stream()
                 .map(BytecodeDefaultValue::directives)
                 .collect(Collectors.toList()),
             this.attributes.directives("local-variable-table"),
-            counting
+            count
         );
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -272,26 +272,23 @@ public final class BytecodeMethod {
 
     /**
      * Generate directives.
-     * @param counting Whether to count opcodes.
      * @return Directives.
      */
-    public DirectivesMethod directives(boolean counting) {
-        final boolean count = true;
+    public DirectivesMethod directives() {
         return new DirectivesMethod(
             new Signature(
                 new MethodName(this.properties.name()).xmir(), this.properties.descriptor()
             ),
             this.properties.directives(this.maxs),
-            this.instructions.stream().map(entry -> entry.directives(count))
+            this.instructions.stream().map(BytecodeEntry::directives)
                 .collect(Collectors.toList()),
-            this.tryblocks.stream().map(entry -> entry.directives(count))
+            this.tryblocks.stream().map(BytecodeEntry::directives)
                 .collect(Collectors.toList()),
             this.annotations.directives(),
             this.defvalues.stream()
                 .map(BytecodeDefaultValue::directives)
                 .collect(Collectors.toList()),
-            this.attributes.directives("local-variable-table"),
-            count
+            this.attributes.directives("local-variable-table")
         );
     }
 
@@ -387,14 +384,6 @@ public final class BytecodeMethod {
      */
     BytecodeMethod opcode(final int opcode, final Object... args) {
         return this.entry(new BytecodeInstruction(opcode, args));
-    }
-
-    /**
-     * Convert to directives with opcodes' counting.
-     * @return Directives.
-     */
-    DirectivesMethod directives() {
-        return this.directives(true);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeProgram.java
@@ -148,21 +148,11 @@ public final class BytecodeProgram {
      * @return Directives program.
      */
     public DirectivesProgram directives(final String listing) {
-        return this.directives(listing, true);
-    }
-
-    /**
-     * Convert to directives.
-     * @param code Program listing.
-     * @param counting Opcodes counting.
-     * @return Directives program.
-     */
-    public DirectivesProgram directives(final String code, final boolean counting) {
         final BytecodeClass top = this.top();
         final ClassName classname = new ClassName(this.pckg, new PrefixedName(top.name()).encode());
-        final DirectivesClass clazz = top.directives(counting);
+        final DirectivesClass clazz = top.directives();
         return new DirectivesProgram(
-            code,
+            listing,
             clazz,
             new DirectivesMetas(
                 classname,

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
@@ -119,7 +119,7 @@ public final class BytecodeTryCatchBlock implements BytecodeEntry {
     }
 
     @Override
-    public Iterable<Directive> directives(final boolean counting) {
+    public Iterable<Directive> directives() {
         return new DirectivesTryCatch(this.start, this.end, this.handler, this.type);
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/LocalVariable.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/LocalVariable.java
@@ -142,8 +142,8 @@ public final class LocalVariable implements BytecodeAttribute {
             new DirectivesValue("", this.name),
             new DirectivesValue("", this.descriptor),
             new DirectivesValue("", this.signature),
-            this.start.directives(false),
-            this.end.directives(false)
+            this.start.directives(),
+            this.end.directives()
         );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
@@ -49,28 +49,15 @@ public final class DirectivesInstruction implements Iterable<Directive> {
     private final Object[] arguments;
 
     /**
-     * Opcodes counting.
-     * Do we add number to opcode name or not?
-     * if true, then we add number to opcode name:
-     *   RETURN -> RETURN-1
-     * if false, then we do not add number to opcode name:
-     *   RETURN -> RETURN
-     */
-    private final boolean counting;
-
-    /**
      * Constructor.
      * @param opcode Opcode
-     * @param counting Opcodes counting
      * @param arguments Instruction arguments
      */
     public DirectivesInstruction(
         final int opcode,
-        final boolean counting,
         final Object... arguments
     ) {
         this.opcode = opcode;
-        this.counting = counting;
         this.arguments = arguments.clone();
     }
 
@@ -94,13 +81,7 @@ public final class DirectivesInstruction implements Iterable<Directive> {
      * @return Opcode name.
      */
     private String name() {
-        final String result;
-        if (this.counting) {
-            result = new OpcodeName(this.opcode).asString();
-        } else {
-            result = new OpcodeName(this.opcode).simplified();
-        }
-        return result;
+        return new OpcodeName(this.opcode).asString();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -80,11 +80,6 @@ public final class DirectivesMethod implements Iterable<Directive> {
     private final DirectivesAttributes attributes;
 
     /**
-     * Opcodes counting.
-     */
-    private final boolean counting;
-
-    /**
      * Constructor.
      * @param name Method name
      */
@@ -97,19 +92,8 @@ public final class DirectivesMethod implements Iterable<Directive> {
      * @param name Method name
      * @param properties Method properties
      */
-    public DirectivesMethod(final String name, final DirectivesMethodProperties properties) {
-        this(name, true, properties);
-    }
-
-    /**
-     * Constructor.
-     * @param name Method name
-     * @param counting Opcodes counting
-     * @param properties Method properties
-     */
     public DirectivesMethod(
         final String name,
-        final boolean counting,
         final DirectivesMethodProperties properties
     ) {
         this(
@@ -119,8 +103,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
             new ArrayList<>(0),
             new DirectivesAnnotations(),
             new ArrayList<>(0),
-            new DirectivesAttributes(),
-            counting
+            new DirectivesAttributes()
         );
     }
 
@@ -133,7 +116,6 @@ public final class DirectivesMethod implements Iterable<Directive> {
      * @param annotations Method annotations
      * @param dvalue Annotation default value
      * @param attributes Method attributes
-     * @param counting Opcodes counting
      * @checkstyle ParameterNumberCheck (10 lines)
      */
     public DirectivesMethod(
@@ -143,8 +125,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
         final List<Iterable<Directive>> exceptions,
         final DirectivesAnnotations annotations,
         final List<Iterable<Directive>> dvalue,
-        final DirectivesAttributes attributes,
-        final boolean counting
+        final DirectivesAttributes attributes
     ) {
         this.name = name;
         this.properties = properties;
@@ -153,7 +134,6 @@ public final class DirectivesMethod implements Iterable<Directive> {
         this.annotations = annotations;
         this.dvalue = dvalue;
         this.attributes = attributes;
-        this.counting = counting;
     }
 
     /**
@@ -163,7 +143,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
      * @return This object
      */
     public DirectivesMethod withOpcode(final int opcode, final Object... operands) {
-        this.instructions.add(new DirectivesInstruction(opcode, this.counting, operands));
+        this.instructions.add(new DirectivesInstruction(opcode, operands));
         return this;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesOperand.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesOperand.java
@@ -52,7 +52,7 @@ public final class DirectivesOperand implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         final Iterator<Directive> result;
         if (this.raw instanceof Label) {
-            result = new BytecodeLabel(this.raw.toString()).directives(false).iterator();
+            result = new BytecodeLabel(this.raw.toString()).directives().iterator();
         } else if (this.raw instanceof Handle) {
             result = new DirectivesHandle((Handle) this.raw).iterator();
         } else {

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesTryCatch.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesTryCatch.java
@@ -85,9 +85,9 @@ public final class DirectivesTryCatch implements Iterable<Directive> {
         return new DirectivesJeoObject(
             "trycatch",
             Stream.of(
-                this.start.directives(false),
-                this.end.directives(false),
-                this.handler.directives(false),
+                this.start.directives(),
+                this.end.directives(),
+                this.handler.directives(),
                 DirectivesTryCatch.nullable(this.type)
             ).map(Directives::new).collect(Collectors.toList())
         ).iterator();

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -52,20 +52,10 @@ public final class XmlInstruction implements XmlBytecodeEntry {
      * @param args Arguments.
      */
     XmlInstruction(final int opcode, final Object... args) {
-        this(true, opcode, args);
-    }
-
-    /**
-     * Constructor.
-     * @param counting Add numbers for instruction names in XML.
-     * @param opcode Opcode.
-     * @param args Arguments.
-     */
-    XmlInstruction(final boolean counting, final int opcode, final Object... args) {
         this(
             new XmlNode(
                 new Xembler(
-                    new DirectivesInstruction(opcode, counting, args),
+                    new DirectivesInstruction(opcode, args),
                     new Transformers.Node()
                 ).xmlQuietly()
             )

--- a/src/test/java/it/JavaSourceCompilationIT.java
+++ b/src/test/java/it/JavaSourceCompilationIT.java
@@ -62,7 +62,7 @@ final class JavaSourceCompilationIT {
         MatcherAssert.assertThat(
             "Bytecode is not equal to the original one, check that transformation is correct and does not change the bytecode",
             new XmirRepresentation(
-                new BytecodeRepresentation(expected).toEO(true, DisassembleMode.DEBUG)
+                new BytecodeRepresentation(expected).toEO(DisassembleMode.DEBUG)
             ).toBytecode().toString(),
             Matchers.equalTo(expected.toString())
         );

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -138,10 +138,10 @@ final class BytecodeClassTest {
             ),
             xmir.toString(),
             XhtmlMatchers.hasXPaths(
-                "//o[@base='jeo.opcode' and @name='getstatic']",
-                "//o[@base='jeo.opcode' and @name='ldc']",
-                "//o[@base='jeo.opcode' and @name='invokevirtual']",
-                "//o[@base='jeo.opcode' and @name='return']"
+                "//o[@base='jeo.opcode' and contains(@name,'getstatic')]",
+                "//o[@base='jeo.opcode' and contains(@name,'ldc')]",
+                "//o[@base='jeo.opcode' and contains(@name,'invokevirtual')]",
+                "//o[@base='jeo.opcode' and contains(@name,'return')]"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -130,7 +130,7 @@ final class BytecodeClassTest {
             new BytecodeProgram(
                 new BytecodeClass("Hello").helloWorldMethod()
             ).bytecode()
-        ).toEO(false);
+        ).toEO();
         MatcherAssert.assertThat(
             String.format(
                 "We expect to get the EO representation of the bytecode where each instruction has a simple name without sequence number, please check the final XML:%n%s%n",

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesInstructionTest.java
@@ -44,7 +44,7 @@ final class DirectivesInstructionTest {
     void addsBeautifulComment(final BytecodeInstruction instr, final String comment) {
         MatcherAssert.assertThat(
             "We expect, that during convertation to XML, we will get a beautiful comment for bytecode instruction",
-            new Xembler(instr.directives(false)).xmlQuietly(),
+            new Xembler(instr.directives()).xmlQuietly(),
             Matchers.containsString(comment)
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -100,7 +100,7 @@ final class DirectivesMethodTest {
     void addsPrefixToTheMethodName() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "We expect that 'j$' prefix will be added to the method name",
-            new Xembler(new BytecodeMethod("φTerm").directives(false)).xml(),
+            new Xembler(new BytecodeMethod("φTerm").directives()).xml(),
             XhtmlMatchers.hasXPaths("./o[contains(@name, 'j$φTerm')]")
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlFrameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlFrameTest.java
@@ -49,7 +49,7 @@ final class XmlFrameTest {
         );
         MatcherAssert.assertThat(
             "Parsed frame type is not correct.",
-            new XmlFrame(new Xembler(expected.directives(false)).xml()).bytecode(),
+            new XmlFrame(new Xembler(expected.directives()).xml()).bytecode(),
             Matchers.equalTo(expected)
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
@@ -38,7 +38,7 @@ final class XmlInstructionTest {
     /**
      * Default instruction which we use for testing.
      */
-    private static final BytecodeInstruction INST = new BytecodeInstruction(
+    private static final BytecodeInstruction EXPECTED = new BytecodeInstruction(
         Opcodes.INVOKESPECIAL, 1, 2, 3
     );
 
@@ -46,8 +46,8 @@ final class XmlInstructionTest {
     void comparesSuccessfullyWithSpaces() {
         MatcherAssert.assertThat(
             "Xml Instruction nodes with different empty spaces, but with the same content should be the same, but it wasn't",
-            new XmlInstruction(false, Opcodes.INVOKESPECIAL, 1, 2, 3).bytecode(),
-            Matchers.equalTo(XmlInstructionTest.INST)
+            new XmlInstruction(Opcodes.INVOKESPECIAL, 1, 2, 3).bytecode(),
+            Matchers.equalTo(XmlInstructionTest.EXPECTED)
         );
     }
 
@@ -56,7 +56,7 @@ final class XmlInstructionTest {
         MatcherAssert.assertThat(
             "Xml Instruction with different arguments should not be equal, but it was",
             new XmlInstruction(Opcodes.INVOKESPECIAL, 32, 23, 14),
-            Matchers.not(Matchers.equalTo(XmlInstructionTest.INST))
+            Matchers.not(Matchers.equalTo(XmlInstructionTest.EXPECTED))
         );
     }
 
@@ -65,7 +65,7 @@ final class XmlInstructionTest {
         MatcherAssert.assertThat(
             "Xml Instruction with different child content should not be equal, but it was",
             new XmlInstruction(Opcodes.INVOKESPECIAL),
-            Matchers.not(Matchers.equalTo(XmlInstructionTest.INST))
+            Matchers.not(Matchers.equalTo(XmlInstructionTest.EXPECTED))
         );
     }
 
@@ -74,7 +74,7 @@ final class XmlInstructionTest {
         MatcherAssert.assertThat(
             "Xml Instruction with different content should not be equal, but it was",
             new XmlInstruction(Opcodes.DUP),
-            Matchers.not(Matchers.equalTo(XmlInstructionTest.INST))
+            Matchers.not(Matchers.equalTo(XmlInstructionTest.EXPECTED))
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlLabelTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlLabelTest.java
@@ -43,7 +43,7 @@ final class XmlLabelTest {
             "Can't retrieve correct label identifier",
             new XmlLabel(
                 new XmlNode(
-                    new Xembler(expected.directives(false)).xml()
+                    new Xembler(expected.directives()).xml()
                 )
             ).bytecode(),
             Matchers.equalTo(expected)

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
@@ -108,7 +108,7 @@ final class XmlMethodTest {
                             new Directives(
                                 new BytecodeMethod(
                                     "someMethodName"
-                                ).directives(false)
+                                ).directives()
                             ).xpath(".//o[@name='exceptions']").append(new DirectivesBytes("???"))
                         ).xmlQuietly()
                     )

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlNodeTest.java
@@ -138,7 +138,7 @@ final class XmlNodeTest {
             "Can't convert to label entry",
             new XmlNode(
                 new Xembler(
-                    new BytecodeLabel("lbl").directives(false)
+                    new BytecodeLabel("lbl").directives()
                 ).xml()
             ).toEntry(),
             Matchers.instanceOf(XmlLabel.class)
@@ -151,7 +151,7 @@ final class XmlNodeTest {
             "Can't convert to instruction entry",
             new XmlNode(
                 new Xembler(
-                    new BytecodeInstruction(Opcodes.ICONST_2).directives(false)
+                    new BytecodeInstruction(Opcodes.ICONST_2).directives()
                 ).xml()
             ).toEntry(),
             Matchers.instanceOf(XmlInstruction.class)

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntryTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntryTest.java
@@ -47,7 +47,7 @@ final class XmlTryCatchEntryTest {
         MatcherAssert.assertThat(
             "Can't convert XML try-catch entry to the correct bytecode",
             new XmlTryCatchEntry(
-                new XmlNode(new Xembler(block.directives(false)).xml())
+                new XmlNode(new Xembler(block.directives()).xml())
             ).bytecode(),
             Matchers.equalTo(block)
         );


### PR DESCRIPTION
At first, I thought we should combine `counting` option together with `DisassembleMode`. However, I noticed, that we can remove `counting` option completly and leave `DisassembleMode` as is without additional modifications or refactoring. This is what I've done exactly.

Closes #893.
