### PR TITLE
feat(#898): Set Correct Jeo Version to XMIR Files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,7 @@ SOFTWARE.
           <include>**/*.eo</include>
           <include>**/*.yaml</include>
           <include>**/*.xmir</include>
+          <include>**/*.MF</include>
         </includes>
       </testResource>
     </testResources>
@@ -318,7 +319,7 @@ SOFTWARE.
         <version>3.4.2</version>
         <configuration>
           <archive>
-              <index>true</index>
+            <index>true</index>
             <manifestEntries>
               <JEO-Version>${project.version}</JEO-Version>
               <JEO-Title>${project.name}</JEO-Title>

--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,22 @@ SOFTWARE.
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.4.2</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <JEO-Version>${project.version}</JEO-Version>
+              <JEO-Title>${project.name}</JEO-Title>
+              <JEO-Vendor>${project.organization.name}</JEO-Vendor>
+              <JEO-Revision>${buildNumber}</JEO-Revision>
+              <JEO-Dob>${timestamp}</JEO-Dob>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
         <configuration>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,11 @@ SOFTWARE.
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>com.jcabi</groupId>
+      <artifactId>jcabi-manifests</artifactId>
+      <!-- version from parent POM -->
+    </dependency>
+    <dependency>
       <groupId>org.cactoos</groupId>
       <artifactId>cactoos</artifactId>
       <version>0.56.1</version>
@@ -313,6 +318,7 @@ SOFTWARE.
         <version>3.4.2</version>
         <configuration>
           <archive>
+              <index>true</index>
             <manifestEntries>
               <JEO-Version>${project.version}</JEO-Version>
               <JEO-Title>${project.name}</JEO-Title>

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesProgram.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.directives;
 
+import com.jcabi.manifests.Manifests;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -85,9 +86,9 @@ public final class DirectivesProgram implements Iterable<Directive> {
         final Directives directives = new Directives();
         directives.add("program")
             .attr("name", this.metas.className().name())
-            .attr("version", "0.0.0")
-            .attr("revision", "0.0.0")
-            .attr("dob", now)
+            .attr("version", Manifests.read("JEO-Version"))
+            .attr("revision", Manifests.read("JEO-Revision"))
+            .attr("dob", Manifests.read("JEO-Dob"))
             .attr("time", now)
             .add("listing")
             .set(this.listing)

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesProgramTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesProgramTest.java
@@ -26,8 +26,11 @@ package org.eolang.jeo.representation.directives;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.ClassName;
+import org.eolang.jeo.representation.bytecode.BytecodeClass;
+import org.eolang.jeo.representation.bytecode.BytecodeProgram;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
 import org.xembly.Transformers;
 import org.xembly.Xembler;
 
@@ -51,6 +54,23 @@ final class DirectivesProgramTest {
             ),
             actual,
             XhtmlMatchers.hasXPath("/program/objects/o[@name='Foo']")
+        );
+    }
+
+    @Test
+    void setsVersion() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect that version and revision number will be set from MANIFEST.MF file",
+            new Xembler(
+                new BytecodeProgram(
+                    new BytecodeClass("Some")
+                ).directives("")
+            ).xml(),
+            XhtmlMatchers.hasXPaths(
+                "/program[@version='1.2.3']",
+                "/program[@revision='1234567']",
+                "/program[@dob='2023-03-19T00:00:00']"
+            )
         );
     }
 }

--- a/src/test/resources/META-INF/MANIFEST.MF
+++ b/src/test/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+JEO-Version: 1.2.3
+JEO-Revision: 1234567
+JEO-Dob: 2023-03-19T00:00:00
+JEO-Vendor: org.eolang
+JEO-Title: jeo


### PR DESCRIPTION
In this PR I fixed the problem with `jeo-maven-plugin` version in XMIR files.
We used to set the default `0.0.0` version, but now we read the current version from `MANIFEST.MF`

Related to: #898.
