### PR TITLE
feat(#901): Add Quotation Marks to String Comments

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesComment.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesComment.java
@@ -38,7 +38,7 @@ public final class DirectivesComment implements Iterable<Directive> {
     /**
      * Unsafe characters.
      */
-    private static final Pattern UNSAFE_CHARS = Pattern.compile("[&<>\"'-]");
+    private static final Pattern UNSAFE_CHARS = Pattern.compile("[&<>'-]");
 
     /**
      * Chars that are discouraged in XML.
@@ -117,9 +117,6 @@ public final class DirectivesComment implements Iterable<Directive> {
                     break;
                 case ">":
                     replacement = "&gt;";
-                    break;
-                case "\"":
-                    replacement = "&quot;";
                     break;
                 case "'":
                     replacement = "&apos;";

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -119,7 +119,14 @@ public final class DirectivesValue implements Iterable<Directive> {
      * @return Sting comment.
      */
     private String comment() {
-        return String.valueOf(this.value.object());
+        final String result;
+        final Object object = this.value.object();
+        if (object instanceof String) {
+            result = String.format("\"%s\"", object);
+        } else {
+            result = String.valueOf(object);
+        }
+        return result;
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
@@ -150,6 +150,15 @@ final class DirectivesValueTest {
         );
     }
 
+    @Test
+    void createsStringWithQuotedComment() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect that string value will be quoted in the comment",
+            new Xembler(new DirectivesValue("java/lang/Object")).xml(),
+            Matchers.containsString("<!-- \"java/lang/Object\" -->")
+        );
+    }
+
     /**
      * Arguments for {@link DirectivesValueTest#determinesTypeCorrectly(Object, String)} test.
      * @return Stream of arguments.


### PR DESCRIPTION
In this PR I added quotation marks for string comments.
Was:
```
java/lang/Object
```

Become:
```
"java/lang/Object"
```

Related to #901.
