### PR TITLE
feat(#904): Track Disassembling Timing in XMIR

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -38,7 +38,6 @@ import org.eolang.jeo.representation.asm.DisassembleMode;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.directives.DirectivesProgram;
 import org.objectweb.asm.ClassReader;
-import org.xembly.Directives;
 import org.xembly.ImpossibleModificationException;
 
 /**
@@ -114,15 +113,11 @@ public final class BytecodeRepresentation {
      * @return XML representation of bytecode.
      */
     public XML toEO(final DisassembleMode mode) {
-        final long start = System.currentTimeMillis();
         final DirectivesProgram directives = new AsmProgram(this.input.value())
             .bytecode(mode.asmOptions())
             .directives(new BytecodeListing(this.input.value()).toString());
-        final long end = System.currentTimeMillis();
         try {
-            return new VerifiedEo(
-                new Directives(directives).xpath("/program").attr("ms", end - start)
-            ).asXml();
+            return new MeasuredEo(new VerifiedEo(directives)).asXml();
         } catch (final IllegalStateException exception) {
             throw new IllegalStateException(
                 String.format(

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -38,6 +38,7 @@ import org.eolang.jeo.representation.asm.DisassembleMode;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.directives.DirectivesProgram;
 import org.objectweb.asm.ClassReader;
+import org.xembly.Directives;
 import org.xembly.ImpossibleModificationException;
 
 /**
@@ -113,11 +114,15 @@ public final class BytecodeRepresentation {
      * @return XML representation of bytecode.
      */
     public XML toEO(final DisassembleMode mode) {
+        final long start = System.currentTimeMillis();
         final DirectivesProgram directives = new AsmProgram(this.input.value())
             .bytecode(mode.asmOptions())
             .directives(new BytecodeListing(this.input.value()).toString());
+        final long end = System.currentTimeMillis();
         try {
-            return new VerifiedEo(directives).asXml();
+            return new VerifiedEo(
+                new Directives(directives).xpath("/program").attr("ms", end - start)
+            ).asXml();
         } catch (final IllegalStateException exception) {
             throw new IllegalStateException(
                 String.format(

--- a/src/main/java/org/eolang/jeo/representation/MeasuredEo.java
+++ b/src/main/java/org/eolang/jeo/representation/MeasuredEo.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import org.xembly.Directives;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * This class tracks the time it takes to convert a bytecode to a XMIR program.
+ * @since 0.6
+ */
+final class MeasuredEo {
+
+    /**
+     * Original transformation.
+     */
+    private final VerifiedEo xmir;
+
+    /**
+     * Constructor.
+     * @param xmir Original transformation
+     */
+    MeasuredEo(final VerifiedEo xmir) {
+        this.xmir = xmir;
+    }
+
+    /**
+     * XML representation of the EO.
+     * @return XML representation
+     * @throws ImpossibleModificationException If something goes wrong
+     */
+    XML asXml() throws ImpossibleModificationException {
+        final long start = System.currentTimeMillis();
+        final XML xml = this.xmir.asXml();
+        final long end = System.currentTimeMillis();
+        return new XMLDocument(
+            new Xembler(
+                new Directives()
+                    .xpath("/program[@ms]/@ms")
+                    .set(String.format("%d", end - start))
+            ).apply(xml.node())
+        );
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesProgram.java
@@ -43,6 +43,12 @@ public final class DirectivesProgram implements Iterable<Directive> {
     private final String listing;
 
     /**
+     * How much time it took to transform bytecode to directives.
+     * Approximate value.
+     */
+    private final long milliseconds;
+
+    /**
      * Top-level class.
      * This field uses atomic reference because the field can't be initialized in the constructor.
      * It is the Java ASM framework limitation.
@@ -74,9 +80,27 @@ public final class DirectivesProgram implements Iterable<Directive> {
         final DirectivesClass clazz,
         final DirectivesMetas name
     ) {
-        this.listing = code;
-        this.klass = clazz;
-        this.metas = name;
+        this(code, 0L, clazz, name);
+    }
+
+    /**
+     * Constructor.
+     * @param listing Listing.
+     * @param milliseconds Milliseconds.
+     * @param klass Class.
+     * @param metas Metas.
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    public DirectivesProgram(
+        final String listing,
+        final long milliseconds,
+        final DirectivesClass klass,
+        final DirectivesMetas metas
+    ) {
+        this.listing = listing;
+        this.milliseconds = milliseconds;
+        this.klass = klass;
+        this.metas = metas;
     }
 
     @Override
@@ -97,7 +121,7 @@ public final class DirectivesProgram implements Iterable<Directive> {
             .add("sheets").up()
             .add("license").up()
             .append(this.metas)
-            .attr("ms", System.currentTimeMillis())
+            .attr("ms", this.milliseconds)
             .add("objects");
         directives.append(this.klass);
         directives.up();

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesProgramTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesProgramTest.java
@@ -73,4 +73,20 @@ final class DirectivesProgramTest {
             )
         );
     }
+
+    @Test
+    void setsMilliseconds() throws ImpossibleModificationException {
+        final ClassName clazz = new ClassName("Some");
+        final DirectivesProgram program = new DirectivesProgram(
+            "some code",
+            10,
+            new DirectivesClass(clazz),
+            new DirectivesMetas(clazz)
+        );
+        MatcherAssert.assertThat(
+            "We expect that milliseconds will be set",
+            new Xembler(program).xml(),
+            XhtmlMatchers.hasXPath("/program[@ms='10']")
+        );
+    }
 }


### PR DESCRIPTION
In this PR I added one more class that tracks the time spend on transformation of a bytecode class to the corresponding XMIR representation and save this time to `/program[@ms]` attribute.

Related to #904.
