### PR TITLE
feat(#912): Do Not Add Empty Packages

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -101,7 +101,7 @@ public final class DirectivesMetas implements Iterable<Directive> {
         if (original.isEmpty()) {
             result = new Directives();
         } else {
-            String prefixed = new PrefixedName(original).encode();
+            final String prefixed = new PrefixedName(original).encode();
             result = new Directives()
                 .add("meta")
                 .add("head").set("package").up()

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -72,7 +72,7 @@ public final class DirectivesMetas implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        final Directives metas = new Directives().add("metas").append(this.pckgDirs());
+        final Directives metas = new Directives().add("metas").append(this.pckg());
         this.jeo()
             .stream()
             .filter(object -> !object.isEmpty())
@@ -95,42 +95,19 @@ public final class DirectivesMetas implements Iterable<Directive> {
      * strange, <a href="https://github.com/objectionary/jeo-maven-plugin/issues/779">see</a>
      * @return Prefixed package name.
      */
-    private Directives pckgDirs() {
+    private Directives pckg() {
         final Directives result;
         final String original = this.name.pckg();
         if (original.isEmpty()) {
             result = new Directives();
         } else {
-            String txt = new PrefixedName(original).encode();
+            String prefixed = new PrefixedName(original).encode();
             result = new Directives()
                 .add("meta")
                 .add("head").set("package").up()
-                .add("tail").set(txt).up()
-                .add("part").set(txt).up()
+                .add("tail").set(prefixed).up()
+                .add("part").set(prefixed).up()
                 .up();
-        }
-        return result;
-//        return new Directives()
-//            .add("meta")
-//            .add("head").set("package").up()
-//            .add("tail").set(this.pckg()).up()
-//            .add("part").set(this.pckg()).up()
-//            .up();
-    }
-
-    /**
-     * Prefixed package name.
-     * We intentionally add prefix to the packages, because sometimes they can be really
-     * strange, <a href="https://github.com/objectionary/jeo-maven-plugin/issues/779">see</a>
-     * @return Prefixed package name.
-     */
-    private String pckg() {
-        final String result;
-        final String original = this.name.pckg();
-        if (original.isEmpty()) {
-            result = "";
-        } else {
-            result = new PrefixedName(original).encode();
         }
         return result;
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -72,13 +72,7 @@ public final class DirectivesMetas implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        final Directives metas = new Directives()
-            .add("metas")
-            .add("meta")
-            .add("head").set("package").up()
-            .add("tail").set(this.pckg()).up()
-            .add("part").set(this.pckg()).up()
-            .up();
+        final Directives metas = new Directives().add("metas").append(this.pckgDirs());
         this.jeo()
             .stream()
             .filter(object -> !object.isEmpty())
@@ -93,6 +87,35 @@ public final class DirectivesMetas implements Iterable<Directive> {
      */
     ClassName className() {
         return this.name;
+    }
+
+    /**
+     * Prefixed package.
+     * We intentionally add prefix to the packages, because sometimes they can be really
+     * strange, <a href="https://github.com/objectionary/jeo-maven-plugin/issues/779">see</a>
+     * @return Prefixed package name.
+     */
+    private Directives pckgDirs() {
+        final Directives result;
+        final String original = this.name.pckg();
+        if (original.isEmpty()) {
+            result = new Directives();
+        } else {
+            String txt = new PrefixedName(original).encode();
+            result = new Directives()
+                .add("meta")
+                .add("head").set("package").up()
+                .add("tail").set(txt).up()
+                .add("part").set(txt).up()
+                .up();
+        }
+        return result;
+//        return new Directives()
+//            .add("meta")
+//            .add("head").set("package").up()
+//            .add("tail").set(this.pckg()).up()
+//            .add("part").set(this.pckg()).up()
+//            .up();
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/CanonicalXmirTest.java
+++ b/src/test/java/org/eolang/jeo/representation/CanonicalXmirTest.java
@@ -56,7 +56,6 @@ final class CanonicalXmirTest {
     @Disabled
     void transformsToPlainXmir() throws ImpossibleModificationException {
         final BytecodeProgram initial = new BytecodeProgram(
-            "org.jeo",
             new BytecodeClass(
                 "App",
                 Collections.singletonList(new BytecodeMethod("main")),

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -88,11 +88,10 @@ final class XmirRepresentationTest {
         final String name = "Bar";
         final BytecodeClass clazz = new BytecodeClass(name);
         final Bytecode expected = new BytecodeProgram(
-            "org.jeo",
             new BytecodeClass(name)
         ).bytecode();
         final Bytecode actual = new XmirRepresentation(
-            new BytecodeProgram("org.jeo", clazz).xml()
+            new BytecodeProgram(clazz).xml()
         ).toBytecode();
         MatcherAssert.assertThat(
             String.format(XmirRepresentationTest.MESSAGE, expected, actual),
@@ -104,7 +103,6 @@ final class XmirRepresentationTest {
     @Test
     void returnsBytecodeRepresentationOfEoObjectWithFields() {
         final Bytecode expected = new BytecodeProgram(
-            "org.jeo",
             new BytecodeClass("Fields").withField("foo")
         ).bytecode();
         final Bytecode actual = new XmirRepresentation(
@@ -120,7 +118,6 @@ final class XmirRepresentationTest {
     @Test
     void convertsHelloWordEoRepresentationIntoBytecode() {
         final Bytecode expected = new BytecodeProgram(
-            "org.jeo",
             new BytecodeClass("Application").helloWorldMethod()
         ).bytecode();
         final Bytecode actual = new XmirRepresentation(

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -128,7 +128,6 @@ final class BytecodeClassTest {
     void transformsBytecodeIntoEoWithoutCountingOpcodes() {
         final XML xmir = new BytecodeRepresentation(
             new BytecodeProgram(
-                "org.jeo",
                 new BytecodeClass("Hello").helloWorldMethod()
             ).bytecode()
         ).toEO();

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -107,7 +107,6 @@ final class BytecodeMethodTest {
         final String clazz = "ParametersExample";
         final String method = "printSum";
         final String xml = new BytecodeProgram(
-            "org.jeo",
             new BytecodeClass(clazz)
                 .withMethod(
                     new BytecodeMethodProperties(
@@ -169,7 +168,6 @@ final class BytecodeMethodTest {
     @Test
     void parsesConstructor() {
         final String xml = new BytecodeProgram(
-            "org.jeo",
             new BytecodeClass("ConstructorExample")
                 .withConstructor(Opcodes.ACC_PUBLIC)
                 .opcode(Opcodes.ALOAD, 0)
@@ -231,7 +229,6 @@ final class BytecodeMethodTest {
     void parsesConstructorWithParameters() {
         final String clazz = "ConstructorParams";
         final String xml = new BytecodeProgram(
-            "org.jeo",
             new BytecodeClass(clazz)
                 .withConstructor("(II)V", Opcodes.ACC_PUBLIC)
                 .opcode(Opcodes.ALOAD, 0)
@@ -295,7 +292,6 @@ final class BytecodeMethodTest {
     void parsesIfStatementCorrectly() {
         final String label = UUID.randomUUID().toString();
         final String xml = new BytecodeProgram(
-            "org.jeo",
             new BytecodeClass("Foo")
                 .withMethod("bar", "(D)I", 0)
                 .opcode(Opcodes.DLOAD, 1)
@@ -342,7 +338,6 @@ final class BytecodeMethodTest {
         final String end = UUID.randomUUID().toString();
         final String handler = UUID.randomUUID().toString();
         final String xml = new BytecodeProgram(
-            "org.jeo",
             new BytecodeClass("Foo")
                 .withMethod("bar", "()V", Opcodes.ACC_PUBLIC)
                 .label(start)
@@ -373,7 +368,7 @@ final class BytecodeMethodTest {
     void doesNotContainTryCatchBlock() {
         MatcherAssert.assertThat(
             "We expect that method without try-catch block doesn't contain try-catch directives.",
-            new BytecodeProgram("org.jeo", new BytecodeClass().helloWorldMethod()).xml().toString(),
+            new BytecodeProgram(new BytecodeClass().helloWorldMethod()).xml().toString(),
             XhtmlMatchers.hasXPath(
                 ".//o[contains(@base,'seq.of0') and @name='trycatchblocks-main']"
             )

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
@@ -99,7 +99,7 @@ final class DirectivesMetasTest {
     }
 
     @Test
-    void createdDirectivesWithEmptyPackage() throws ImpossibleModificationException {
+    void createsDirectivesWithEmptyPackage() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "We expect that <metas>/<package> won't be created if package is empty",
             new Xembler(

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
@@ -97,4 +97,18 @@ final class DirectivesMetasTest {
             )
         );
     }
+
+    @Test
+    void createdDirectivesWithEmptyPackage() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect that <metas>/<package> won't be created if package is empty",
+            new Xembler(
+                new DirectivesMetas(new ClassName("WithoutPackage")),
+                new Transformers.Node()
+            ).xml(),
+            Matchers.not(
+                XhtmlMatchers.hasXPath("/metas/meta/head[text()='package']")
+            )
+        );
+    }
 }


### PR DESCRIPTION
If a package is empty we just don't add `meta/head[text()='package']` to directives.

Related to #912.
