### PR TITLE
feat(#917): Different Atoms For Different Opcodes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
-      <version>0.43.2</version>
+      <version>0.44.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.volodya-lombrozo</groupId>

--- a/src/it/annotations/pom.xml
+++ b/src/it/annotations/pom.xml
@@ -64,7 +64,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.43.2</version>
+        <version>0.44.0</version>
         <executions>
           <execution>
             <id>convert-xmir-to-eo</id>

--- a/src/it/bytecode-to-eo/pom.xml
+++ b/src/it/bytecode-to-eo/pom.xml
@@ -70,7 +70,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.43.2</version>
+        <version>0.44.0</version>
         <executions>
           <execution>
             <id>convert-xmir-to-phi</id>

--- a/src/it/custom-transformations/pom.xml
+++ b/src/it/custom-transformations/pom.xml
@@ -64,7 +64,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.43.2</version>
+        <version>0.44.0</version>
         <executions>
           <!--
             @todo #610:30min Enable EO Printing in 'custom-transformations' it.

--- a/src/it/exceptions/pom.xml
+++ b/src/it/exceptions/pom.xml
@@ -82,7 +82,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.43.2</version>
+        <version>0.44.0</version>
         <executions>
           <execution>
             <id>convert-xmir-to-eo</id>

--- a/src/it/generics/pom.xml
+++ b/src/it/generics/pom.xml
@@ -64,7 +64,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.43.2</version>
+        <version>0.44.0</version>
         <executions>
           <execution>
             <id>convert-xmir-to-eo</id>

--- a/src/it/jna/pom.xml
+++ b/src/it/jna/pom.xml
@@ -219,7 +219,7 @@ SOFTWARE.
           <plugin>
             <groupId>org.eolang</groupId>
             <artifactId>eo-maven-plugin</artifactId>
-            <version>0.43.2</version>
+            <version>0.44.0</version>
             <executions>
               <execution>
                 <id>xmir-to-phi</id>

--- a/src/it/phi-unphi/pom.xml
+++ b/src/it/phi-unphi/pom.xml
@@ -89,7 +89,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.43.2</version>
+        <version>0.44.0</version>
         <executions>
           <execution>
             <id>xmir-to-phi</id>

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -84,7 +84,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.43.2</version>
+        <version>0.44.0</version>
         <executions>
           <execution>
             <id>convert-xmir-to-phi</id>

--- a/src/it/spring/verify.groovy
+++ b/src/it/spring/verify.groovy
@@ -37,5 +37,5 @@ assert app.text.contains("<tail>jeo.opcode</tail>")
 //Check that if class doesn't have instructions, it doesn't have "opcode" imports.
 def empty = new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/spring/WithoutInstructions.xmir')
 assert empty.exists()
-assert !empty.text.contains("<tail>jeo.opcode</tail>")
+assert !empty.text.contains("<tail>jeo.opcode.return</tail>")
 true

--- a/src/it/spring/verify.groovy
+++ b/src/it/spring/verify.groovy
@@ -33,7 +33,7 @@ assert app.exists()
 assert app.text.contains("metas")
 assert app.text.contains("<head>package</head>")
 // Check that we have "opcode" and "label" imports where they are needed
-assert app.text.contains("<tail>jeo.opcode</tail>")
+assert app.text.contains("<tail>jeo.opcode.return</tail>")
 //Check that if class doesn't have instructions, it doesn't have "opcode" imports.
 def empty = new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/spring/WithoutInstructions.xmir')
 assert empty.exists()

--- a/src/it/takes/pom.xml
+++ b/src/it/takes/pom.xml
@@ -80,7 +80,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.43.2</version>
+        <version>0.44.0</version>
         <executions>
           <execution>
             <id>convert-xmir-to-phi</id>

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesEoObject.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesEoObject.java
@@ -26,7 +26,6 @@ package org.eolang.jeo.representation.directives;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -78,7 +77,6 @@ public final class DirectivesEoObject implements Iterable<Directive> {
             .attr("base", new EoFqn(this.base).fqn());
         if (!this.name.isEmpty()) {
             directives.attr("name", this.name);
-            directives.attr("line", new Random().nextInt(Integer.MAX_VALUE));
         }
         return directives
             .append(this.inner.stream().reduce(new Directives(), Directives::append))

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
@@ -64,7 +64,7 @@ public final class DirectivesInstruction implements Iterable<Directive> {
     @Override
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
-            "opcode",
+            this.base(),
             this.name(),
             Stream.concat(
                 Stream.of(
@@ -82,6 +82,14 @@ public final class DirectivesInstruction implements Iterable<Directive> {
      */
     private String name() {
         return new OpcodeName(this.opcode).asString();
+    }
+
+    /**
+     * Base of the instruction.
+     * @return String base.
+     */
+    private String base() {
+        return String.format("%s.%s", "opcode", new OpcodeName(this.opcode).simplified());
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesJeoObject.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesJeoObject.java
@@ -26,7 +26,6 @@ package org.eolang.jeo.representation.directives;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Collectors;
 import org.xembly.Directive;
 import org.xembly.Directives;
@@ -123,7 +122,6 @@ public final class DirectivesJeoObject implements Iterable<Directive> {
             .attr("base", new JeoFqn(this.base).fqn());
         if (!this.name.isEmpty()) {
             directives.attr("name", this.name);
-            directives.attr("line", new Random().nextInt(Integer.MAX_VALUE));
         }
         return directives
             .append(this.inner.stream().reduce(new Directives(), Directives::append))

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -32,12 +32,6 @@ import org.xembly.Directive;
  * Data Object Directive in EO language.
  *
  * @since 0.1.0
- * @todo #627:90min Remove 'line' attribute usages.
- *  We add 'line' attribute in many places to be able print XMIR representation as PHI expressions.
- *  Actually we shouldn't add any artificial attributes to the representation.
- *  When the following issue will be solved we should remove 'line' attribute from all places
- *  where it used:
- *  https://github.com/objectionary/eo/issues/3189
  */
 @ToString
 public final class DirectivesValue implements Iterable<Directive> {

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -138,10 +138,10 @@ final class BytecodeClassTest {
             ),
             xmir.toString(),
             XhtmlMatchers.hasXPaths(
-                "//o[@base='jeo.opcode' and contains(@name,'getstatic')]",
-                "//o[@base='jeo.opcode' and contains(@name,'ldc')]",
-                "//o[@base='jeo.opcode' and contains(@name,'invokevirtual')]",
-                "//o[@base='jeo.opcode' and contains(@name,'return')]"
+                "//o[@base='jeo.opcode.getstatic' and contains(@name,'getstatic')]",
+                "//o[@base='jeo.opcode.ldc' and contains(@name,'ldc')]",
+                "//o[@base='jeo.opcode.invokevirtual' and contains(@name,'invokevirtual')]",
+                "//o[@base='jeo.opcode.return' and contains(@name,'return')]"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
@@ -58,13 +58,11 @@ final class DirectivesMetasTest {
 
     @Test
     void addsAliasesForAllTheRequiredObjects() throws ImpossibleModificationException {
-        final String xml = new Xembler(
-            new BytecodeProgram(new BytecodeClass().helloWorldMethod()).directives("")
-        ).xml();
-        System.out.println(xml);
         MatcherAssert.assertThat(
             "Can't create corresponding xembly directives for all the required objects",
-            xml,
+            new Xembler(
+                new BytecodeProgram(new BytecodeClass().helloWorldMethod()).directives("")
+            ).xml(),
             Matchers.allOf(
                 XhtmlMatchers.hasXPath("/program/metas/meta/head[text()='alias']"),
                 XhtmlMatchers.hasXPath("/program/metas/meta/tail[text()='jeo.opcode.return']"),

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
@@ -58,14 +58,16 @@ final class DirectivesMetasTest {
 
     @Test
     void addsAliasesForAllTheRequiredObjects() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new BytecodeProgram(new BytecodeClass().helloWorldMethod()).directives("")
+        ).xml();
+        System.out.println(xml);
         MatcherAssert.assertThat(
             "Can't create corresponding xembly directives for all the required objects",
-            new Xembler(
-                new BytecodeProgram(new BytecodeClass().helloWorldMethod()).directives("")
-            ).xml(),
+            xml,
             Matchers.allOf(
                 XhtmlMatchers.hasXPath("/program/metas/meta/head[text()='alias']"),
-                XhtmlMatchers.hasXPath("/program/metas/meta/tail[text()='jeo.opcode']"),
+                XhtmlMatchers.hasXPath("/program/metas/meta/tail[text()='jeo.opcode.return']"),
                 XhtmlMatchers.hasXPath("/program/metas/meta/tail[text()='jeo.label']"),
                 XhtmlMatchers.hasXPath("/program/metas/meta/part[text()='jeo.int']"),
                 XhtmlMatchers.hasXPath("/program/metas/meta/part[text()='jeo.string']"),


### PR DESCRIPTION
In this PR I add opcode names to their base.
For example, we used to have:
```
jeo.opcode
```
Now we have
```
jeo.opcode.ireturn
```
And we did it for all the opcodes.

Related to #917.

