### PR TITLE
feat(#889): Optimize Disassemble/Assemble Goals

### DIFF
--- a/src/main/java/org/eolang/jeo/Assembling.java
+++ b/src/main/java/org/eolang/jeo/Assembling.java
@@ -45,6 +45,11 @@ public final class Assembling implements Transformation {
     private final Path from;
 
     /**
+     * XMIR representation.
+     */
+    private final XmirRepresentation repr;
+
+    /**
      * Constructor.
      * @param target Target folder.
      * @param representation Representation to assemble.
@@ -52,6 +57,7 @@ public final class Assembling implements Transformation {
     Assembling(final Path target, final Path representation) {
         this.folder = target;
         this.from = representation;
+        this.repr = new XmirRepresentation(this.from);
     }
 
     @Override
@@ -61,8 +67,7 @@ public final class Assembling implements Transformation {
 
     @Override
     public Path target() {
-        final XmirRepresentation repr = new XmirRepresentation(this.from);
-        final String name = new PrefixedName(repr.name()).decode();
+        final String name = new PrefixedName(this.repr.name()).decode();
         final String[] subpath = name.split("\\.");
         subpath[subpath.length - 1] = String.format("%s.class", subpath[subpath.length - 1]);
         return Paths.get(this.folder.toString(), subpath);
@@ -70,6 +75,6 @@ public final class Assembling implements Transformation {
 
     @Override
     public byte[] transform() {
-        return new XmirRepresentation(this.from).toBytecode().bytes();
+        return this.repr.toBytecode().bytes();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
@@ -88,7 +88,7 @@ public final class XmirRepresentation {
      * @param xml XML.
      */
     public XmirRepresentation(final XML xml) {
-        this(xml.node(), "Unknown");
+        this(xml.node().getFirstChild(), "Unknown");
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
@@ -210,7 +210,13 @@ public final class XmirRepresentation {
 
     /**
      * Optimized schema for XMIR.
+     * It is an optimized version of {@link org.eolang.parser.Schema} class.
      * @since 0.6
+     * @todo #889:30min Use the `Schema` class instead of `OptimizedSchema`.
+     *  The `OptimizedSchema` class is a temporary solution to avoid the performance
+     *  issues with the `Schema` class. We will be able to remove this class after
+     *  the following issue is resolved:
+     *  https://github.com/jcabi/jcabi-xml/issues/277
      */
     private static class OptimizedSchema {
         /**

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesSeq.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesSeq.java
@@ -82,19 +82,14 @@ public final class DirectivesSeq implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
+        final List<Directives> all = this.stream()
+            .map(Directives::new)
+            .collect(Collectors.toList());
         return new DirectivesJeoObject(
-            String.format("seq.of%d", this.size()),
+            String.format("seq.of%d", all.size()),
             this.name,
-            this.stream().map(Directives::new).collect(Collectors.toList())
+            all
         ).iterator();
-    }
-
-    /**
-     * Size of the sequence.
-     * @return Size.
-     */
-    private long size() {
-        return this.stream().count();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -64,14 +64,6 @@ public final class XmlInstruction implements XmlBytecodeEntry {
 
     /**
      * Constructor.
-     * @param xml XML string that represents an instruction.
-     */
-    XmlInstruction(final String xml) {
-        this(new XmlNode(xml));
-    }
-
-    /**
-     * Constructor.
      * @param xmlnode Instruction node.
      */
     XmlInstruction(final XmlNode xmlnode) {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -43,7 +43,13 @@ import org.w3c.dom.NodeList;
 public final class XmlNode {
 
     /**
-     * Parent node.
+     * XML node.
+     * Attention!
+     * Here we use the {@link Node} class instead of the {@link com.jcabi.xml.XML}
+     * by performance reasons.
+     * In some cases {@link Node} 10 times faster than {@link com.jcabi.xml.XML}.
+     * You can read more about it here:
+     * <a href="https://github.com/objectionary/jeo-maven-plugin/pull/924">Optimization</a>
      */
     private final Node node;
 
@@ -57,7 +63,7 @@ public final class XmlNode {
 
     /**
      * Constructor.
-     * @param parent Parent node.
+     * @param parent Xml node.
      */
     public XmlNode(final Node parent) {
         this.node = parent;

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -23,7 +23,6 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -46,7 +46,7 @@ public final class XmlNode {
     /**
      * Parent node.
      */
-    private final XML node;
+    private final Node node;
 
     /**
      * Constructor.
@@ -58,17 +58,9 @@ public final class XmlNode {
 
     /**
      * Constructor.
-     * @param parent XML document
-     */
-    public XmlNode(final Node parent) {
-        this(new XMLDocument(parent));
-    }
-
-    /**
-     * Constructor.
      * @param parent Parent node.
      */
-    public XmlNode(final XML parent) {
+    public XmlNode(final Node parent) {
         this.node = parent;
     }
 
@@ -76,7 +68,7 @@ public final class XmlNode {
     public boolean equals(final Object obj) {
         final boolean res;
         if (obj instanceof XmlNode) {
-            res = this.node.equals(((XmlNode) obj).node);
+            res = new XMLDocument(this.node).equals(new XMLDocument(((XmlNode) obj).node));
         } else {
             res = false;
         }
@@ -106,7 +98,7 @@ public final class XmlNode {
      * @return Text content.
      */
     public String text() {
-        return this.node.node().getTextContent();
+        return this.node.getTextContent();
     }
 
     /**
@@ -116,7 +108,7 @@ public final class XmlNode {
      */
     public Optional<String> attribute(final String name) {
         final Optional<String> result;
-        final NamedNodeMap attrs = this.node.node().getAttributes();
+        final NamedNodeMap attrs = this.node.getAttributes();
         if (attrs == null) {
             result = Optional.empty();
         } else {
@@ -140,7 +132,7 @@ public final class XmlNode {
      * @return List of elements.
      */
     List<String> xpath(final String xpath) {
-        return this.node.xpath(xpath);
+        return new XMLDocument(this.node).xpath(xpath);
     }
 
     /**
@@ -206,7 +198,7 @@ public final class XmlNode {
      * @return Class.
      */
     XmlClass toClass() {
-        return new XmlClass(this.node.node());
+        return new XmlClass(this.node);
     }
 
     /**
@@ -233,9 +225,14 @@ public final class XmlNode {
      */
     private Optional<XmlNode> optchild(final String name) {
         Optional<XmlNode> result = Optional.empty();
-        final List<XML> nodes = this.node.nodes(name);
-        if (!nodes.isEmpty()) {
-            result = Optional.of(new XmlNode(nodes.get(0)));
+        final NodeList children = this.node.getChildNodes();
+        final int length = children.getLength();
+        for (int index = 0; index < length; ++index) {
+            final Node current = children.item(index);
+            if (current.getNodeName().equals(name)) {
+                result = Optional.of(new XmlNode(current));
+                break;
+            }
         }
         return result;
     }
@@ -260,7 +257,7 @@ public final class XmlNode {
      * @return Stream of class objects.
      */
     private Stream<Node> objects() {
-        final NodeList children = this.node.node().getChildNodes();
+        final NodeList children = this.node.getChildNodes();
         final List<Node> res = new ArrayList<>(children.getLength());
         for (int index = 0; index < children.getLength(); ++index) {
             final Node child = children.item(index);

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -89,7 +89,7 @@ public final class XmlProgram {
      *
      * @param root Root node.
      */
-    private XmlProgram(final Node root) {
+    public XmlProgram(final Node root) {
         this.root = root;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -43,6 +43,11 @@ public final class XmlProgram {
 
     /**
      * Root node.
+     * Here we use the {@link Node} class instead of the {@link com.jcabi.xml.XML}
+     * by performance reasons.
+     * In some cases {@link Node} 10 times faster than {@link com.jcabi.xml.XML}.
+     * You can read more about it here:
+     * <a href="https://github.com/objectionary/jeo-maven-plugin/pull/924">Optimization</a>
      */
     private final Node root;
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -40,10 +40,6 @@ import org.xembly.Xembler;
  * @since 0.1
  */
 public final class XmlProgram {
-    /**
-     * Program node name.
-     */
-    private static final String PROGRAM = "program";
 
     /**
      * Root node.
@@ -123,7 +119,6 @@ public final class XmlProgram {
      */
     private XmlClass top() {
         return new XmlNode(this.root)
-//            .child(XmlProgram.PROGRAM)
             .child("objects")
             .child("o")
             .toClass();

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -64,7 +64,7 @@ public final class XmlProgram {
      * @param xml Raw XMIR.
      */
     public XmlProgram(final XML xml) {
-        this(xml.node());
+        this(xml.node().getFirstChild());
     }
 
     /**
@@ -80,7 +80,7 @@ public final class XmlProgram {
                         new DirectivesClass(name), new DirectivesMetas(name)
                     )
                 ).xmlQuietly()
-            ).node()
+            )
         );
     }
 
@@ -123,7 +123,7 @@ public final class XmlProgram {
      */
     private XmlClass top() {
         return new XmlNode(this.root)
-            .child(XmlProgram.PROGRAM)
+//            .child(XmlProgram.PROGRAM)
             .child("objects")
             .child("o")
             .toClass();

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -185,12 +185,11 @@ final class XmirRepresentationTest {
             );
         }
         final long end = System.currentTimeMillis();
-        final long l = end - start;
         Logger.info(
             this,
             "We made %d attempts to convert bytecode to xmir and back in %[ms]s",
             attempts,
-            l
+            end - start
         );
 
     }

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -167,6 +167,7 @@ final class XmirRepresentationTest {
      */
     @Test
     @Disabled
+    @SuppressWarnings("PMD.GuardLogStatement")
     void convertsToXmirAndBack() {
         final Bytecode before = new BytecodeProgram(
             new BytecodeClass("org/eolang/foo/Math")

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation;
 
+import com.jcabi.log.Logger;
 import com.jcabi.matchers.XhtmlMatchers;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -34,6 +35,7 @@ import org.eolang.jeo.representation.bytecode.BytecodeProgram;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -152,5 +154,43 @@ final class XmirRepresentationTest {
                 )
             )
         );
+    }
+
+    /**
+     * This is a performance test, which is disabled by default.
+     * It is used to measure the performance of the conversion of the EO object
+     * into the bytecode representation and back.
+     * Timings before the optimization were: 21s, 23s, 21s, 21s (500 attempts)
+     */
+    @Test
+    @Disabled
+    void convertsToXmirAndBack() {
+        final Bytecode before = new BytecodeProgram(
+            new BytecodeClass("org/eolang/foo/Math")
+                .helloWorldMethod()
+        ).bytecode();
+        final int attempts = 500;
+        final long start = System.currentTimeMillis();
+        for (int current = 0; current < attempts; ++current) {
+            final Bytecode actual = new XmirRepresentation(
+                new BytecodeRepresentation(
+                    before
+                ).toEO()
+            ).toBytecode();
+            MatcherAssert.assertThat(
+                String.format(XmirRepresentationTest.MESSAGE, before, actual),
+                actual,
+                Matchers.equalTo(before)
+            );
+        }
+        final long end = System.currentTimeMillis();
+        final long l = end - start;
+        Logger.info(
+            this,
+            "We made %d attempts to convert bytecode to xmir and back in %[ms]s",
+            attempts,
+            l
+        );
+
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -25,6 +25,8 @@ package org.eolang.jeo.representation;
 
 import com.jcabi.log.Logger;
 import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -191,6 +193,23 @@ final class XmirRepresentationTest {
             attempts,
             end - start
         );
+    }
 
+    @Test
+    void throwsExceptionIfXmirIsInvalid() {
+        MatcherAssert.assertThat(
+            "We excpect that XSD violation message will be easily understandable by developers",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> new XmirRepresentation(
+                    new XMLDocument(
+                        new BytecodeProgram(
+                            new BytecodeClass("org/eolang/foo/Math")
+                        ).xml().toString().replace("<head>package</head>", "")
+                    )
+                ).toBytecode()
+            ).getCause().getMessage(),
+            Matchers.containsString("There are XSD violations, see the log")
+        );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -161,9 +161,6 @@ final class XmirRepresentationTest {
      * This is a performance test, which is disabled by default.
      * It is used to measure the performance of the conversion of the EO object
      * into the bytecode representation and back.
-     * 1) Timings before the optimization were: 21s, 23s, 21s, 21s (500 attempts)
-     * 2) `XMLDocument` -> `org.w3c.Node` optimization: 11s, 10s, 11s, 10s (500 attempts)
-     * 3) Remove `XMLDocument` usage: 10s, 9s, 9s, 9s (500 attempts)
      */
     @Test
     @Disabled

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation;
 
 import com.jcabi.log.Logger;
 import com.jcabi.matchers.XhtmlMatchers;
-import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -164,7 +163,7 @@ final class XmirRepresentationTest {
      * into the bytecode representation and back.
      * 1) Timings before the optimization were: 21s, 23s, 21s, 21s (500 attempts)
      * 2) `XMLDocument` -> `org.w3c.Node` optimization: 11s, 10s, 11s, 10s (500 attempts)
-     * 3) Remove `XMLDocument` from the `XmirRepresentation` constructor: 10s, 9s, 9s, 9s (500 attempts)
+     * 3) Remove `XMLDocument` usage: 10s, 9s, 9s, 9s (500 attempts)
      */
     @Test
     @Disabled

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -164,6 +164,7 @@ final class XmirRepresentationTest {
      * into the bytecode representation and back.
      * 1) Timings before the optimization were: 21s, 23s, 21s, 21s (500 attempts)
      * 2) `XMLDocument` -> `org.w3c.Node` optimization: 11s, 10s, 11s, 10s (500 attempts)
+     * 3) Remove `XMLDocument` from the `XmirRepresentation` constructor: 10s, 9s, 9s, 9s (500 attempts)
      */
     @Test
     @Disabled

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -160,7 +160,8 @@ final class XmirRepresentationTest {
      * This is a performance test, which is disabled by default.
      * It is used to measure the performance of the conversion of the EO object
      * into the bytecode representation and back.
-     * Timings before the optimization were: 21s, 23s, 21s, 21s (500 attempts)
+     * 1) Timings before the optimization were: 21s, 23s, 21s, 21s (500 attempts)
+     * 2) `XMLDocument` -> `org.w3c.Node` optimization: 11s, 10s, 11s, 10s (500 attempts)
      */
     @Test
     @Disabled

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesSeqTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesSeqTest.java
@@ -24,8 +24,13 @@
 package org.eolang.jeo.representation.directives;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.xembly.Directives;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
@@ -49,6 +54,50 @@ final class DirectivesSeqTest {
                 "/o[contains(@base,'seq.of2') and @name='@']",
                 "/o[contains(@base,'seq.of2') and @name='@']/o[contains(@base,'string')]/o[@base='org.eolang.bytes' and text()='31-']",
                 "/o[contains(@base,'seq.of2') and @name='@']/o[contains(@base,'string')]/o[@base='org.eolang.bytes' and text()='32-']"
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("sequences")
+    void correctlyComputesSize(
+        final DirectivesSeq actual, final int expected
+    ) throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "The size of the sequence is not as expected",
+            new Xembler(actual).xml(),
+            XhtmlMatchers.hasXPath(
+                String.format(
+                    "/o[contains(@base,'seq.of%d') and @name='@']",
+                    expected
+                )
+            )
+        );
+    }
+
+    /**
+     * Sequences to test.
+     * @return Stream of arguments.
+     */
+    private static Stream<Arguments> sequences() {
+        return Stream.of(
+            Arguments.of(
+                new DirectivesSeq(
+                    new DirectivesValue("1"), new DirectivesValue("2")
+                ),
+                2
+            ),
+            Arguments.of(new DirectivesSeq(), 0),
+            Arguments.of(new DirectivesSeq(new Directives(), new Directives()), 0),
+            Arguments.of(
+                new DirectivesSeq(
+                    new DirectivesValue("1"), new Directives(),
+                    new Directives(), new DirectivesValue("4")
+                ),
+                2
+            ),
+            Arguments.of(
+                new DirectivesSeq(), 0
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesSeqTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesSeqTest.java
@@ -79,7 +79,7 @@ final class DirectivesSeqTest {
      * Sequences to test.
      * @return Stream of arguments.
      */
-    private static Stream<Arguments> sequences() {
+    static Stream<Arguments> sequences() {
         return Stream.of(
             Arguments.of(
                 new DirectivesSeq(

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesSeqTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesSeqTest.java
@@ -60,7 +60,7 @@ final class DirectivesSeqTest {
 
     @ParameterizedTest
     @MethodSource("sequences")
-    void correctlyComputesSize(
+    void computesSize(
         final DirectivesSeq actual, final int expected
     ) throws ImpossibleModificationException {
         MatcherAssert.assertThat(


### PR DESCRIPTION
In this PR I optimize `disassemble/assemle` goals to speed up development.

Timings after optimization:
```
[INFO]           spring-fat/pom.xml ............................... SUCCESS (301.7 s)
[INFO]           spring-fat/pom.xml ............................... SUCCESS (313.2 s)
[INFO]           spring-fat/pom.xml ............................... SUCCESS (378.5 s)
```

As you can see, in some cases we got ~ x10 speed up.

Related to #889.
