### PR TITLE
frat(#928): Don't Print EO if Java < 11"

### DIFF
--- a/src/it/bytecode-to-eo/pom.xml
+++ b/src/it/bytecode-to-eo/pom.xml
@@ -83,19 +83,38 @@ SOFTWARE.
               <phiOutputDir>${project.build.directory}/generated-sources/jeo-phi</phiOutputDir>
             </configuration>
           </execution>
-          <execution>
-            <id>convert-xmir-to-eo</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>print</goal>
-            </goals>
-            <configuration>
-              <printSourcesDir>${project.build.directory}/generated-sources/jeo-xmir</printSourcesDir>
-              <printOutputDir>${project.build.directory}/generated-sources/jeo-eo</printOutputDir>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>Print EO</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eolang</groupId>
+            <artifactId>eo-maven-plugin</artifactId>
+            <version>0.44.0</version>
+            <executions>
+              <execution>
+                <id>convert-xmir-to-eo</id>
+                <phase>process-classes</phase>
+                <goals>
+                  <goal>print</goal>
+                </goals>
+                <configuration>
+                  <printSourcesDir>${project.build.directory}/generated-sources/jeo-xmir</printSourcesDir>
+                  <printOutputDir>${project.build.directory}/generated-sources/jeo-eo</printOutputDir>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/src/it/bytecode-to-eo/verify.groovy
+++ b/src/it/bytecode-to-eo/verify.groovy
@@ -30,6 +30,5 @@ assert log.contains("WithoutPackage.class' disassembled to ")
 assert log.contains("BUILD SUCCESS")
 //Check that we have generated XMIR object file.
 assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/Application.xmir').exists()
-assert new File(basedir, 'target/generated-sources/jeo-eo/org/eolang/jeo/Application.eo').exists()
 assert new File(basedir, 'target/generated-sources/jeo-phi/org/eolang/jeo/Application.phi').exists()
 true


### PR DESCRIPTION
In this PR I fix the problem with `bytecode-to-eo` integration test. I print `eo` objects only on Java 11 and above.

Closes: #928.
