### PR TITLE
feat(#953): Use `jcabi` Xml Implementation

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
@@ -27,7 +27,6 @@ import com.jcabi.xml.XML;
 import java.nio.file.Path;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.xmir.JcabiXmlDoc;
-import org.eolang.jeo.representation.xmir.NativeXmlDoc;
 import org.eolang.jeo.representation.xmir.XmlDoc;
 import org.eolang.jeo.representation.xmir.XmlNode;
 import org.eolang.jeo.representation.xmir.XmlProgram;

--- a/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
@@ -52,14 +52,9 @@ public final class XmirRepresentation {
     /**
      * Constructor.
      * @param path Path to XML file.
-     * @todo #948:90min Use {@link JcabiXmlDoc} instead of {@link NativeXmlDoc}.
-     *  This class should use {@link JcabiXmlDoc} instead of {@link NativeXmlDoc}
-     *  because it's more human-readable and easier to maintain. However the current
-     *  implementation creates some issues in the integration tests.
-     *  Most probably, we will need to fix them first.
      */
     public XmirRepresentation(final Path path) {
-        this(new NativeXmlDoc(path), path.toAbsolutePath().toString());
+        this(new JcabiXmlDoc(path), path.toAbsolutePath().toString());
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlDoc.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlDoc.java
@@ -41,18 +41,18 @@ public final class JcabiXmlDoc implements XmlDoc {
 
     /**
      * Constructor.
-     * @param doc XML
-     */
-    public JcabiXmlDoc(final XML doc) {
-        this(new JcabiXmlNode(doc.inner().getFirstChild()));
-    }
-
-    /**
-     * Constructor.
      * @param path Path to XML file.
      */
     public JcabiXmlDoc(final Path path) {
         this(JcabiXmlDoc.open(path));
+    }
+
+    /**
+     * Constructor.
+     * @param doc XML
+     */
+    public JcabiXmlDoc(final XML doc) {
+        this(new JcabiXmlNode(doc));
     }
 
     /**
@@ -65,7 +65,7 @@ public final class JcabiXmlDoc implements XmlDoc {
 
     @Override
     public XmlNode root() {
-        return this.doc;
+        return this.doc.child("program");
     }
 
     @Override
@@ -80,9 +80,9 @@ public final class JcabiXmlDoc implements XmlDoc {
      * @checkstyle IllegalCatchCheck (20 lines)
      */
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    private static XmlNode open(final Path path) {
+    private static XML open(final Path path) {
         try {
-            return new JcabiXmlNode(new XMLDocument(path).inner().getFirstChild());
+            return new XMLDocument(path);
         } catch (final FileNotFoundException exception) {
             throw new IllegalStateException(
                 String.format("Can't find file '%s'", path),

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlDoc.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlDoc.java
@@ -88,10 +88,10 @@ public final class JcabiXmlDoc implements XmlDoc {
                 String.format("Can't find file '%s'", path),
                 exception
             );
-        } catch (final Exception broken) {
+        } catch (final RuntimeException broken) {
             throw new IllegalStateException(
                 String.format(
-                    "Can't parse XML from the file '%s'",
+                    "Can't parse Jcabi XML from the file '%s'",
                     path
                 ),
                 broken

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -54,8 +54,8 @@ public final class JcabiXmlNode implements XmlNode {
      * Ctor.
      * @param xml XML string.
      */
-    JcabiXmlNode(final String xml) {
-        this(new XMLDocument(xml).inner().getFirstChild());
+    JcabiXmlNode(final String... xml) {
+        this(new XMLDocument(String.join("\n", xml)).inner().getFirstChild());
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -54,7 +54,7 @@ public final class JcabiXmlNode implements XmlNode {
      * Ctor.
      * @param xml XML string.
      */
-    public JcabiXmlNode(final String xml) {
+    JcabiXmlNode(final String xml) {
         this(new XMLDocument(xml).inner().getFirstChild());
     }
 
@@ -62,7 +62,7 @@ public final class JcabiXmlNode implements XmlNode {
      * Ctor.
      * @param item XML node.
      */
-    public JcabiXmlNode(final Node item) {
+    JcabiXmlNode(final Node item) {
         this(new XMLDocument(item));
     }
 
@@ -70,7 +70,7 @@ public final class JcabiXmlNode implements XmlNode {
      * Ctor.
      * @param root XML document.
      */
-    public JcabiXmlNode(final XML root) {
+    JcabiXmlNode(final XML root) {
         this.doc = root;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -100,6 +100,9 @@ public interface XmlNode {
      */
     boolean hasAttribute(String name, String value);
 
+    /**
+     * Validate the node.
+     */
     void validate();
 
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -24,14 +24,8 @@
 package org.eolang.jeo.representation.xmir;
 
 import com.jcabi.xml.XML;
-import com.jcabi.xml.XMLDocument;
-import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.PrefixedName;
 import org.eolang.jeo.representation.bytecode.BytecodeProgram;
-import org.eolang.jeo.representation.directives.DirectivesClass;
-import org.eolang.jeo.representation.directives.DirectivesMetas;
-import org.eolang.jeo.representation.directives.DirectivesProgram;
-import org.xembly.Xembler;
 
 /**
  * XMIR Program.
@@ -49,7 +43,7 @@ public final class XmlProgram {
      * @param lines Xmir lines.
      */
     public XmlProgram(final String... lines) {
-        this(new XMLDocument(String.join("\n", lines)));
+        this(new JcabiXmlNode(lines));
     }
 
     /**
@@ -57,23 +51,7 @@ public final class XmlProgram {
      * @param xml Raw XMIR.
      */
     public XmlProgram(final XML xml) {
-        this(new NativeXmlNode(xml.inner().getFirstChild()));
-    }
-
-    /**
-     * Constructor.
-     * @param name Class name.
-     */
-    XmlProgram(final ClassName name) {
-        this(
-            new XMLDocument(
-                new Xembler(
-                    new DirectivesProgram(
-                        new DirectivesClass(name), new DirectivesMetas(name)
-                    )
-                ).xmlQuietly()
-            )
-        );
+        this(new JcabiXmlDoc(xml).root());
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/xmir/JcabiXmlDocTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/JcabiXmlDocTest.java
@@ -52,4 +52,16 @@ final class JcabiXmlDocTest {
             org.hamcrest.Matchers.equalTo("1")
         );
     }
+
+    @Test
+    void findsFirstChildInFileWithComment(@TempDir final Path dir) throws IOException {
+        final Path path = dir.resolve("test.xml");
+        Files.write(path, String.format("<!-- Some comment -->%s", JcabiXmlDocTest.XML)
+            .getBytes(StandardCharsets.UTF_8));
+        MatcherAssert.assertThat(
+            "Can't read XML from file",
+            new JcabiXmlDoc(path).root().firstChild(),
+            org.hamcrest.Matchers.equalTo("2")
+        );
+    }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/JcabiXmlDocTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/JcabiXmlDocTest.java
@@ -56,8 +56,11 @@ final class JcabiXmlDocTest {
     @Test
     void findsFirstChildInFileWithComment(@TempDir final Path dir) throws IOException {
         final Path path = dir.resolve("test.xml");
-        Files.write(path, String.format("<!-- Some comment -->%s", JcabiXmlDocTest.XML)
-            .getBytes(StandardCharsets.UTF_8));
+        Files.write(
+            path,
+            String.format("<!-- Some comment -->%s", JcabiXmlDocTest.XML)
+                .getBytes(StandardCharsets.UTF_8)
+        );
         MatcherAssert.assertThat(
             "Can't read XML from file",
             new JcabiXmlDoc(path).root().firstChild(),

--- a/src/test/java/org/eolang/jeo/representation/xmir/JcabiXmlDocTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/JcabiXmlDocTest.java
@@ -40,7 +40,7 @@ final class JcabiXmlDocTest {
     /**
      * Example XML.
      */
-    private static final String XML = "<root><a>1</a><b>2</b></root>";
+    private static final String XML = "<program><o>1</o></program>";
 
     @Test
     void createsFromFile(@TempDir final Path dir) throws IOException {
@@ -48,7 +48,7 @@ final class JcabiXmlDocTest {
         Files.write(path, JcabiXmlDocTest.XML.getBytes(StandardCharsets.UTF_8));
         MatcherAssert.assertThat(
             "Can't read XML from file",
-            new JcabiXmlDoc(path).root().xpath("/root/a/text()").get(0),
+            new JcabiXmlDoc(path).root().xpath("/program/o/text()").get(0),
             org.hamcrest.Matchers.equalTo("1")
         );
     }
@@ -61,7 +61,7 @@ final class JcabiXmlDocTest {
         MatcherAssert.assertThat(
             "Can't read XML from file",
             new JcabiXmlDoc(path).root().firstChild(),
-            org.hamcrest.Matchers.equalTo("2")
+            org.hamcrest.Matchers.equalTo(new JcabiXmlNode("<o>1</o>"))
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlProgramTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlProgramTest.java
@@ -23,6 +23,7 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import com.jcabi.xml.XMLDocument;
 import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.eolang.jeo.representation.bytecode.BytecodeProgram;
@@ -51,7 +52,18 @@ final class XmlProgramTest {
         final String name = "FooBar";
         MatcherAssert.assertThat(
             "Can't convert program to bytecode.",
-            new XmlProgram(new ClassName(pckg, name)).bytecode(),
+            new XmlProgram(
+                new XMLDocument(
+                    new Xembler(
+                        new DirectivesProgram(
+                            new DirectivesClass(new ClassName(pckg, name)),
+                            new DirectivesMetas(
+                                new ClassName(pckg, name)
+                            )
+                        )
+                    ).xmlQuietly()
+                )
+            ).bytecode(),
             Matchers.equalTo(
                 new BytecodeProgram(
                     pckg,


### PR DESCRIPTION
In this PR I switched from `NativeXmlDoc` usage to `JcabiXmlDoc`.

Closes: #953.
