### PR TITLE
feat(#938): Use `objectionary/lints` Before and After `phi/unphi`

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/VerifiedEo.java
+++ b/src/main/java/org/eolang/jeo/representation/VerifiedEo.java
@@ -25,13 +25,7 @@ package org.eolang.jeo.representation;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.stream.Collectors;
-import org.eolang.lints.Defect;
-import org.eolang.lints.Program;
-import org.eolang.lints.Severity;
-import org.eolang.parser.StrictXmir;
+import org.eolang.jeo.representation.xmir.JcabiXmlDoc;
 import org.xembly.Directive;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
@@ -67,26 +61,7 @@ final class VerifiedEo {
      */
     XML asXml() throws ImpossibleModificationException {
         final XML res = new XMLDocument(new Xembler(this.directives).xml());
-        try {
-            final Collection<Defect> defects = new Program(new StrictXmir(res)).defects()
-                .stream()
-                .filter(defect -> defect.severity() == Severity.ERROR)
-                .collect(Collectors.toList());
-            if (!defects.isEmpty()) {
-                throw new IllegalStateException(
-                    String.format(
-                        "EO is incorrect: %s, %n%s%n",
-                        defects,
-                        res
-                    )
-                );
-            }
-        } catch (final IOException exception) {
-            throw new IllegalStateException(
-                String.format("Failed to verify EO: %n%s%n", res),
-                exception
-            );
-        }
+        new JcabiXmlDoc(res).validate();
         return res;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParam.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParam.java
@@ -24,6 +24,7 @@
 package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
+import java.util.Random;
 import org.eolang.jeo.representation.DecodedString;
 import org.objectweb.asm.Type;
 import org.xembly.Directive;
@@ -33,6 +34,11 @@ import org.xembly.Directive;
  * @since 0.6
  */
 public final class DirectivesMethodParam implements Iterable<Directive> {
+
+    /**
+     * Random number generator.
+     */
+    private static final Random RANDOM = new Random();
 
     /**
      * Index of the parameter.
@@ -87,11 +93,12 @@ public final class DirectivesMethodParam implements Iterable<Directive> {
         return new DirectivesJeoObject(
             "param",
             String.format(
-                "param-%s-%s-%d-%d",
+                "param-%s-%s-%d-%d-%d",
                 new DecodedString(this.type.toString()).encode(),
                 this.name,
                 this.access,
-                this.index
+                this.index,
+                DirectivesMethodParam.RANDOM.nextInt()
             ),
             this.annotations
         ).iterator();

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
@@ -61,13 +61,19 @@ final class BytecodeMethodParameterTest {
     private static Stream<Arguments> parameters() {
         return Stream.of(
             Arguments.of(
-                0, Type.INT_TYPE, "/o[contains(@base,'param') and contains(@name,'param-I-arg0-0-0')]"
+                0,
+                Type.INT_TYPE,
+                "/o[contains(@base,'param') and contains(@name,'param-I-arg0-0-0')]"
             ),
             Arguments.of(
-                1, Type.INT_TYPE, "/o[contains(@base,'param') and contains(@name,'param-I-arg1-0-1')]"
+                1,
+                Type.INT_TYPE,
+                "/o[contains(@base,'param') and contains(@name,'param-I-arg1-0-1')]"
             ),
             Arguments.of(
-                2, Type.DOUBLE_TYPE, "/o[contains(@base,'param') and contains(@name,'param-D-arg2-0-2')]"
+                2,
+                Type.DOUBLE_TYPE,
+                "/o[contains(@base,'param') and contains(@name,'param-D-arg2-0-2')]"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
@@ -61,13 +61,13 @@ final class BytecodeMethodParameterTest {
     private static Stream<Arguments> parameters() {
         return Stream.of(
             Arguments.of(
-                0, Type.INT_TYPE, "/o[contains(@base,'param') and @name='param-I-arg0-0-0']"
+                0, Type.INT_TYPE, "/o[contains(@base,'param') and contains(@name,'param-I-arg0-0-0')]"
             ),
             Arguments.of(
-                1, Type.INT_TYPE, "/o[contains(@base,'param') and @name='param-I-arg1-0-1']"
+                1, Type.INT_TYPE, "/o[contains(@base,'param') and contains(@name,'param-I-arg1-0-1')]"
             ),
             Arguments.of(
-                2, Type.DOUBLE_TYPE, "/o[contains(@base,'param') and @name='param-D-arg2-0-2']"
+                2, Type.DOUBLE_TYPE, "/o[contains(@base,'param') and contains(@name,'param-D-arg2-0-2')]"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParametersTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParametersTest.java
@@ -48,8 +48,8 @@ final class BytecodeMethodParametersTest {
             ).xml(),
             XhtmlMatchers.hasXPaths(
                 "/o[contains(@base,'params')]",
-                "/o[contains(@base,'params')]/o[contains(@base,'param') and @name='param-I-arg0-0-0']",
-                "/o[contains(@base,'params')]/o[contains(@base,'param') and @name='param-I-arg1-0-1']"
+                "/o[contains(@base,'params')]/o[contains(@base,'param') and contains(@name,'param-I-arg0-0-0')]",
+                "/o[contains(@base,'params')]/o[contains(@base,'param') and contains(@name,'param-I-arg1-0-1')]"
             )
         );
     }


### PR DESCRIPTION
In this PR I use `objectionary/lints` to verify `xmir` after `dissasseble` phase and then after `phi/unphi/unroll` phases.

Related to: #938
