### PR TITLE
feat(#958): Upgrade `objectionary/lints` Library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>lints</artifactId>
-      <version>0.0.29</version>
+      <version>0.0.31</version>
     </dependency>
     <dependency>
       <groupId>org.cactoos</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>lints</artifactId>
-      <version>0.0.26</version>
+      <version>0.0.29</version>
     </dependency>
     <dependency>
       <groupId>org.cactoos</groupId>

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation.xmir;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -157,28 +157,21 @@ public final class JcabiXmlNode implements XmlNode {
 
     @Override
     public void validate() {
-        try {
-            // @checkstyle MethodBodyCommentsCheck (4 lines)
-            // @todo #939:60min Fix All The Warnings in the EO Representation.
-            //  Here we just catch only the errors in the EO representation.
-            //  We need to fix all the warnings in the EO representation as well.
-            final Collection<Defect> defects = new Program(new StrictXmir(this.doc)).defects()
-                .stream()
-                .filter(defect -> defect.severity() == Severity.ERROR)
-                .collect(Collectors.toList());
-            if (!defects.isEmpty()) {
-                throw new IllegalStateException(
-                    String.format(
-                        "XMIR is incorrect: %s, %n%s%n",
-                        defects,
-                        this.doc
-                    )
-                );
-            }
-        } catch (final IOException exception) {
+        // @checkstyle MethodBodyCommentsCheck (4 lines)
+        // @todo #939:60min Fix All The Warnings in the EO Representation.
+        //  Here we just catch only the errors in the EO representation.
+        //  We need to fix all the warnings in the EO representation as well.
+        final Collection<Defect> defects = new Program(new StrictXmir(this.doc)).defects()
+            .stream()
+            .filter(defect -> defect.severity() == Severity.ERROR)
+            .collect(Collectors.toList());
+        if (!defects.isEmpty()) {
             throw new IllegalStateException(
-                String.format("Failed to verify XMIR document: %n%s%n", this.doc),
-                exception
+                String.format(
+                    "XMIR is incorrect: %s, %n%s%n",
+                    defects,
+                    this.doc
+                )
             );
         }
     }


### PR DESCRIPTION
In this PR I have upgradeed `objectionary/lints` library up to `0.0.31` version.

Closes: #958.
