### PR TITLE
feat(#967): Fix the Bug Realted to Absent `metas`

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
@@ -83,7 +83,10 @@ public final class XmirRepresentation {
     public String name() {
         final XmlNode root = this.xml.root();
         return new ClassName(
-            root.xpath("/program/metas/meta[head[text()]='package']/tail/text()").get(0),
+            root.xpath("/program/metas/meta[head[text()]='package']/tail/text()")
+                .stream()
+                .findFirst()
+                .orElse(""),
             root.xpath("/program/@name").get(0)
         ).full();
     }

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -25,6 +25,8 @@ package org.eolang.jeo.representation;
 
 import com.jcabi.log.Logger;
 import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -38,6 +40,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Node;
+import org.xembly.Directives;
+import org.xembly.Xembler;
 
 /**
  * Test case for {@link XmirRepresentation}.
@@ -76,6 +81,27 @@ final class XmirRepresentationTest {
             actual,
             Matchers.equalTo(expected)
         );
+    }
+
+    @Test
+    void retrievesEmptyPackageWhenXmirWithoutMetas() {
+        final String actual = new XmirRepresentation(
+            new XMLDocument(
+                new Xembler(new Directives().xpath("/program/metas").remove())
+                    .applyQuietly(new BytecodeProgram(new BytecodeClass("Math")).xml().inner())
+            )
+        ).name();
+        final String expected = "j$Math";
+        MatcherAssert.assertThat(
+            String.format(
+                "The name of the class (without package) is not retrieved correctly, we expected '%s', but got '%s'",
+                expected,
+                actual
+            ),
+            actual,
+            Matchers.equalTo(expected)
+        );
+
     }
 
     @Test

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -25,7 +25,6 @@ package org.eolang.jeo.representation;
 
 import com.jcabi.log.Logger;
 import com.jcabi.matchers.XhtmlMatchers;
-import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -40,7 +39,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.w3c.dom.Node;
 import org.xembly.Directives;
 import org.xembly.Xembler;
 
@@ -101,7 +99,6 @@ final class XmirRepresentationTest {
             actual,
             Matchers.equalTo(expected)
         );
-
     }
 
     @Test


### PR DESCRIPTION
In this PR I fixed the bug related to a class name retrieval. Now, if the `metas` section is absent, we return empty package instead of throwing a runtime exception.

Related to #967.
