### PR TITLE
feat(#965): Fix All XMIR Offences Related to the ’name-outside-of-abstract-object’ Check

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
-      <version>0.50.0</version>
+      <version>0.50.1</version>
     </dependency>
     <dependency>
       <groupId>com.github.volodya-lombrozo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@ SOFTWARE.
   <groupId>org.eolang</groupId>
   <artifactId>jeo-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>1.0-SNAPSHOT</version>
   <name>jeo</name>
   <url>https://objectionary.github.io/jeo-maven-plugin</url>
   <description>Optimisation of Java Bytecode via EOLANG</description>

--- a/src/it/annotations/pom.xml
+++ b/src/it/annotations/pom.xml
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/annotations/verify.groovy
+++ b/src/it/annotations/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/bytecode-to-eo/pom.xml
+++ b/src/it/bytecode-to-eo/pom.xml
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/bytecode-to-eo/verify.groovy
+++ b/src/it/bytecode-to-eo/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/custom-transformations/pom.xml
+++ b/src/it/custom-transformations/pom.xml
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/custom-transformations/verify.groovy
+++ b/src/it/custom-transformations/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/exceptions/pom.xml
+++ b/src/it/exceptions/pom.xml
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/exceptions/src/main/java/org/eolang/jeo/exceptions/Application.java
+++ b/src/it/exceptions/src/main/java/org/eolang/jeo/exceptions/Application.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/exceptions/src/main/java/org/eolang/jeo/exceptions/MyResource.java
+++ b/src/it/exceptions/src/main/java/org/eolang/jeo/exceptions/MyResource.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/exceptions/src/main/java/org/eolang/jeo/exceptions/ResourceWithException.java
+++ b/src/it/exceptions/src/main/java/org/eolang/jeo/exceptions/ResourceWithException.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/exceptions/verify.groovy
+++ b/src/it/exceptions/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/generics/pom.xml
+++ b/src/it/generics/pom.xml
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/generics/verify.groovy
+++ b/src/it/generics/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/jna/invoker.properties
+++ b/src/it/jna/invoker.properties
@@ -1,7 +1,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (c) 2016-2024 Objectionary.com
+# Copyright (c) 2016-2025 Objectionary.com
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/src/it/jna/pom.xml
+++ b/src/it/jna/pom.xml
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/jna/src/main/java/org/eolang/hone/App.java
+++ b/src/it/jna/src/main/java/org/eolang/hone/App.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/jna/src/main/java/org/eolang/hone/JnaPrinter.java
+++ b/src/it/jna/src/main/java/org/eolang/hone/JnaPrinter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/jna/verify.groovy
+++ b/src/it/jna/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/phi-unphi/invoker.properties
+++ b/src/it/phi-unphi/invoker.properties
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2016-2024 Objectionary.com
+# Copyright (c) 2016-2025 Objectionary.com
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/src/it/phi-unphi/pom.xml
+++ b/src/it/phi-unphi/pom.xml
@@ -100,7 +100,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.50.0</version>
+        <version>0.50.1</version>
         <executions>
           <execution>
             <id>xmir-to-phi</id>

--- a/src/it/phi-unphi/pom.xml
+++ b/src/it/phi-unphi/pom.xml
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/phi-unphi/src/main/java/org/eolang/hone/App.java
+++ b/src/it/phi-unphi/src/main/java/org/eolang/hone/App.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/phi-unphi/src/main/java/org/eolang/hone/mess/A.java
+++ b/src/it/phi-unphi/src/main/java/org/eolang/hone/mess/A.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/phi-unphi/src/main/java/org/eolang/hone/mess/B.java
+++ b/src/it/phi-unphi/src/main/java/org/eolang/hone/mess/B.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/phi-unphi/src/main/java/org/eolang/hone/mess/C.java
+++ b/src/it/phi-unphi/src/main/java/org/eolang/hone/mess/C.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/phi-unphi/src/main/java/org/eolang/hone/mess/D.java
+++ b/src/it/phi-unphi/src/main/java/org/eolang/hone/mess/D.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/phi-unphi/src/main/java/org/eolang/hone/param/Parameter.java
+++ b/src/it/phi-unphi/src/main/java/org/eolang/hone/param/Parameter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/phi-unphi/verify.groovy
+++ b/src/it/phi-unphi/verify.groovy
@@ -38,10 +38,8 @@ private String assertionMessage(String message) {
 
 private void generateGitHubIssue() {
     new File(basedir, 'build.log').text
-    copy('target/generated-sources/jeo-disassemble/org/eolang/hone/App.xmir', 'App.xmir.disassemble.txt')
-    copy('target/generated-sources/eo-phi/org/eolang/hone/App.phi', 'App.phi.txt')
-    copy('target/generated-sources/eo-unphi/org/eolang/hone/App.xmir', 'App.xmir.unphi.txt')
-    copy('target/generated-sources/jeo-unroll/org/eolang/hone/App.xmir', 'App.xmir.unroll.txt')
+    copyAll('org/eolang/hone/App')
+    copyAll('org/eolang/hone/param/Parameter')
     def issue = new File(basedir, "issue.md")
     issue.text = '''I run the following [integration test](https://github.com/objectionary/jeo-maven-plugin/tree/master/src/it/phi-unphi):
  
@@ -89,6 +87,14 @@ gh issue create \\
     def file = new File(basedir, "create_issue.sh")
     file.text = bashScript
     println "Bash script generated: file://${basedir}/create_issue.sh"
+}
+
+private void copyAll(final String subpath) {
+    def name = subpath.tokenize('/').last()
+    copy('target/generated-sources/jeo-disassemble/' + subpath + ".xmir", name + '.xmir.disassemble.txt')
+    copy('target/generated-sources/eo-phi/' + subpath + ".phi", name + '.phi.txt')
+    copy('target/generated-sources/eo-unphi/' + subpath + '.xmir', name + '.xmir.unphi.txt')
+    copy('target/generated-sources/jeo-unroll/' + subpath + '.xmir', name + '.xmir.unroll.txt')
 }
 
 private void copy(final String source, final String destination) {

--- a/src/it/phi-unphi/verify.groovy
+++ b/src/it/phi-unphi/verify.groovy
@@ -3,7 +3,7 @@ import java.nio.file.Files
 /*
  * MIT License
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/spring-fat/src/main/java/org/eolang/jeo/spring/Application.java
+++ b/src/it/spring-fat/src/main/java/org/eolang/jeo/spring/Application.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/spring-fat/src/main/java/org/eolang/jeo/spring/Receptionist.java
+++ b/src/it/spring-fat/src/main/java/org/eolang/jeo/spring/Receptionist.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/spring-fat/src/test/java/org/eolang/jeo/spring/ApplicationTest.java
+++ b/src/it/spring-fat/src/test/java/org/eolang/jeo/spring/ApplicationTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/spring-fat/verify.groovy
+++ b/src/it/spring-fat/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/spring/src/main/java/org/eolang/jeo/spring/Application.java
+++ b/src/it/spring/src/main/java/org/eolang/jeo/spring/Application.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/spring/src/main/java/org/eolang/jeo/spring/Receptionist.java
+++ b/src/it/spring/src/main/java/org/eolang/jeo/spring/Receptionist.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/spring/verify.groovy
+++ b/src/it/spring/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/takes/pom.xml
+++ b/src/it/takes/pom.xml
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/takes/src/main/java/org/eolang/jeo/takes/Application.java
+++ b/src/it/takes/src/main/java/org/eolang/jeo/takes/Application.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/takes/verify.groovy
+++ b/src/it/takes/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/variable-names/pom.xml
+++ b/src/it/variable-names/pom.xml
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/it/variable-names/src/main/java/org/eolang/jeo/variables/Application.java
+++ b/src/it/variable-names/src/main/java/org/eolang/jeo/variables/Application.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/it/variable-names/verify.groovy
+++ b/src/it/variable-names/verify.groovy
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/AssembleMojo.java
+++ b/src/main/java/org/eolang/jeo/AssembleMojo.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/Assembler.java
+++ b/src/main/java/org/eolang/jeo/Assembler.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/Assembling.java
+++ b/src/main/java/org/eolang/jeo/Assembling.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/BytecodeClasses.java
+++ b/src/main/java/org/eolang/jeo/BytecodeClasses.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/Caching.java
+++ b/src/main/java/org/eolang/jeo/Caching.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/Disassembler.java
+++ b/src/main/java/org/eolang/jeo/Disassembler.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/Disassembling.java
+++ b/src/main/java/org/eolang/jeo/Disassembling.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/JeoClassLoader.java
+++ b/src/main/java/org/eolang/jeo/JeoClassLoader.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/Logging.java
+++ b/src/main/java/org/eolang/jeo/Logging.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/ParallelTranslator.java
+++ b/src/main/java/org/eolang/jeo/ParallelTranslator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/PluginStartup.java
+++ b/src/main/java/org/eolang/jeo/PluginStartup.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/Summary.java
+++ b/src/main/java/org/eolang/jeo/Summary.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/Transformation.java
+++ b/src/main/java/org/eolang/jeo/Transformation.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/Translator.java
+++ b/src/main/java/org/eolang/jeo/Translator.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/Unroll.java
+++ b/src/main/java/org/eolang/jeo/Unroll.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/UnrollMojo.java
+++ b/src/main/java/org/eolang/jeo/UnrollMojo.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/Unroller.java
+++ b/src/main/java/org/eolang/jeo/Unroller.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/XmirFiles.java
+++ b/src/main/java/org/eolang/jeo/XmirFiles.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/matchers/SameXml.java
+++ b/src/main/java/org/eolang/jeo/matchers/SameXml.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/matchers/WithoutLines.java
+++ b/src/main/java/org/eolang/jeo/matchers/WithoutLines.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/matchers/package-info.java
+++ b/src/main/java/org/eolang/jeo/matchers/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/package-info.java
+++ b/src/main/java/org/eolang/jeo/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/BytecodeListing.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeListing.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/CanonicalXmir.java
+++ b/src/main/java/org/eolang/jeo/representation/CanonicalXmir.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/CanonicalXmir.java
+++ b/src/main/java/org/eolang/jeo/representation/CanonicalXmir.java
@@ -170,8 +170,8 @@ public final class CanonicalXmir {
                     ),
                     new TrClasspath<Shift>(
                         "/org/eolang/parser/remove-cuts.xsl",
-                        "/org/eolang/parser/add-default-package.xsl",
-                        "/org/eolang/parser/explicit-data.xsl"
+                        "/org/eolang/parser/shake/add-default-package.xsl",
+                        "/org/eolang/parser/shake/explicit-data.xsl"
                     ).back()
                 ),
                 CanonicalXmir.class,

--- a/src/main/java/org/eolang/jeo/representation/ClassName.java
+++ b/src/main/java/org/eolang/jeo/representation/ClassName.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/ClassNameVisitor.java
+++ b/src/main/java/org/eolang/jeo/representation/ClassNameVisitor.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/DecodedString.java
+++ b/src/main/java/org/eolang/jeo/representation/DecodedString.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/DefaultVersion.java
+++ b/src/main/java/org/eolang/jeo/representation/DefaultVersion.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/EncodedString.java
+++ b/src/main/java/org/eolang/jeo/representation/EncodedString.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/MeasuredEo.java
+++ b/src/main/java/org/eolang/jeo/representation/MeasuredEo.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/MethodName.java
+++ b/src/main/java/org/eolang/jeo/representation/MethodName.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/PrefixedName.java
+++ b/src/main/java/org/eolang/jeo/representation/PrefixedName.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/Signature.java
+++ b/src/main/java/org/eolang/jeo/representation/Signature.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmAnnotationProperty.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmAnnotationProperty.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmAnnotations.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmClass.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmField.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmField.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmInstruction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmLabels.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmLabels.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmMethodParameters.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmMethodParameters.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmProgram.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/asm/DisassembleMode.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DisassembleMode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/asm/package-info.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/Bytecode.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/Bytecode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotationAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotationAnnotationValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotationValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotations.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeArrayAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeArrayAnnotationValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttribute.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttributes.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClassProperties.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeDefaultValue.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeDefaultValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeEntry.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeEnumAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeEnumAnnotationValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeField.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeField.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeFrame.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeFrame.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeHandler.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeHandler.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabel.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLine.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLine.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMaxs.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMaxs.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodBuilder.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodBuilder.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameter.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameters.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameters.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodePlainAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodePlainAnnotationValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeProgram.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlock.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/CustomClassWriter.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/CustomClassWriter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/InnerClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/InnerClass.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/InstructionsFlow.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/InstructionsFlow.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/LocalVariable.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/LocalVariable.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/MaxLocals.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/MaxLocals.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/MaxStack.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/MaxStack.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/UnrecognizedOpcode.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/UnrecognizedOpcode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/bytecode/package-info.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotationAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotationAnnotationValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotations.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesArrayAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesArrayAnnotationValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesBytes.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesBytes.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -173,7 +173,7 @@ public final class DirectivesClass implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        return new DirectivesJeoObject(
+        return new DirectivesGlobalObject(
             "class",
             this.name.name(),
             this.properties,

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesComment.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesComment.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesDefaultValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesDefaultValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesEnumAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesEnumAnnotationValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesEoObject.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesEoObject.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesFrame.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesFrame.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesGlobalObject.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesGlobalObject.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,6 @@
  */
 package org.eolang.jeo.representation.directives;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -32,11 +31,11 @@ import org.xembly.Directive;
 import org.xembly.Directives;
 
 /**
- * Directives that represent a pure EO object.
- * Similar to {@link DirectivesJeoObject}, but for objects that are parts of the EO language.
- * @since 0.6
+ * Directives that represent a global object.
+ * Similar to {@link DirectivesJeoObject}, but instead of 'as' attribute, it has 'name' attribute.
+ * @since 0.8
  */
-public final class DirectivesEoObject implements Iterable<Directive> {
+public final class DirectivesGlobalObject implements Iterable<Directive> {
 
     /**
      * The base of the object.
@@ -56,19 +55,13 @@ public final class DirectivesEoObject implements Iterable<Directive> {
     /**
      * Constructor.
      * @param base The base of the object.
-     */
-    public DirectivesEoObject(final String base) {
-        this(base, "", new ArrayList<>(0));
-    }
-
-    /**
-     * Constructor.
-     * @param base The base of the object.
      * @param name The name of the object.
      * @param inner Inner components.
      */
     @SafeVarargs
-    DirectivesEoObject(final String base, final String name, final Iterable<Directive>... inner) {
+    public DirectivesGlobalObject(
+        final String base, final String name, final Iterable<Directive>... inner
+    ) {
         this(base, name, Arrays.stream(inner).map(Directives::new).collect(Collectors.toList()));
     }
 
@@ -78,7 +71,19 @@ public final class DirectivesEoObject implements Iterable<Directive> {
      * @param name The name of the object.
      * @param inner Inner components.
      */
-    DirectivesEoObject(final String base, final String name, final List<Directives> inner) {
+    public DirectivesGlobalObject(final String base, final String name, final Directives... inner) {
+        this(base, name, Arrays.asList(inner));
+    }
+
+    /**
+     * Constructor.
+     * @param base The base of the object.
+     * @param name The name of the object.
+     * @param inner Inner components.
+     */
+    public DirectivesGlobalObject(
+        final String base, final String name, final List<Directives> inner
+    ) {
         this.base = base;
         this.name = name;
         this.inner = inner;
@@ -87,12 +92,13 @@ public final class DirectivesEoObject implements Iterable<Directive> {
     @Override
     public Iterator<Directive> iterator() {
         final Directives directives = new Directives().add("o")
-            .attr("base", new EoFqn(this.base).fqn());
+            .attr("base", new JeoFqn(this.base).fqn());
         if (!this.name.isEmpty()) {
-            directives.attr("as", this.name);
+            directives.attr("name", this.name);
         }
         return directives
             .append(this.inner.stream().reduce(new Directives(), Directives::append))
-            .up().iterator();
+            .up()
+            .iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesHandle.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesHandle.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesJeoObject.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesJeoObject.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesJeoObject.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesJeoObject.java
@@ -128,7 +128,7 @@ public final class DirectivesJeoObject implements Iterable<Directive> {
         final Directives directives = new Directives().add("o")
             .attr("base", new JeoFqn(this.base).fqn());
         if (!this.name.isEmpty()) {
-            directives.attr("name", this.name);
+            directives.attr("as", this.name);
         }
         return directives
             .append(this.inner.stream().reduce(new Directives(), Directives::append))

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesLabel.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMaxs.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMaxs.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParam.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParam.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesOperand.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesOperand.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesPlainAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesPlainAnnotationValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesProgram.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -142,7 +142,7 @@ public final class DirectivesProgram implements Iterable<Directive> {
             "\n",
             "The MIT License (MIT)",
             "",
-            "Copyright (c) 2016-2024 Objectionary.com",
+            "Copyright (c) 2016-2025 Objectionary.com",
             "",
             "Permission is hereby granted, free of charge, to any person obtaining a copy",
             "of this software and associated documentation files (the \"Software\"), to deal",

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesSeq.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesSeq.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesTryCatch.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesTryCatch.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValues.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValues.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/EoFqn.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/EoFqn.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/JeoFqn.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/JeoFqn.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/OpcodeName.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/OpcodeName.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/directives/package-info.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/package-info.java
+++ b/src/main/java/org/eolang/jeo/representation/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlDoc.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlDoc.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -164,7 +164,7 @@ public final class JcabiXmlNode implements XmlNode {
         final Collection<String> ignore = new HashSet<>(
             Arrays.asList(
                 "mandatory-home",
-                "name-outside-of-abstract-object",
+//                "name-outside-of-abstract-object",
                 "empty-object",
                 "incorrect-package",
                 "object-does-not-match-filename"

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -164,7 +164,6 @@ public final class JcabiXmlNode implements XmlNode {
         final Collection<String> ignore = new HashSet<>(
             Arrays.asList(
                 "mandatory-home",
-//                "name-outside-of-abstract-object",
                 "empty-object",
                 "incorrect-package",
                 "object-does-not-match-filename"

--- a/src/main/java/org/eolang/jeo/representation/xmir/NativeXmlDoc.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/NativeXmlDoc.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/NativeXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/NativeXmlNode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/Parameter.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/Parameter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/ParsingException.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/ParsingException.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotation.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotationValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotations.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttributes.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlBytecodeEntry.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -133,7 +133,7 @@ public final class XmlClass {
      */
     private Optional<XmlAnnotations> annotations() {
         return this.node.children()
-            .filter(o -> o.hasAttribute("name", "annotations"))
+            .filter(o -> o.hasAttribute("as", "annotations"))
             .findFirst()
             .map(XmlAnnotations::new);
     }
@@ -175,7 +175,7 @@ public final class XmlClass {
      */
     private Optional<XmlAttributes> attributes() {
         return this.node.children()
-            .filter(o -> o.hasAttribute("name", "attributes"))
+            .filter(o -> o.hasAttribute("as", "attributes"))
             .findFirst()
             .map(XmlAttributes::new);
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
@@ -72,7 +72,7 @@ public final class XmlClassProperties {
      * @return Access modifiers.
      */
     private int access() {
-        return new XmlValue(this.clazz.child("name", "access")).integer();
+        return new XmlValue(this.clazz.child("as", "access")).integer();
     }
 
     /**
@@ -130,7 +130,7 @@ public final class XmlClassProperties {
      * @return Child node.
      */
     private Optional<XmlNode> child(final String name) {
-        return this.clazz.optchild("name", name);
+        return this.clazz.optchild("as", name);
     }
 
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlDefaultValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlDefaultValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlDoc.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlDoc.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -71,7 +71,7 @@ public class XmlField {
      */
     private String name() {
         return new PrefixedName(
-            this.node.attribute("name").orElseThrow(
+            this.node.attribute("as").orElseThrow(
                 () -> new IllegalStateException(
                     String.format("Can't find field name in '%s'", this.node)
                 )
@@ -124,7 +124,7 @@ public class XmlField {
      * @return Annotations.
      */
     private Optional<XmlAnnotations> annotations() {
-        return this.node.optchild("name", String.format("annotations-%s", this.name()))
+        return this.node.optchild("as", String.format("annotations-%s", this.name()))
             .map(XmlAnnotations::new);
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlFrame.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlFrame.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlHandler.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlHandler.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLocalVariable.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLocalVariable.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMaxs.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMaxs.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -158,7 +158,7 @@ public final class XmlMethod {
      */
     private BytecodeAttributes attrs() {
         return this.node.children()
-            .filter(element -> element.hasAttribute("name", "local-variable-table"))
+            .filter(element -> element.hasAttribute("as", "local-variable-table"))
             .findFirst()
             .map(XmlAttributes::new)
             .map(XmlAttributes::attributes)
@@ -173,7 +173,7 @@ public final class XmlMethod {
         return new MethodName(
             new PrefixedName(
                 new Signature(
-                    this.node.attribute("name")
+                    this.node.attribute("as")
                         .orElseThrow(
                             () -> new IllegalStateException(
                                 "Method 'name' attribute is not present"
@@ -189,7 +189,7 @@ public final class XmlMethod {
      * @return Instructions.
      */
     private List<XmlBytecodeEntry> instructions() {
-        return this.node.child("name", "body")
+        return this.node.child("as", "body")
             .children()
             .filter(element -> element.attribute("base").isPresent())
             .map(XmlMethod::toEntry)
@@ -293,7 +293,7 @@ public final class XmlMethod {
     private List<XmlTryCatchEntry> trycatchEntries() {
         return this.node.children()
             .filter(
-                element -> element.attribute("name")
+                element -> element.attribute("as")
                     .map(s -> s.contains("trycatchblocks"))
                     .orElse(false))
             .flatMap(XmlNode::children)
@@ -308,7 +308,7 @@ public final class XmlMethod {
      */
     private BytecodeAnnotations annotations() {
         return this.node.children()
-            .filter(element -> element.hasAttribute("name", "annotations"))
+            .filter(element -> element.hasAttribute("as", "annotations"))
             .findFirst()
             .map(XmlAnnotations::new)
             .map(XmlAnnotations::bytecode)

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlOperand.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlOperand.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java
@@ -100,7 +100,7 @@ public final class XmlParam {
     private BytecodeAnnotations annotations() {
         return this.root.children()
             .filter(
-                node -> node.attribute("name")
+                node -> node.attribute("as")
                     .map(name -> name.startsWith("param-annotations-"))
                     .orElse(false)
             )
@@ -126,7 +126,7 @@ public final class XmlParam {
      * @return Name attribute.
      */
     private String name() {
-        return this.root.attribute("name").orElseThrow(
+        return this.root.attribute("as").orElseThrow(
             () -> new IllegalStateException(
                 String.format("'name' attribute is not present in xml param %n%s%n", this.root)
             )

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlParams.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlParams.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlProgram.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/org/eolang/jeo/representation/xmir/package-info.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/org/eolang/parser/add-cuts.xsl
+++ b/src/main/resources/org/eolang/parser/add-cuts.xsl
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/org/eolang/parser/add-refs.xsl
+++ b/src/main/resources/org/eolang/parser/add-refs.xsl
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/org/eolang/parser/remove-cuts.xsl
+++ b/src/main/resources/org/eolang/parser/remove-cuts.xsl
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/org/eolang/parser/roll-bases.xsl
+++ b/src/main/resources/org/eolang/parser/roll-bases.xsl
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/org/eolang/parser/vars-float-down.xsl
+++ b/src/main/resources/org/eolang/parser/vars-float-down.xsl
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/org/eolang/parser/wrap-method-calls.xsl
+++ b/src/main/resources/org/eolang/parser/wrap-method-calls.xsl
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -2,7 +2,7 @@
 <!--
 The MIT License (MIT)
 
-Copyright (c) 2016-2024 Objectionary.com
+Copyright (c) 2016-2025 Objectionary.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/it/EoSource.java
+++ b/src/test/java/it/EoSource.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/it/JavaSourceClass.java
+++ b/src/test/java/it/JavaSourceClass.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/it/JavaSourceCompilationIT.java
+++ b/src/test/java/it/JavaSourceCompilationIT.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/it/JavaToEoTest.java
+++ b/src/test/java/it/JavaToEoTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/it/package-info.java
+++ b/src/test/java/it/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/CachingTest.java
+++ b/src/test/java/org/eolang/jeo/CachingTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/ParallelTranslatorTest.java
+++ b/src/test/java/org/eolang/jeo/ParallelTranslatorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/PluginStartupTest.java
+++ b/src/test/java/org/eolang/jeo/PluginStartupTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/XmirFilesTest.java
+++ b/src/test/java/org/eolang/jeo/XmirFilesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/matchers/SameXmlTest.java
+++ b/src/test/java/org/eolang/jeo/matchers/SameXmlTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/matchers/WithoutLinesTest.java
+++ b/src/test/java/org/eolang/jeo/matchers/WithoutLinesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/matchers/package-info.java
+++ b/src/test/java/org/eolang/jeo/matchers/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/package-info.java
+++ b/src/test/java/org/eolang/jeo/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/BytecodeListingTest.java
+++ b/src/test/java/org/eolang/jeo/representation/BytecodeListingTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/CanonicalXmirTest.java
+++ b/src/test/java/org/eolang/jeo/representation/CanonicalXmirTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/ClassNameVisitorTest.java
+++ b/src/test/java/org/eolang/jeo/representation/ClassNameVisitorTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/DecodedStringTest.java
+++ b/src/test/java/org/eolang/jeo/representation/DecodedStringTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/DisassemblerTest.java
+++ b/src/test/java/org/eolang/jeo/representation/DisassemblerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/EncodedStringTest.java
+++ b/src/test/java/org/eolang/jeo/representation/EncodedStringTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/MethodNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/MethodNameTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/PrefixedNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/PrefixedNameTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/SignatureTest.java
+++ b/src/test/java/org/eolang/jeo/representation/SignatureTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/asm/AsmLabelsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/AsmLabelsTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/asm/AsmProgramTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/AsmProgramTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/asm/package-info.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
@@ -63,17 +63,17 @@ final class BytecodeMethodParameterTest {
             Arguments.of(
                 0,
                 Type.INT_TYPE,
-                "/o[contains(@base,'param') and contains(@name,'param-I-arg0-0-0')]"
+                "/o[contains(@base,'param') and contains(@as,'param-I-arg0-0-0')]"
             ),
             Arguments.of(
                 1,
                 Type.INT_TYPE,
-                "/o[contains(@base,'param') and contains(@name,'param-I-arg1-0-1')]"
+                "/o[contains(@base,'param') and contains(@as,'param-I-arg1-0-1')]"
             ),
             Arguments.of(
                 2,
                 Type.DOUBLE_TYPE,
-                "/o[contains(@base,'param') and contains(@name,'param-D-arg2-0-2')]"
+                "/o[contains(@base,'param') and contains(@as,'param-D-arg2-0-2')]"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParametersTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParametersTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParametersTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParametersTest.java
@@ -48,8 +48,8 @@ final class BytecodeMethodParametersTest {
             ).xml(),
             XhtmlMatchers.hasXPaths(
                 "/o[contains(@base,'params')]",
-                "/o[contains(@base,'params')]/o[contains(@base,'param') and contains(@name,'param-I-arg0-0-0')]",
-                "/o[contains(@base,'params')]/o[contains(@base,'param') and contains(@name,'param-I-arg1-0-1')]"
+                "/o[contains(@base,'params')]/o[contains(@base,'param') and contains(@as,'param-I-arg0-0-0')]",
+                "/o[contains(@base,'params')]/o[contains(@base,'param') and contains(@as,'param-I-arg1-0-1')]"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -370,7 +370,7 @@ final class BytecodeMethodTest {
             "We expect that method without try-catch block doesn't contain try-catch directives.",
             new BytecodeProgram(new BytecodeClass().helloWorldMethod()).xml().toString(),
             XhtmlMatchers.hasXPath(
-                ".//o[contains(@base,'seq.of0') and contains(@name,'trycatchblocks-main')]"
+                ".//o[contains(@base,'seq.of0') and contains(@as,'trycatchblocks-main')]"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeProgramTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeProgramTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeValueTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/bytecode/package-info.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationAnnotationValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationAnnotationValueTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java
@@ -41,7 +41,7 @@ final class DirectivesAnnotationsTest {
             "Must return empty directives if no annotations",
             new Xembler(new DirectivesAnnotations()).xml(),
             XhtmlMatchers.hasXPaths(
-                "/o[contains(@base,'jeo.seq.of0') and contains(@name,'annotations')]"
+                "/o[contains(@base,'jeo.seq.of0') and contains(@as,'annotations')]"
             )
         );
     }
@@ -55,13 +55,13 @@ final class DirectivesAnnotationsTest {
                 new DirectivesAnnotations().add(new DirectivesAnnotation(annotation, true))
             ).xml(),
             XhtmlMatchers.hasXPaths(
-                "/o[contains(@base,'seq.of1') and contains(@name,'annotations')]/o",
+                "/o[contains(@base,'seq.of1') and contains(@as,'annotations')]/o",
                 String.format(
-                    "/o[contains(@base,'seq.of1') and contains(@name,'annotations')]/o/o[1][contains(@base,'string')]/o[text()='%s']",
+                    "/o[contains(@base,'seq.of1') and contains(@as,'annotations')]/o/o[1][contains(@base,'string')]/o[text()='%s']",
                     new DirectivesValue(annotation).hex()
                 ),
                 String.format(
-                    "/o[contains(@base,'seq.of1') and contains(@name,'annotations')]/o/o[2][contains(@base,'bool')]/o[text()='%s']",
+                    "/o[contains(@base,'seq.of1') and contains(@as,'annotations')]/o/o[2][contains(@base,'bool')]/o[text()='%s']",
                     new DirectivesValue(true).hex()
                 )
             )

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesArrayAnnotationValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesArrayAnnotationValueTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAttributeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAttributeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAttributesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAttributesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAttributesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAttributesTest.java
@@ -46,7 +46,7 @@ final class DirectivesAttributesTest {
                 )
             ).xml(),
             XhtmlMatchers.hasXPaths(
-                "./o[contains(@name, 'attributes') and contains(@base, 'seq.of2')]",
+                "./o[contains(@as, 'attributes') and contains(@base, 'seq.of2')]",
                 "./o[contains(@base, 'seq.of2')]/o[contains(@base, 'first')]",
                 "./o[contains(@base, 'seq.of2')]/o[contains(@base, 'second')]"
             )

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassPropertiesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassPropertiesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassPropertiesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassPropertiesTest.java
@@ -53,11 +53,11 @@ final class DirectivesClassPropertiesTest {
                     ).up()
             ).xml(),
             XhtmlMatchers.hasXPaths(
-                "/o/o[contains(@base,'jeo.int') and contains(@name,'version')]",
-                "/o/o[contains(@base,'jeo.int') and contains(@name,'access')]",
-                "/o/o[contains(@base,'org.eolang.string') and contains(@name,'signature')]",
-                "/o/o[contains(@base,'org.eolang.string') and contains(@name,'supername')]",
-                "/o/o[contains(@base,'jeo.seq.of1') and contains(@name,'interfaces')]"
+                "/o/o[contains(@base,'jeo.int') and contains(@as,'version')]",
+                "/o/o[contains(@base,'jeo.int') and contains(@as,'access')]",
+                "/o/o[contains(@base,'org.eolang.string') and contains(@as,'signature')]",
+                "/o/o[contains(@base,'org.eolang.string') and contains(@as,'supername')]",
+                "/o/o[contains(@base,'jeo.seq.of1') and contains(@as,'interfaces')]"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -53,13 +53,13 @@ final class DirectivesClassTest {
             ).xml(),
             XhtmlMatchers.hasXPaths(
                 "/o[@name='Neo']",
-                "/o[@name='Neo']/o[contains(@name,'version')]",
-                "/o[@name='Neo']/o[contains(@name,'access')]",
-                "/o[@name='Neo']/o[contains(@name,'signature')]",
-                "/o[@name='Neo']/o[contains(@name,'supername')]",
-                "/o[@name='Neo']/o[contains(@name,'interfaces')]",
-                "/o[@name='Neo']/o[contains(@name,'annotations')]",
-                "/o[@name='Neo']/o[contains(@name,'attributes')]"
+                "/o[@name='Neo']/o[contains(@as,'version')]",
+                "/o[@name='Neo']/o[contains(@as,'access')]",
+                "/o[@name='Neo']/o[contains(@as,'signature')]",
+                "/o[@name='Neo']/o[contains(@as,'supername')]",
+                "/o[@name='Neo']/o[contains(@as,'interfaces')]",
+                "/o[@name='Neo']/o[contains(@as,'annotations')]",
+                "/o[@name='Neo']/o[contains(@as,'attributes')]"
             )
         );
     }
@@ -92,7 +92,7 @@ final class DirectivesClassTest {
                 new XMLDocument(xml)
             ),
             xml,
-            XhtmlMatchers.hasXPath("/o[@name='Neo']/o[contains(@name,'method')]")
+            XhtmlMatchers.hasXPath("/o[@name='Neo']/o[contains(@as,'method')]")
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesCommentTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesCommentTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesEnumAnnotationValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesEnumAnnotationValueTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesFieldTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesFieldTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesFieldTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesFieldTest.java
@@ -49,11 +49,11 @@ final class DirectivesFieldTest {
             ),
             xml,
             XhtmlMatchers.hasXPaths(
-                "/o[contains(@base,'field') and contains(@name,'unknown')]",
-                "/o/o[@name='access-unknown']/o[contains(text(),'01')]",
-                "/o/o[@name='descriptor-unknown']/o[text()='49-']",
-                "/o/o[@name='signature-unknown']",
-                "/o/o[contains(@base,'int') and @name='value-unknown']/o[contains(text(),'0')]"
+                "/o[contains(@base,'field') and contains(@as,'unknown')]",
+                "/o/o[@as='access-unknown']/o[contains(text(),'01')]",
+                "/o/o[@as='descriptor-unknown']/o[text()='49-']",
+                "/o/o[@as='signature-unknown']",
+                "/o/o[contains(@base,'int') and @as='value-unknown']/o[contains(text(),'0')]"
             )
         );
     }
@@ -76,11 +76,11 @@ final class DirectivesFieldTest {
             ),
             xml,
             XhtmlMatchers.hasXPaths(
-                "/o[contains(@base,'field') and contains(@name,'serialVersionUID')]",
-                "/o/o[@name='access-serialVersionUID']/o[contains(text(),'1A')]",
-                "/o/o[@name='descriptor-serialVersionUID']/o[text()='4A-']",
-                "/o/o[@name='signature-serialVersionUID']",
-                "/o/o[@name='value-serialVersionUID']/o[text()='62-84-EB-5F-88-47-CD-E1']"
+                "/o[contains(@base,'field') and contains(@as,'serialVersionUID')]",
+                "/o/o[@as='access-serialVersionUID']/o[contains(text(),'1A')]",
+                "/o/o[@as='descriptor-serialVersionUID']/o[text()='4A-']",
+                "/o/o[@as='signature-serialVersionUID']",
+                "/o/o[@as='value-serialVersionUID']/o[text()='62-84-EB-5F-88-47-CD-E1']"
             )
         );
     }
@@ -105,7 +105,7 @@ final class DirectivesFieldTest {
             ).xml(),
             XhtmlMatchers.hasXPaths(
                 String.format(
-                    "/o[contains(@base,'field') and contains(@name,'%s')]",
+                    "/o[contains(@base,'field') and contains(@as,'%s')]",
                     original
                 )
             )

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesFrameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesFrameTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesHandleTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesHandleTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesInstructionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -101,7 +101,7 @@ final class DirectivesMethodTest {
         MatcherAssert.assertThat(
             "We expect that 'j$' prefix will be added to the method name",
             new Xembler(new BytecodeMethod("φTerm").directives()).xml(),
-            XhtmlMatchers.hasXPaths("./o[contains(@name, 'j$φTerm')]")
+            XhtmlMatchers.hasXPaths("./o[contains(@as, 'j$φTerm')]")
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesPlainAnnotationValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesPlainAnnotationValueTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesProgramTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesProgramTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesSeqTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesSeqTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesSeqTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesSeqTest.java
@@ -51,9 +51,9 @@ final class DirectivesSeqTest {
                 )
             ).xml(),
             XhtmlMatchers.hasXPaths(
-                "/o[contains(@base,'seq.of2') and contains(@name,'seq')]",
-                "/o[contains(@base,'seq.of2') and contains(@name,'seq')]/o[contains(@base,'string')]/o[@base='org.eolang.bytes' and text()='31-']",
-                "/o[contains(@base,'seq.of2') and contains(@name,'seq')]/o[contains(@base,'string')]/o[@base='org.eolang.bytes' and text()='32-']"
+                "/o[contains(@base,'seq.of2') and contains(@as,'seq')]",
+                "/o[contains(@base,'seq.of2') and contains(@as,'seq')]/o[contains(@base,'string')]/o[@base='org.eolang.bytes' and text()='31-']",
+                "/o[contains(@base,'seq.of2') and contains(@as,'seq')]/o[contains(@base,'string')]/o[@base='org.eolang.bytes' and text()='32-']"
             )
         );
     }
@@ -68,7 +68,7 @@ final class DirectivesSeqTest {
             new Xembler(actual).xml(),
             XhtmlMatchers.hasXPath(
                 String.format(
-                    "/o[contains(@base,'seq.of%d') and contains(@name,'seq')]",
+                    "/o[contains(@base,'seq.of%d') and contains(@as,'seq')]",
                     expected
                 )
             )

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesTryCatchTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesTryCatchTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
@@ -52,7 +52,7 @@ final class DirectivesValueTest {
             new SameXml(
                 String.join(
                     "\n",
-                    "<o base='jeo.int' name='access'>",
+                    "<o base='jeo.int' as='access'>",
                     "  <o base='org.eolang.bytes'>00-00-00-00-00-00-00-2A</o>",
                     "</o>"
                 )

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValuesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValuesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValuesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValuesTest.java
@@ -44,8 +44,8 @@ final class DirectivesValuesTest {
             "We expect that array of values will be converted to correct Xembly directives",
             new Xembler(new DirectivesValues("name", "value")).xml(),
             XhtmlMatchers.hasXPaths(
-                "./o[contains(@base,'seq.of1') and contains(@name,'name')]",
-                "./o[contains(@base,'seq.of1') and contains(@name,'name')]/o/o[@base='org.eolang.bytes' and text()='76-61-6C-75-65']"
+                "./o[contains(@base,'seq.of1') and contains(@as,'name')]",
+                "./o[contains(@base,'seq.of1') and contains(@as,'name')]/o/o[@base='org.eolang.bytes' and text()='76-61-6C-75-65']"
             )
         );
     }
@@ -58,7 +58,7 @@ final class DirectivesValuesTest {
                 new Xembler(
                     new DirectivesValues("", "some-value")
                 ).xmlQuietly()
-            ).attribute("name").orElseThrow(
+            ).attribute("as").orElseThrow(
                 () -> new IllegalStateException("Name attribute is absent")
             ),
             Matchers.matchesRegex("^[^0-9].*")

--- a/src/test/java/org/eolang/jeo/representation/directives/EoFqnTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/EoFqnTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/HasClass.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasClass.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
@@ -190,7 +190,7 @@ public final class HasMethod extends TypeSafeMatcher<String> {
     private Stream<String> definition() {
         final String root = this.root();
         return Stream.of(
-            root.concat("/@name"),
+            root.concat("/@as"),
             root.concat("/o[contains(@base,'seq')]/@base")
         );
     }
@@ -204,7 +204,7 @@ public final class HasMethod extends TypeSafeMatcher<String> {
         return this.params.stream()
             .map(
                 param -> String.format(
-                    "%s/o[contains(@base,'params')]/o[contains(@name,'%s') and contains(@base,'param')]/@name",
+                    "%s/o[contains(@base,'params')]/o[contains(@as,'%s') and contains(@base,'param')]/@as",
                     root,
                     param
                 )
@@ -247,7 +247,7 @@ public final class HasMethod extends TypeSafeMatcher<String> {
      */
     private String root() {
         return String.format(
-            "/program/objects/o[contains(@name,'%s')]/o[contains(@name,'%s')]",
+            "/program/objects/o[contains(@name,'%s')]/o[contains(@as,'%s')]",
             this.clazz,
             this.name
         );
@@ -296,7 +296,7 @@ public final class HasMethod extends TypeSafeMatcher<String> {
          */
         Stream<String> checks(final String root) {
             final String instruction = String.format(
-                "%s/o[contains(@base,'seq') and contains(@name,'body')]/o[contains(@base,'opcode')]",
+                "%s/o[contains(@base,'seq') and contains(@as,'body')]/o[contains(@base,'opcode')]",
                 root
             );
             return Stream.concat(
@@ -397,7 +397,7 @@ public final class HasMethod extends TypeSafeMatcher<String> {
          */
         private static String path(final String root) {
             return String.format(
-                "%s/o[contains(@base,'seq') and contains(@name, 'trycatchblocks')]/o[contains(@base,'trycatch')]",
+                "%s/o[contains(@base,'seq') and contains(@as, 'trycatchblocks')]/o[contains(@base,'trycatch')]",
                 root
             );
         }
@@ -420,7 +420,7 @@ public final class HasMethod extends TypeSafeMatcher<String> {
         static Stream<String> checks(final String root) {
             return Stream.of(
                 String.format(
-                    "%s/o[contains(@base,'seq') and contains(@name,'body')]/o[contains(@base,'label')]/o[@base='org.eolang.bytes']/@base",
+                    "%s/o[contains(@base,'seq') and contains(@as,'body')]/o[contains(@base,'label')]/o[@base='org.eolang.bytes']/@base",
                     root
                 )
             );

--- a/src/test/java/org/eolang/jeo/representation/directives/JeoFqnTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/JeoFqnTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/OpcodeNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/OpcodeNameTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/directives/package-info.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/package-info.java
+++ b/src/test/java/org/eolang/jeo/representation/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/JcabiXmlDocTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/JcabiXmlDocTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/JcabiXmlNodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/JcabiXmlNodeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/NativeXmlDocTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/NativeXmlDocTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/NativeXmlNodeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/NativeXmlNodeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlAnnotationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlAnnotationTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlAnnotationsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlAnnotationsTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlAttributeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlAttributeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlAttributesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlAttributesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlClassPropertiesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlClassPropertiesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlClassTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlFieldTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlFieldTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlFrameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlFrameTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlHandlerTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlHandlerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlLabelTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlLabelTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
@@ -109,7 +109,7 @@ final class XmlMethodTest {
                                 new BytecodeMethod(
                                     "someMethodName"
                                 ).directives()
-                            ).xpath(".//o[contains(@name, 'body')]")
+                            ).xpath(".//o[contains(@as, 'body')]")
                                 .append(new DirectivesBytes("???"))
                         ).xmlQuietly()
                     )

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlParamTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlParamTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlProgramTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlProgramTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntryTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntryTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlValueTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/eolang/jeo/representation/xmir/package-info.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/maxs/MaxInterface.java
+++ b/src/test/resources/maxs/MaxInterface.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2024 Objectionary.com
+ * Copyright (c) 2016-2025 Objectionary.com
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
In this PR I changed the `name` attribute to `as` for all inner objects, in order to fix all the `xmir` offences related to the `name-outside-of-abstract-object`.

Related to #965.

