### PR TITLE
feat(#977): Use `org.eolang.true` and `org.eolang.false` for Boolean Values

### DIFF
--- a/src/it/annotations/pom.xml
+++ b/src/it/annotations/pom.xml
@@ -67,7 +67,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.50.1</version>
+        <version>0.50.2</version>
         <executions>
           <execution>
             <id>convert-xmir-to-eo</id>

--- a/src/it/bytecode-to-eo/pom.xml
+++ b/src/it/bytecode-to-eo/pom.xml
@@ -73,7 +73,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.50.1</version>
+        <version>0.50.2</version>
         <executions>
           <execution>
             <id>convert-xmir-to-phi</id>
@@ -101,7 +101,7 @@ SOFTWARE.
           <plugin>
             <groupId>org.eolang</groupId>
             <artifactId>eo-maven-plugin</artifactId>
-            <version>0.50.1</version>
+            <version>0.50.2</version>
             <executions>
               <execution>
                 <id>convert-xmir-to-eo</id>

--- a/src/it/custom-transformations/pom.xml
+++ b/src/it/custom-transformations/pom.xml
@@ -67,7 +67,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.50.1</version>
+        <version>0.50.2</version>
         <executions>
           <!--
             @todo #610:30min Enable EO Printing in 'custom-transformations' it.

--- a/src/it/exceptions/pom.xml
+++ b/src/it/exceptions/pom.xml
@@ -85,7 +85,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.50.1</version>
+        <version>0.50.2</version>
         <executions>
           <execution>
             <id>convert-xmir-to-eo</id>

--- a/src/it/generics/pom.xml
+++ b/src/it/generics/pom.xml
@@ -67,7 +67,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.50.1</version>
+        <version>0.50.2</version>
         <executions>
           <execution>
             <id>convert-xmir-to-eo</id>

--- a/src/it/jna/pom.xml
+++ b/src/it/jna/pom.xml
@@ -225,7 +225,7 @@ SOFTWARE.
           <plugin>
             <groupId>org.eolang</groupId>
             <artifactId>eo-maven-plugin</artifactId>
-            <version>0.50.1</version>
+            <version>0.50.2</version>
             <executions>
               <execution>
                 <id>xmir-to-phi</id>

--- a/src/it/phi-unphi/pom.xml
+++ b/src/it/phi-unphi/pom.xml
@@ -100,7 +100,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.50.1</version>
+        <version>0.50.2</version>
         <executions>
           <execution>
             <id>xmir-to-phi</id>

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -87,7 +87,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.50.1</version>
+        <version>0.50.2</version>
         <executions>
           <execution>
             <id>convert-xmir-to-phi</id>

--- a/src/it/takes/pom.xml
+++ b/src/it/takes/pom.xml
@@ -83,7 +83,7 @@ SOFTWARE.
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.50.1</version>
+        <version>0.50.2</version>
         <executions>
           <execution>
             <id>convert-xmir-to-phi</id>

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -30,6 +30,7 @@ import org.eolang.jeo.representation.bytecode.Codec;
 import org.eolang.jeo.representation.bytecode.EoCodec;
 import org.eolang.jeo.representation.bytecode.PlainLongCodec;
 import org.xembly.Directive;
+import org.xembly.Directives;
 
 /**
  * Data Object Directive in EO language.
@@ -124,6 +125,9 @@ public final class DirectivesValue implements Iterable<Directive> {
             case "string":
                 res = this.eoObject(type, codec);
                 break;
+            case "bool":
+                res = this.booleanObject(type);
+                break;
             default:
                 res = this.jeoObject(type, codec);
                 break;
@@ -199,6 +203,25 @@ public final class DirectivesValue implements Iterable<Directive> {
             this.name,
             new DirectivesComment(this.comment()),
             new DirectivesNumber(this.hex(codec))
+        );
+    }
+
+    /**
+     * Boolean object.
+     * @param type Type of the object, usually "bool".
+     * @return Boolean object directives.
+     */
+    private Iterable<Directive> booleanObject(final String type) {
+        final String base;
+        if ((boolean) this.value.value()) {
+            base = "QQ.true";
+        } else {
+            base = "QQ.false";
+        }
+        return new DirectivesJeoObject(
+            type,
+            this.name,
+            new Directives().add("o").attr("base", base).up()
         );
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -34,6 +34,7 @@ import org.xembly.Directives;
 
 /**
  * Data Object Directive in EO language.
+ *
  * @since 0.1.0
  */
 @ToString
@@ -75,6 +76,7 @@ public final class DirectivesValue implements Iterable<Directive> {
 
     /**
      * Constructor.
+     *
      * @param data Data.
      * @param <T> Data type.
      */
@@ -84,6 +86,7 @@ public final class DirectivesValue implements Iterable<Directive> {
 
     /**
      * Constructor.
+     *
      * @param name Name.
      * @param data Data.
      * @param <T> Data type.
@@ -94,6 +97,7 @@ public final class DirectivesValue implements Iterable<Directive> {
 
     /**
      * Constructor.
+     *
      * @param name Name.
      * @param value Value.
      */
@@ -137,6 +141,7 @@ public final class DirectivesValue implements Iterable<Directive> {
 
     /**
      * Value of the data.
+     *
      * @param codec Codec
      * @return Value
      */
@@ -146,6 +151,7 @@ public final class DirectivesValue implements Iterable<Directive> {
 
     /**
      * Type of the data.
+     *
      * @return Type
      */
     String type() {
@@ -154,6 +160,7 @@ public final class DirectivesValue implements Iterable<Directive> {
 
     /**
      * Check if the value fits into the double.
+     *
      * @return True if fits.
      */
     private boolean fits() {
@@ -163,6 +170,7 @@ public final class DirectivesValue implements Iterable<Directive> {
 
     /**
      * EO object.
+     *
      * @param base Base.
      * @param codec Codec to use for bytes encoding.
      * @return EO object directives.
@@ -178,6 +186,7 @@ public final class DirectivesValue implements Iterable<Directive> {
 
     /**
      * JEO object.
+     *
      * @param base Base.
      * @param codec Codec to use for bytes encoding.
      * @return JEO object directives.
@@ -193,6 +202,7 @@ public final class DirectivesValue implements Iterable<Directive> {
 
     /**
      * JEO number.
+     *
      * @param base Object base.
      * @param codec Codec to use for bytes encoding.
      * @return JEO number directives.
@@ -208,15 +218,16 @@ public final class DirectivesValue implements Iterable<Directive> {
 
     /**
      * Boolean object.
+     *
      * @param type Type of the object, usually "bool".
      * @return Boolean object directives.
      */
     private Iterable<Directive> booleanObject(final String type) {
         final String base;
         if ((boolean) this.value.value()) {
-            base = "QQ.true";
+            base = "org.eolang.true";
         } else {
-            base = "QQ.false";
+            base = "org.eolang.false";
         }
         return new DirectivesJeoObject(
             type,
@@ -227,6 +238,7 @@ public final class DirectivesValue implements Iterable<Directive> {
 
     /**
      * Bytes of the representative comment.
+     *
      * @return Sting comment.
      */
     private String comment() {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
@@ -75,11 +75,26 @@ public final class XmlValue {
      * @return Object.
      */
     public Object object() {
-        Codec codec = new EoCodec();
-        if (!this.node.child("o").hasAttribute("base", "org.eolang.number")) {
-            codec = new PlainLongCodec(codec);
+        final String base = this.base();
+        final Object res;
+        if (base.equals("bool")) {
+            res = this.parseBoolean();
+        } else {
+            Codec codec = new EoCodec();
+            if (!this.node.child("o").hasAttribute("base", "org.eolang.number")) {
+                codec = new PlainLongCodec(codec);
+            }
+            res = new BytecodeBytes(base, this.bytes()).object(codec);
         }
-        return new BytecodeBytes(this.base(), this.bytes()).object(codec);
+        return res;
+    }
+
+    /**
+     * Parse boolean value.
+     * @return Boolean.
+     */
+    private Object parseBoolean() {
+        return this.node.child("o").hasAttribute("base", "QQ.true");
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
@@ -77,7 +77,7 @@ public final class XmlValue {
     public Object object() {
         final String base = this.base();
         final Object res;
-        if (base.equals("bool")) {
+        if ("bool".equals(base)) {
             res = this.parseBoolean();
         } else {
             Codec codec = new EoCodec();

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
@@ -94,7 +94,7 @@ public final class XmlValue {
      * @return Boolean.
      */
     private Object parseBoolean() {
-        return this.node.child("o").hasAttribute("base", "QQ.true");
+        return this.node.child("o").hasAttribute("base", "org.eolang.true");
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java
@@ -63,10 +63,7 @@ final class DirectivesAnnotationsTest {
                     "/o[contains(@base,'seq.of1') and contains(@as,'annotations')]/o/o[1][contains(@base,'string')]/o[text()='%s']",
                     new DirectivesValue(annotation).hex(codec)
                 ),
-                String.format(
-                    "/o[contains(@base,'seq.of1') and contains(@as,'annotations')]/o/o[2][contains(@base,'bool')]/o[text()='%s']",
-                    new DirectivesValue(true).hex(codec)
-                )
+                "/o[contains(@base,'seq.of1') and contains(@as,'annotations')]/o/o[2][contains(@base,'bool')]/o[contains(@base,'true')]"
             )
         );
     }
@@ -85,7 +82,7 @@ final class DirectivesAnnotationsTest {
             XhtmlMatchers.hasXPaths(
                 "/o[contains(@base,'annotation') and count(o) = 3]",
                 "/o[contains(@base,'annotation')]/o[1]/o[text()='4C-6A-61-76-61-2F-6C-61-6E-67-2F-4F-76-65-72-72-69-64-65-3B']",
-                "/o[contains(@base,'annotation')]/o[2]/o[text()='01-']",
+                "/o[contains(@base,'annotation')]/o[2]/o[contains(@base,'true')]",
                 "/o[contains(@base,'annotation')]/o[contains(@base,'annotation-property')]"
             )
         );

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
@@ -103,6 +103,15 @@ final class DirectivesValueTest {
         );
     }
 
+    @Test
+    void convertsBoolean() {
+        MatcherAssert.assertThat(
+            "Converts boolean to XML",
+            new Xembler(new DirectivesValue(true)).xmlQuietly(),
+            new SameXml("<o base='jeo.bool'><o base='QQ.true'></o></o>")
+        );
+    }
+
     @MethodSource("types")
     @ParameterizedTest
     void determinesTypeCorrectly(final Object data, final String type) {

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
@@ -108,7 +108,7 @@ final class DirectivesValueTest {
         MatcherAssert.assertThat(
             "Converts boolean to XML",
             new Xembler(new DirectivesValue(true)).xmlQuietly(),
-            new SameXml("<o base='jeo.bool'><o base='QQ.true'></o></o>")
+            new SameXml("<o base='jeo.bool'><o base='org.eolang.true'></o></o>")
         );
     }
 


### PR DESCRIPTION
In this PR I change the transformation method for boolean values. Long story short:
Instead of:
```xml
<o base="jeo.bool">
  <o base="org.eolang.bytes">00-</o>
</o>
```

we have the following now:

```xml
<o base="org.eolang.true"/>
<o base="org.eolang.false"/>
```

Related to #977
