### PR TITLE
feat(#965): Fix Some XMIR Offences

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -56,7 +56,6 @@ public final class DirectivesMetas implements Iterable<Directive> {
         if (!this.name.pckg().isEmpty()) {
             result.append(this.pckg());
         }
-//        result.append(DirectivesMetas.unlint());
         result.append(DirectivesMetas.version());
         return result.up().iterator();
     }
@@ -106,18 +105,6 @@ public final class DirectivesMetas implements Iterable<Directive> {
             .add("meta")
             .add("head").set("version").up()
             .add("tail").set(Manifests.read("JEO-Version")).up()
-            .up();
-    }
-
-    /**
-     * Ignored XMIR checks.
-     * @return Directives for ignored checks.
-     */
-    private static Directives unlint() {
-        return new Directives()
-            .add("meta")
-            .add("head").set("unlint").up()
-            .add("tail").set("mandatory-package").up()
             .up();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -56,7 +56,7 @@ public final class DirectivesMetas implements Iterable<Directive> {
         if (!this.name.pckg().isEmpty()) {
             result.append(this.pckg());
         }
-        result.append(DirectivesMetas.unlint());
+//        result.append(DirectivesMetas.unlint());
         result.append(DirectivesMetas.version());
         return result.up().iterator();
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -52,6 +52,7 @@ public final class DirectivesMetas implements Iterable<Directive> {
     @Override
     public Iterator<Directive> iterator() {
         final Directives result = new Directives().add("metas");
+        result.append(DirectivesMetas.home());
         if (!this.name.pckg().isEmpty()) {
             result.append(this.pckg());
         }
@@ -66,6 +67,18 @@ public final class DirectivesMetas implements Iterable<Directive> {
      */
     ClassName className() {
         return this.name;
+    }
+
+    /**
+     * Home directives.
+     * @return Directives for home.
+     */
+    private static Iterable<Directive> home() {
+        return new Directives().add("meta")
+            .add("head").set("home").up()
+            .add("tail").set("https://github.com/objectionary/jeo-maven-plugin").up()
+            .add("part").set("https://github.com/objectionary/jeo-maven-plugin").up()
+            .up();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -158,9 +158,12 @@ public final class JcabiXmlNode implements XmlNode {
     @Override
     public void validate() {
         //@checkstyle MethodBodyCommentsCheck (10 lines)
-        // @todo #946:30min Remove the ignore list from the 'validate' method.
-        //  The ignore list is used to ignore some defects that we haven't implemented yet.
-        //  We should remove the ignore list and fix the defects that are being ignored.
+        // @todo #965:30min Remove 'object-does-not-match-filename' from the ignore list.
+        //  This is a temporary solution to ignore the 'object-does-not-match-filename' defect.
+        //  Most probably, this check will be removed at all:
+        //  https://github.com/objectionary/lints/issues/352
+        //  If so, we should remove the ignore list after the issue is resolved.
+        //  Otherwise we need to fix filenames.
         final Collection<String> ignore = new HashSet<>(
             Arrays.asList(
                 "object-does-not-match-filename"

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -163,7 +163,6 @@ public final class JcabiXmlNode implements XmlNode {
         //  We should remove the ignore list and fix the defects that are being ignored.
         final Collection<String> ignore = new HashSet<>(
             Arrays.asList(
-                "empty-object",
                 "incorrect-package",
                 "object-does-not-match-filename"
             )

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -163,7 +163,6 @@ public final class JcabiXmlNode implements XmlNode {
         //  We should remove the ignore list and fix the defects that are being ignored.
         final Collection<String> ignore = new HashSet<>(
             Arrays.asList(
-                "mandatory-home",
                 "empty-object",
                 "incorrect-package",
                 "object-does-not-match-filename"

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -163,7 +163,6 @@ public final class JcabiXmlNode implements XmlNode {
         //  We should remove the ignore list and fix the defects that are being ignored.
         final Collection<String> ignore = new HashSet<>(
             Arrays.asList(
-                "incorrect-package",
                 "object-does-not-match-filename"
             )
         );


### PR DESCRIPTION
In this PR I fixed several minor issues related to incorrect XMIR generated by `disassemble` goal. The only issue we are left with is `object-does-notmatch-filename`. I've added one more puzzle to close it later when we decide how to solve it:
https://github.com/objectionary/lints/issues/352

Closes: #965
