### PR TITLE
feat(#1015): Enable `jcabi-xcop` Check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,26 +243,6 @@
     </testResources>
     <plugins>
       <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>3.1.0</version>
-        <executions>
-          <execution>
-            <id>jcabi-xcop</id>
-            <!--
-               @todo #30:30min Enable jcabi-xcop check.
-                Due recent changes in LICENSE generation, jcabi-xcop check
-                doesn't work. It happens because the LICENSE file is generated
-                later then the jcabi-xcop check. We need to fix this issue.
-                Most probably, the issue is related to SPDX license generation.
-            -->
-            <phase>none</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <executions>
           <execution>


### PR DESCRIPTION
In this PR I've enabled `jcabi-xcop` check to validate XML documents in the repository.

Closes: #1015
