### PR TITLE
feat(#1012): upgrade logback-classic library '1.5.16' -> '1.5.17'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.5.16</version>
+      <version>1.5.17</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>


### PR DESCRIPTION
Upgrade logback-classic library `1.5.16` -> `1.5.17`.

Related to #1012
