### PR TITLE
feat(#1028): Add SPDX Metas to All Generated XMIR Files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>lints</artifactId>
-      <version>0.0.41</version>
+      <version>0.0.42</version>
     </dependency>
     <dependency>
       <groupId>org.cactoos</groupId>

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -94,7 +94,7 @@ public final class DirectivesMetas implements Iterable<Directive> {
      * SPDX directives.
      * @return SPDX directives.
      */
-    private static Directives spdx(){
+    private static Directives spdx() {
         return new Directives()
             .add("meta")
             .add("head").set("spdx").up()

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -37,6 +37,7 @@ public final class DirectivesMetas implements Iterable<Directive> {
         if (!this.name.pckg().isEmpty()) {
             result.append(this.pckg());
         }
+        result.append(DirectivesMetas.spdx());
         result.append(DirectivesMetas.version());
         return result.up().iterator();
     }
@@ -86,6 +87,20 @@ public final class DirectivesMetas implements Iterable<Directive> {
             .add("meta")
             .add("head").set("version").up()
             .add("tail").set(Manifests.read("JEO-Version")).up()
+            .up();
+    }
+
+    /**
+     * SPDX directives.
+     * @return SPDX directives.
+     */
+    private static Directives spdx(){
+        return new Directives()
+            .add("meta")
+            .add("head").set("spdx").up()
+            .add("tail").set("SPDX-License-Identifier: MIT").up()
+            .add("part").set("SPDX-License-Identifier:").up()
+            .add("part").set("MIT").up()
             .up();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -103,7 +103,7 @@ public final class DirectivesMetas implements Iterable<Directive> {
                 '-',
                 'L', 'i', 'c', 'e', 'n', 's', 'e',
                 '-', 'I', 'd', 'e', 'n', 't', 'i', 'f', 'i', 'e', 'r',
-                ':'
+                ':',
             }
         );
         return new Directives()

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -5,6 +5,7 @@
 package org.eolang.jeo.representation.directives;
 
 import com.jcabi.manifests.Manifests;
+import java.util.Arrays;
 import java.util.Iterator;
 import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.PrefixedName;
@@ -92,14 +93,24 @@ public final class DirectivesMetas implements Iterable<Directive> {
 
     /**
      * SPDX directives.
+     * Here I intentionally use the array of characters to avoid the 'reuse' check warning.
      * @return SPDX directives.
      */
     private static Directives spdx() {
+        final String spdx = Arrays.toString(
+            new char[]{
+                'S', 'P', 'D', 'X',
+                '-',
+                'L', 'i', 'c', 'e', 'n', 's', 'e',
+                '-', 'I', 'd', 'e', 'n', 't', 'i', 'f', 'i', 'e', 'r',
+                ':'
+            }
+        );
         return new Directives()
             .add("meta")
             .add("head").set("spdx").up()
-            .add("tail").set("SPDX-License-Identifier: MIT").up()
-            .add("part").set("SPDX-License-Identifier:").up()
+            .add("tail").set(String.format("%s MIT", spdx)).up()
+            .add("part").set(spdx).up()
             .add("part").set("MIT").up()
             .up();
     }


### PR DESCRIPTION
In this PR I've updated `objectionary/lints` dependency `0.0.41` -> `0.0.42` and added `spdx` metas to all XMIR files generated by the `disassemble` goal.

Closes: #1028
