### PR TITLE
feat(#543): Bytecode Verification for 'spring-fat' Integration Test

### DIFF
--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -81,7 +81,7 @@
              the transformation. For not it's not so crucial, but in the future, we
              should enable it.
           -->
-          <skipVerification>true</skipVerification>
+          <skipVerification>false</skipVerification>
         </configuration>
         <executions>
           <execution>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -75,13 +75,12 @@
         <configuration>
           <disabled>false</disabled>
           <!--
-            @todo #488:90min Enable Bytecode Verification For Spring Fat Integration Test.
+             Impossible to Make Bytecode Verification For Spring Fat Integration Test.
              We skip verification because the Spring Framework uses many classes that
              are not in the classpath and the plugin cannot verify the correctness of
-             the transformation. For not it's not so crucial, but in the future, we
-             should enable it.
+             the transformation.
           -->
-          <skipVerification>false</skipVerification>
+          <skipVerification>true</skipVerification>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
This PR addresses issue #543 by removing the puzzle related to bytecode verification. We just can't enable bytecode verification for the 'spring-fat' integration test. I've added explanation to the comment.

Closes: #543