### PR TITLE
feat(#619): Enable EO Printing in 'custom-transformations' integration test

### DIFF
--- a/src/it/custom-transformations/pom.xml
+++ b/src/it/custom-transformations/pom.xml
@@ -50,26 +50,17 @@
         <artifactId>eo-maven-plugin</artifactId>
         <version>0.54.1</version>
         <executions>
-          <!--
-            @todo #610:30min Enable EO Printing in 'custom-transformations' it.
-             The `print` goal is currently disabled because it doesn't support
-             Java 8. You can read more about it right here:
-             https://github.com/objectionary/eo/issues/3207
-             Once it is implemented, this comment should be removed and the goal
-             should be enabled. Don't forget to enable checks in `verify.groovy`
-             file related to `.eo` files. Now they are commented.
-          -->
-          <!--          <execution>-->
-          <!--            <id>convert-xmir-to-eo</id>-->
-          <!--            <phase>process-classes</phase>-->
-          <!--            <goals>-->
-          <!--              <goal>print</goal>-->
-          <!--            </goals>-->
-          <!--            <configuration>-->
-          <!--              <printSourcesDir>${project.build.directory}/generated-sources/jeo-xmir</printSourcesDir>-->
-          <!--              <printOutputDir>${project.build.directory}/generated-sources/jeo-eo</printOutputDir>-->
-          <!--            </configuration>-->
-          <!--          </execution>-->
+          <execution>
+            <id>convert-xmir-to-eo</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>print</goal>
+            </goals>
+            <configuration>
+              <printSourcesDir>${project.build.directory}/generated-sources/jeo-xmir</printSourcesDir>
+              <printOutputDir>${project.build.directory}/generated-sources/jeo-eo</printOutputDir>
+            </configuration>
+          </execution>
           <execution>
             <id>convert-xmir-to-phi</id>
             <phase>process-classes</phase>


### PR DESCRIPTION
This pull request enables the EO Printing goal in the 'custom-transformations' integration test, which was previously disabled due to lack of support for Java 8. The necessary configurations have been uncommented to activate the  goal. Closes #619.