### PR TITLE
fix(#1044): Remove `parallelThreads` from `pom.xml` configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,6 @@
           <pomExcludes>
             <exclude>spring-fat/pom.xml</exclude>
           </pomExcludes>
-          <parallelThreads>10</parallelThreads>
         </configuration>
       </plugin>
       <plugin>
@@ -527,7 +526,6 @@
                 All integration tests are enabled in the 'long' profile.
               -->
               <pomExcludes/>
-              <parallelThreads>10</parallelThreads>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
This pull request removes the `<parallelThreads>` configuration from the Maven Surefire and Failsafe plugins in the 'pom.xml' file to streamline the build process and exclude flaky behaviour. Closes #1044.
