### PR TITLE
chore(#633): Remove 'xmir-to-phi' transformation from 'spring-fat' integration test

### DIFF
--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -97,31 +97,6 @@
           </execution>
         </executions>
       </plugin>
-      <!--
-        @todo #627:30min Too Long PHI Printing In Spring-Fat IT
-         We need to optimize PHI pringint in `eo-maven-plugin`
-         and then enable the code below.
-         You can check the progress of the issue by the link:
-         https://github.com/objectionary/eo/issues/3257
-      -->
-      <!--            <plugin>-->
-      <!--              <groupId>org.eolang</groupId>-->
-      <!--              <artifactId>eo-maven-plugin</artifactId>-->
-      <!--              <version>0.39.0</version>-->
-      <!--              <executions>-->
-      <!--                <execution>-->
-      <!--                  <id>convert-xmir-to-phi</id>-->
-      <!--                  <phase>process-classes</phase>-->
-      <!--                  <goals>-->
-      <!--                    <goal>xmir-to-phi</goal>-->
-      <!--                  </goals>-->
-      <!--                  <configuration>-->
-      <!--                    <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>-->
-      <!--                    <phiOutputDir>${project.build.directory}/generated-sources/jeo-phi</phiOutputDir>-->
-      <!--                  </configuration>-->
-      <!--                </execution>-->
-      <!--              </executions>-->
-      <!--            </plugin>-->
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This pull request removes outdated comments related to the optimization of PHI printing within the `spring-fat`  integration test. The transformation is still rather long and most probably will stay the same in the future. So, to speed up the build, we can just avoid running this transformation on large number of files. Closes #633.