### PR TITLE
test(#1051): Make `License` thread safe and add concurrent test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,12 @@
       <version>1.37</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.yegor256</groupId>
+      <artifactId>together</artifactId>
+      <version>0.1.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <testResources>

--- a/src/main/java/org/eolang/jeo/representation/License.java
+++ b/src/main/java/org/eolang/jeo/representation/License.java
@@ -8,6 +8,7 @@ import org.cactoos.Scalar;
 import org.cactoos.Text;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.text.Sticky;
+import org.cactoos.text.Synced;
 import org.cactoos.text.TextOf;
 
 /**
@@ -35,7 +36,7 @@ public final class License implements Scalar<String> {
      * @param content The name of file with license.
      */
     public License(final String content) {
-        this.content = new Sticky(new TextOf(new ResourceOf(content)));
+        this.content = new Synced(new Sticky(new TextOf(new ResourceOf(content))));
     }
 
     @Override

--- a/src/test/java/org/eolang/jeo/representation/LicenseTest.java
+++ b/src/test/java/org/eolang/jeo/representation/LicenseTest.java
@@ -4,9 +4,12 @@
  */
 package org.eolang.jeo.representation;
 
+import com.yegor256.Together;
+import org.cactoos.list.ListOf;
 import org.cactoos.text.FormattedText;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -20,12 +23,20 @@ final class LicenseTest {
     void readsLicenseFileCorrectly() throws Exception {
         final String name = "LICENSE.txt";
         MatcherAssert.assertThat(
-            new FormattedText(
-                "Unexpected file:'%s' content",
-                name
-            ).asString(),
+            new FormattedText("Unexpected file:'%s' content", name).asString(),
             new License(name).value(),
             Matchers.containsString("MIT")
+        );
+    }
+
+    @RepeatedTest(10)
+    void readsLicenseConcurrently() {
+        final License license = new License();
+        final int total = 10;
+        MatcherAssert.assertThat(
+            "Unexpected license content",
+            new ListOf<>(new Together<>(total, i -> license.value())),
+            Matchers.everyItem(Matchers.containsString("MIT"))
         );
     }
 }


### PR DESCRIPTION
This pull request enhances the `License` class by introducing thread safety with the `Synced` decorator and adds a new test to verify concurrent access. Additionally, it updates the `pom.xml` to include the `together` library for testing purposes. Closes #1051.