### PR TITLE
fix(#1063): remove random suffix from method body name generation

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesSeq.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesSeq.java
@@ -4,12 +4,10 @@
  */
 package org.eolang.jeo.representation.directives;
 
-import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.cactoos.scalar.LengthOf;
@@ -22,10 +20,6 @@ import org.xembly.Directives;
  * @since 0.6
  */
 public final class DirectivesSeq implements Iterable<Directive> {
-    /**
-     * Random number generator.
-     */
-    private static final Random RANDOM = new SecureRandom();
 
     /**
      * Name of the sequence.
@@ -69,13 +63,12 @@ public final class DirectivesSeq implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        final int number = Math.abs(DirectivesSeq.RANDOM.nextInt());
         final List<Directives> all = this.stream()
             .map(Directives::new)
             .collect(Collectors.toList());
         return new DirectivesJeoObject(
             String.format("seq.of%d", all.size()),
-            String.format("%s-%d", this.name, number),
+            this.name,
             all
         ).iterator();
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -5,6 +5,8 @@
 package org.eolang.jeo.representation.directives;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import java.util.Collections;
+import org.eolang.jeo.representation.Signature;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.eolang.jeo.representation.bytecode.BytecodeMaxs;
@@ -15,6 +17,7 @@ import org.eolang.jeo.representation.xmir.XmlMethod;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
@@ -114,6 +117,33 @@ final class DirectivesMethodTest {
                         "./o[contains(@base,'method')]/o[contains(@as,'attributes')]"
                     )
                 )
+            )
+        );
+    }
+
+    /**
+     * This test was added to check if the #1063 issue is fixed.
+     * You can read more about it
+     * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/1063">here</a>
+     */
+    @Test
+    void generatesMethodWithSimpleBodyName() throws ImpossibleModificationException {
+        final String descriptor = "()I";
+        MatcherAssert.assertThat(
+            "We expect that the method body name will be generated correctly without any suffixes and prefixes",
+            new Xembler(
+                new DirectivesMethod(
+                    new Signature("checks1063", descriptor),
+                    new DirectivesMethodProperties(1, descriptor, ""),
+                    Collections.singletonList(new DirectivesInstruction(Opcodes.RETURN)),
+                    Collections.emptyList(),
+                    new DirectivesAnnotations(),
+                    Collections.emptyList(),
+                    new DirectivesAttributes()
+                )
+            ).xml(),
+            XhtmlMatchers.hasXPath(
+                "./o[contains(@base,'method') and contains(@as,'checks1063')]/o[@as='body']"
             )
         );
     }


### PR DESCRIPTION
This pull request refines the `DirectivesSeq` class by removing the unused random number generator. Additionally, a new test is introduced in `DirectivesMethodTest` to verify the correct generation of method body names.

Related to #1063