### PR TITLE
feat(#1060): Simplify `Φ.jeo.bool(Φ̇.false)` -> `Φ̇.false`

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -11,7 +11,6 @@ import org.eolang.jeo.representation.bytecode.Codec;
 import org.eolang.jeo.representation.bytecode.EoCodec;
 import org.eolang.jeo.representation.bytecode.PlainLongCodec;
 import org.xembly.Directive;
-import org.xembly.Directives;
 
 /**
  * Data Object Directive in EO language.
@@ -111,7 +110,7 @@ public final class DirectivesValue implements Iterable<Directive> {
                 res = this.eoObject(type, codec);
                 break;
             case "bool":
-                res = this.booleanObject(type);
+                res = this.booleanObject();
                 break;
             default:
                 res = this.jeoObject(type, codec);
@@ -200,21 +199,16 @@ public final class DirectivesValue implements Iterable<Directive> {
     /**
      * Boolean object.
      *
-     * @param type Type of the object, usually "bool".
      * @return Boolean object directives.
      */
-    private Iterable<Directive> booleanObject(final String type) {
+    private Iterable<Directive> booleanObject() {
         final String base;
         if ((boolean) this.value.value()) {
-            base = new EoFqn("true").fqn();
+            base = "true";
         } else {
-            base = new EoFqn("false").fqn();
+            base = "false";
         }
-        return new DirectivesJeoObject(
-            type,
-            this.name,
-            new Directives().add("o").attr("base", base).up()
-        );
+        return new DirectivesEoObject(base, this.name);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
@@ -59,7 +59,7 @@ public final class XmlValue {
     public Object object() {
         final String base = this.base();
         final Object res;
-        if ("bool".equals(base)) {
+        if (XmlValue.isBoolean(base)) {
             res = this.parseBoolean();
         } else {
             Codec codec = new EoCodec();
@@ -72,11 +72,20 @@ public final class XmlValue {
     }
 
     /**
+     * Object base.
+     * @param base Object 'base' attribute value.
+     * @return True if it's boolean, false otherwise.
+     */
+    private static boolean isBoolean(final String base) {
+        return "true".equals(base) || "false".equals(base);
+    }
+
+    /**
      * Parse boolean value.
      * @return Boolean.
      */
     private Object parseBoolean() {
-        return this.node.child("o").hasAttribute("base", new EoFqn("true").fqn());
+        return this.node.hasAttribute("base", new EoFqn("true").fqn());
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java
@@ -43,7 +43,7 @@ final class DirectivesAnnotationsTest {
                     "/o[contains(@base,'seq.of1') and contains(@as,'annotations')]/o/o[1][contains(@base,'string')]/o[1]/o[text()='%s']",
                     new DirectivesValue(annotation).hex(codec)
                 ),
-                "/o[contains(@base,'seq.of1') and contains(@as,'annotations')]/o/o[2][contains(@base,'bool')]/o[contains(@base,'true')]"
+                "/o[contains(@base,'seq.of1') and contains(@as,'annotations')]/o/o[2][contains(@base,'true')]"
             )
         );
     }
@@ -62,7 +62,7 @@ final class DirectivesAnnotationsTest {
             XhtmlMatchers.hasXPaths(
                 "/o[contains(@base,'annotation') and count(o) = 3]",
                 "/o[contains(@base,'annotation')]/o[1]/o[1]/o[text()='4C-6A-61-76-61-2F-6C-61-6E-67-2F-4F-76-65-72-72-69-64-65-3B']",
-                "/o[contains(@base,'annotation')]/o[2]/o[contains(@base,'true')]",
+                "/o[contains(@base,'annotation')]/o[2][contains(@base,'true')]",
                 "/o[contains(@base,'annotation')]/o[contains(@base,'annotation-property')]"
             )
         );

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
@@ -89,7 +89,7 @@ final class DirectivesValueTest {
             "Converts boolean to XML",
             new Xembler(new DirectivesValue(true)).xmlQuietly(),
             XhtmlMatchers.hasXPath(
-                "./o[contains(@base,'jeo.bool')]/o[contains(@base,'org.eolang.true')]"
+                "./o[contains(@base,'org.eolang.true')]"
             )
         );
     }


### PR DESCRIPTION
This pull request refactors the handling of boolean objects within the `DirectivesValue` and `XmlValue` classes. Now, instead of `Φ.jeo.bool(Φ̇.false)` object, we just geneare `Φ̇.false`.  Additionally, the PR updates the corresponding test cases to align with these changes.

Related to #1060