### PR TITLE
feat(#1061): Simplify integer representation to `number` type

### DIFF
--- a/src/it/phi-unphi/verify.groovy
+++ b/src/it/phi-unphi/verify.groovy
@@ -7,7 +7,8 @@ import java.nio.file.Files
 String log = new File(basedir, 'build.log').text;
 assert log.contains("BUILD SUCCESS"): assertionMessage("BUILD FAILED")
 assert log.contains("sin(42.000000) = -0.916522"): assertionMessage("sin(42.000000) = -0.916522 not found")
-assert log.contains("We have the field with the unicode character 'Φ'"): assertionMessage("We can't find the field with the unicode character 'Φ'")
+assert new File(basedir, "target/generated-sources/eo-phi/org/eolang/hone/App.phi").text
+  .contains("Φ.jeo.opcode.dup(89)"): assertionMessage("We can't find the correct PHI integer representation")
 
 private String assertionMessage(String message) {
     generateGitHubIssue()

--- a/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
@@ -37,7 +37,7 @@ enum DataType {
     /**
      * Integer.
      */
-    INT("int", Integer.class),
+    INT("number", Integer.class),
 
     /**
      * Long.

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesNumber.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesNumber.java
@@ -20,17 +20,36 @@ final class DirectivesNumber implements Iterable<Directive> {
     private final String hex;
 
     /**
+     * Name of the number.
+     */
+    private final String name;
+
+    /**
      * Constructor.
      * @param hex Hex number.
      */
     DirectivesNumber(final String hex) {
+        this("", hex);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param name Name of the number.
+     * @param hex Hex number.
+     */
+    DirectivesNumber(final String name, final String hex) {
         this.hex = hex;
+        this.name = name;
     }
 
     @Override
     public Iterator<Directive> iterator() {
-        return new Directives()
-            .add("o")
+        final Directives number = new Directives().add("o");
+        if (!this.name.isEmpty()) {
+            number.attr("as", this.name);
+        }
+        return number
             .attr("base", new EoFqn("number").fqn())
             .append(new DirectivesBytes(this.hex))
             .up()

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -18,6 +18,7 @@ import org.xembly.Directive;
  * @since 0.1.0
  */
 @ToString
+@SuppressWarnings("PMD.TooManyMethods")
 public final class DirectivesValue implements Iterable<Directive> {
 
     /**
@@ -92,9 +93,11 @@ public final class DirectivesValue implements Iterable<Directive> {
         final Iterable<Directive> res;
         final Codec codec = DirectivesValue.CODEC;
         switch (type) {
+            case "number":
+                res = this.integerNumber(codec);
+                break;
             case "byte":
             case "short":
-            case "int":
             case "float":
             case "double":
                 res = this.jeoNumber(type, codec);
@@ -178,6 +181,19 @@ public final class DirectivesValue implements Iterable<Directive> {
             new DirectivesComment(this.comment()),
             new DirectivesBytes(this.hex(codec))
         );
+    }
+
+    /**
+     * Integer number object.
+     * We decided to use simplified representation of integer numbers.
+     * Previously, we used {@link #jeoNumber(String, Codec)} wrapper.
+     * You can read about it here:
+     * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/1061">#1061</a>
+     * @param codec Codec to use for bytes encoding.
+     * @return JEO number directives.
+     */
+    private Iterable<Directive> integerNumber(final Codec codec) {
+        return new DirectivesNumber(this.name, this.hex(codec));
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeObjectTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeObjectTest.java
@@ -59,7 +59,7 @@ final class BytecodeObjectTest {
         return Stream.of(
             Arguments.of(
                 new BytecodeObject(42),
-                "int",
+                "number",
                 new byte[]{0, 0, 0, 0, 0, 0, 0, 42},
                 42
             ),

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassPropertiesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassPropertiesTest.java
@@ -34,8 +34,8 @@ final class DirectivesClassPropertiesTest {
                     ).up()
             ).xml(),
             XhtmlMatchers.hasXPaths(
-                "/o/o[contains(@base,'jeo.int') and contains(@as,'version')]",
-                "/o/o[contains(@base,'jeo.int') and contains(@as,'access')]",
+                "/o/o[contains(@base,'number') and contains(@as,'version')]",
+                "/o/o[contains(@base,'number') and contains(@as,'access')]",
                 "/o/o[contains(@base,'org.eolang.string') and contains(@as,'signature')]",
                 "/o/o[contains(@base,'org.eolang.string') and contains(@as,'supername')]",
                 "/o/o[contains(@base,'jeo.seq.of1') and contains(@as,'interfaces')]"

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesFieldTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesFieldTest.java
@@ -34,7 +34,7 @@ final class DirectivesFieldTest {
                 "/o/o[@as='access-unknown']",
                 "/o/o[@as='descriptor-unknown']",
                 "/o/o[@as='signature-unknown']",
-                "/o/o[contains(@base,'int') and @as='value-unknown']"
+                "/o/o[contains(@base,'number') and @as='value-unknown']"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesHandleTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesHandleTest.java
@@ -31,7 +31,7 @@ final class DirectivesHandleTest {
             xml,
             XhtmlMatchers.hasXPaths(
                 "/o[contains(@base,'handle')]",
-                "/o[contains(@base,'handle')]/o[contains(@base,'int')]",
+                "/o[contains(@base,'handle')]/o[contains(@base,'number')]",
                 "/o[contains(@base,'handle')]/o[contains(@base,'string')]"
             )
         );

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
@@ -42,7 +42,7 @@ final class DirectivesValueTest {
             ),
             xml,
             XhtmlMatchers.hasXPath(
-                "./o[contains(@base,'jeo.int') and @as='access']/o[contains(@base,'number')]/o[contains(@base, 'bytes')]/text()"
+                "./o[contains(@base,'number') and @as='access']/o[contains(@base, 'bytes')]/text()"
             )
         );
     }
@@ -61,6 +61,25 @@ final class DirectivesValueTest {
                 String.format(
                     "./o[contains(@base,'%s') and @as='access']/o[contains(@base,'number')]/o[contains(@base,'bytes')]/o[text()='%s']",
                     base,
+                    bytes
+                )
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("integers")
+    void convertsIntegers(final Number number, final String bytes) {
+        final String xml = new Xembler(new DirectivesValue("access", number)).xmlQuietly();
+        MatcherAssert.assertThat(
+            String.format(
+                "We expect that integer value is converted to the correct XMIR, but got the incorrect one: %n%s%n",
+                xml
+            ),
+            xml,
+            XhtmlMatchers.hasXPath(
+                String.format(
+                    "./o[contains(@base,'number') and @as='access']/o[contains(@base,'bytes')]/o[text()='%s']",
                     bytes
                 )
             )
@@ -178,7 +197,7 @@ final class DirectivesValueTest {
      */
     static Stream<Arguments> types() {
         return Stream.of(
-            Arguments.of(1, "int"),
+            Arguments.of(1, "number"),
             Arguments.of("Hello!", "string"),
             Arguments.of(new byte[]{1, 2, 3}, "bytes"),
             Arguments.of(new byte[0], "bytes"),
@@ -218,14 +237,24 @@ final class DirectivesValueTest {
     static Stream<Arguments> numbers() {
         final String same = "3F-F0-00-00-00-00-00-00";
         return Stream.of(
-            Arguments.of(1, "jeo.int", same),
             Arguments.of(1L, "jeo.long", same),
             Arguments.of(1.0f, "jeo.float", same),
             Arguments.of(1.0d, "jeo.double", same),
             Arguments.of((short) 1, "jeo.short", same),
-            Arguments.of((byte) 1, "jeo.byte", same),
-            Arguments.of(100, "jeo.int", "40-59-00-00-00-00-00-00"),
-            Arguments.of(1057, "jeo.int", "40-90-84-00-00-00-00-00")
+            Arguments.of((byte) 1, "jeo.byte", same)
+        );
+    }
+
+    /**
+     * Arguments for {@link DirectivesValueTest#convertsIntegers(Number, String)} (Number, String)}.
+     * @return Stream of arguments.
+     */
+    static Stream<Arguments> integers() {
+        final String same = "3F-F0-00-00-00-00-00-00";
+        return Stream.of(
+            Arguments.of(1, same),
+            Arguments.of(100, "40-59-00-00-00-00-00-00"),
+            Arguments.of(1057, "40-90-84-00-00-00-00-00")
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/HasMethod.java
@@ -285,7 +285,7 @@ public final class HasMethod extends TypeSafeMatcher<String> {
                 Stream.of(
                     instruction.concat("/@base"),
                     String.format(
-                        "%s/o[contains(@base,'int')]/o[contains(@base,'number')]/o[contains(@base,'bytes')]/o[text()='%s']/text()",
+                        "%s/o[contains(@base,'number')]/o[contains(@base,'bytes')]/o[text()='%s']/text()",
                         instruction,
                         new DirectivesValue((double) this.opcode).hex(new JavaCodec())
                     )
@@ -312,7 +312,7 @@ public final class HasMethod extends TypeSafeMatcher<String> {
                                 ((Number) arg).doubleValue()
                             );
                             result = String.format(
-                                "%s/o[contains(@base,'%s')]/o[contains(@base,'number')]/o[contains(@base,'bytes')]/o[text()='%s']/text()",
+                                "%s/o[contains(@base,'%s')]/o[contains(@base,'bytes')]/o[text()='%s']/text()",
                                 instruction,
                                 simple.type(),
                                 hex.hex(new JavaCodec())

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlValueTest.java
@@ -28,7 +28,7 @@ final class XmlValueTest {
         final int expected = 1057;
         final int actual = (int) new XmlValue(
             new NativeXmlNode(
-                "<o base='jeo.int'><o base='Q.org.eolang.bytes'><o>40-90-84-00-00-00-00-00</o></o></o>"
+                "<o base='Q.org.eolang.number'><o base='Q.org.eolang.bytes'><o>40-90-84-00-00-00-00-00</o></o></o>"
             )
         ).object();
         MatcherAssert.assertThat(


### PR DESCRIPTION
This pull request refactors the handling of integer representations in the PHI representation. It replaces the usage of `int` with `number` for a more consistent and simplified representation of integer numbers.

In other words, instead of `Φ.jeo.opcode.dload(Φ.jeo.int(24), Φ.jeo.int(1))`, we have `Φ.jeo.opcode.dload(24, 1)`

Related to #1061