### PR TITLE
feat(#1064): Method names `j$main-%28%5BLjava%2Flang%2FString%3B%29V`  -> `j$main-2`

### DIFF
--- a/src/it/phi-unphi/verify.groovy
+++ b/src/it/phi-unphi/verify.groovy
@@ -9,6 +9,8 @@ assert log.contains("BUILD SUCCESS"): assertionMessage("BUILD FAILED")
 assert log.contains("sin(42.000000) = -0.916522"): assertionMessage("sin(42.000000) = -0.916522 not found")
 assert new File(basedir, "target/generated-sources/eo-phi/org/eolang/hone/App.phi").text
   .contains("Φ.jeo.opcode.dup(89)"): assertionMessage("We can't find the correct PHI integer representation")
+assert new File(basedir, "target/generated-sources/eo-phi/org/eolang/hone/mess/A.phi").text
+  .contains("j\$print-3"): assertionMessage("We can't find overloaded method in PHI (with an additional number that is allow us to distinguish between overloaded methods)")
 
 private String assertionMessage(String message) {
     generateGitHubIssue()

--- a/src/main/java/org/eolang/jeo/representation/NumberedName.java
+++ b/src/main/java/org/eolang/jeo/representation/NumberedName.java
@@ -1,25 +1,6 @@
 /*
- * The MIT License (MIT)
- *
- * Copyright (c) 2016-2025 Objectionary.com
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
  */
 package org.eolang.jeo.representation;
 

--- a/src/main/java/org/eolang/jeo/representation/NumberedName.java
+++ b/src/main/java/org/eolang/jeo/representation/NumberedName.java
@@ -1,0 +1,118 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation;
+
+/**
+ * Name with the number at the end.
+ * For example, `foo`, `foo-2`, `foo-3`.
+ * @since 0.9
+ */
+public final class NumberedName {
+
+    /**
+     * Number of the name.
+     */
+    private final int number;
+
+    /**
+     * Original name.
+     */
+    private final String name;
+
+    public NumberedName(final String encoded) {
+        this(NumberedName.suffix(encoded), NumberedName.prefix(encoded));
+    }
+
+    /**
+     * Constructor.
+     * @param number Number of the name starting from 1.
+     * @param name Name of an object.
+     */
+    public NumberedName(final int number, final String name) {
+        this.number = number;
+        this.name = name;
+    }
+
+    /**
+     * Name without the number.
+     * @return Name without the number.
+     */
+    public String plain() {
+        return this.name;
+    }
+
+    @Override
+    public String toString() {
+        if (this.number < 1) {
+            throw new IllegalArgumentException(
+                String.format("Number must be greater than 0, but was: %d", this.number)
+            );
+        }
+        final StringBuilder result = new StringBuilder(this.name);
+        if (this.number > 1) {
+            result.append('-').append(this.number);
+        }
+        return result.toString();
+    }
+
+    /**
+     * Returns the number of the name.
+     * @param encoded Encoded name, like `foo-2`.
+     * @return Number of the name, like `2`.
+     */
+    private static int suffix(final String encoded) {
+        final int result;
+        final int index = encoded.lastIndexOf('-');
+        if (index == -1) {
+            result = 1;
+        } else {
+            final String number = encoded.substring(index + 1);
+            try {
+                result = Integer.parseInt(number);
+            } catch (final NumberFormatException ex) {
+                throw new IllegalArgumentException(
+                    String.format("Invalid number in name: %s", number),
+                    ex
+                );
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Gets the name without the number.
+     * @param encoded Encoded name, like `foo-2`.
+     * @return Name without the number, like `foo`.
+     */
+    private static String prefix(final String encoded) {
+        final String result;
+        final int index = encoded.lastIndexOf('-');
+        if (index == -1) {
+            result = encoded;
+        } else {
+            result = encoded.substring(0, index);
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -284,7 +284,8 @@ public final class BytecodeClass {
             new ClassName(new PrefixedName(this.name).encode()),
             this.props.directives(),
             this.fields.stream().map(BytecodeField::directives).collect(Collectors.toList()),
-            this.cmethods.stream().map(BytecodeMethod::directives)
+            this.cmethods.stream()
+                .map(method -> method.directives(this.mnumber(method)))
                 .collect(Collectors.toList()),
             this.annotations.directives(),
             this.attributes.directives("attributes")
@@ -325,6 +326,18 @@ public final class BytecodeClass {
                 exception
             );
         }
+    }
+
+    /**
+     * Method number.
+     * @param method Method.
+     * @return Method number.
+     */
+    private int mnumber(final BytecodeMethod method) {
+        return this.methods().stream()
+            .filter(m -> m.name().equals(method.name()))
+            .collect(Collectors.toList())
+            .indexOf(method) + 1;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.MethodName;
-import org.eolang.jeo.representation.Signature;
+import org.eolang.jeo.representation.NumberedName;
 import org.eolang.jeo.representation.asm.AsmLabels;
 import org.eolang.jeo.representation.directives.DirectivesMethod;
 import org.objectweb.asm.MethodVisitor;
@@ -252,13 +252,29 @@ public final class BytecodeMethod {
     }
 
     /**
+     * Method instructions.
+     * @return Instructions.
+     */
+    public List<BytecodeEntry> intructions() {
+        return Collections.unmodifiableList(this.instructions);
+    }
+
+    /**
      * Generate directives.
+     * Since EO can't have overloaded methods, we need to add suffix to their names.
+     * This suffix is a number of the method.
+     * For example, if we have two methods with the same name, say 'foo',
+     * then we add suffixes to their names:
+     * foo and foo-2.
+     * That is why we need to pass method number to this method.
+     * @param number Method number.
      * @return Directives.
      */
-    public DirectivesMethod directives() {
+    public DirectivesMethod directives(final int number) {
         return new DirectivesMethod(
-            new Signature(
-                new MethodName(this.properties.name()).xmir(), this.properties.descriptor()
+            new NumberedName(
+                number,
+                new MethodName(this.properties.name()).xmir()
             ),
             this.properties.directives(this.maxs),
             this.instructions.stream().map(BytecodeEntry::directives)
@@ -274,11 +290,11 @@ public final class BytecodeMethod {
     }
 
     /**
-     * Method instructions.
-     * @return Instructions.
+     * Generate directives.
+     * @return Directives.
      */
-    public List<BytecodeEntry> intructions() {
-        return Collections.unmodifiableList(this.instructions);
+    DirectivesMethod directives() {
+        return this.directives(1);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.MethodName;
+import org.eolang.jeo.representation.NumberedName;
 import org.eolang.jeo.representation.PrefixedName;
-import org.eolang.jeo.representation.Signature;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -28,7 +28,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
     /**
      * Method name.
      */
-    private final Signature name;
+    private final NumberedName name;
 
     /**
      * Method properties.
@@ -78,7 +78,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
         final DirectivesMethodProperties properties
     ) {
         this(
-            new Signature(new MethodName(name).xmir(), properties.descr()),
+            new NumberedName(1, new MethodName(name).xmir()),
             properties,
             new ArrayList<>(0),
             new ArrayList<>(0),
@@ -100,7 +100,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
      * @checkstyle ParameterNumberCheck (10 lines)
      */
     public DirectivesMethod(
-        final Signature name,
+        final NumberedName name,
         final DirectivesMethodProperties properties,
         final List<Iterable<Directive>> instructions,
         final List<Iterable<Directive>> exceptions,
@@ -142,14 +142,14 @@ public final class DirectivesMethod implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "method",
-            new PrefixedName(this.name.encoded()).encode(),
+            new PrefixedName(this.name.toString()).encode(),
             Stream.concat(
                 Stream.of(
                     this.properties,
                     this.annotations,
                     new DirectivesOptionalSeq("body", this.instructions),
                     new DirectivesOptionalSeq(
-                        String.format("trycatchblocks-%s", this.name.name()),
+                        String.format("trycatchblocks-%s", this.name.plain()),
                         this.exceptions
                     )
                 ),

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -13,8 +13,8 @@ import java.util.stream.Stream;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.MethodName;
+import org.eolang.jeo.representation.NumberedName;
 import org.eolang.jeo.representation.PrefixedName;
-import org.eolang.jeo.representation.Signature;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.eolang.jeo.representation.bytecode.BytecodeAttributes;
 import org.eolang.jeo.representation.bytecode.BytecodeMaxs;
@@ -170,14 +170,14 @@ public final class XmlMethod {
     private String name() {
         return new MethodName(
             new PrefixedName(
-                new Signature(
+                new NumberedName(
                     this.node.attribute("as")
                         .orElseThrow(
                             () -> new IllegalStateException(
                                 "Method 'name' attribute is not present"
                             )
                         )
-                ).name()
+                ).plain()
             ).decode()
         ).bytecode();
     }

--- a/src/test/java/org/eolang/jeo/representation/NumberedNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/NumberedNameTest.java
@@ -1,25 +1,6 @@
 /*
- * The MIT License (MIT)
- *
- * Copyright (c) 2016-2025 Objectionary.com
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
  */
 package org.eolang.jeo.representation;
 

--- a/src/test/java/org/eolang/jeo/representation/NumberedNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/NumberedNameTest.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.jeo.representation;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Test case for {@link NumberedName}.
+ * @since 0.9
+ */
+final class NumberedNameTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "foo, 1, foo",
+        "foo, 2, foo-2",
+        "foo, 3, foo-3"
+    })
+    void formatsName(final String name, final int number, final String expected) {
+        MatcherAssert.assertThat(
+            String.format(
+                "Incorrectly formatted name, expected %s, got %s",
+                expected,
+                new NumberedName(number, name)
+            ),
+            new NumberedName(number, name).toString(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    void throwsExceptionWhenNumberIsLessThanOne() {
+        MatcherAssert.assertThat(
+            "We expect that exception message will be human-readable",
+            Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new NumberedName(0, "foo").toString(),
+                "Exception was not thrown"
+            ).getMessage(),
+            Matchers.equalTo("Number must be greater than 0, but was: 0")
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "foo, foo",
+        "foo-2, foo",
+        "bar-3, bar",
+        "foobar-4, foobar"
+    })
+    void decodesName(final String encoded, final String expected) {
+        MatcherAssert.assertThat(
+            "Incorrectly decoded name",
+            new NumberedName(encoded).plain(),
+            Matchers.equalTo(expected)
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -6,7 +6,7 @@ package org.eolang.jeo.representation.directives;
 
 import com.jcabi.matchers.XhtmlMatchers;
 import java.util.Collections;
-import org.eolang.jeo.representation.Signature;
+import org.eolang.jeo.representation.NumberedName;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.eolang.jeo.representation.bytecode.BytecodeMaxs;
@@ -84,7 +84,7 @@ final class DirectivesMethodTest {
     void addsPrefixToTheMethodName() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "We expect that 'j$' prefix will be added to the method name",
-            new Xembler(new BytecodeMethod("φTerm").directives()).xml(),
+            new Xembler(new BytecodeMethod("φTerm").directives(1)).xml(),
             XhtmlMatchers.hasXPaths("./o[contains(@as, 'j$φTerm')]")
         );
     }
@@ -133,7 +133,7 @@ final class DirectivesMethodTest {
             "We expect that the method body name will be generated correctly without any suffixes and prefixes",
             new Xembler(
                 new DirectivesMethod(
-                    new Signature("checks1063", descriptor),
+                    new NumberedName(1, "checks1063"),
                     new DirectivesMethodProperties(1, descriptor, ""),
                     Collections.singletonList(new DirectivesInstruction(Opcodes.RETURN)),
                     Collections.emptyList(),


### PR DESCRIPTION
This PR changes method name generation strategy by removing encoded descriptor from the name and adds numbered suffixes to distinguish between overloaded methods. Long story short, instead of 
 `j$main-%28%5BLjava%2Flang%2FString%3B%29V` now we have `j$main-2`.

Related to #1064