### PR TITLE
refactor(#1062): simplify PHI parameter representation for optimization

### DIFF
--- a/src/it/phi-unphi/verify.groovy
+++ b/src/it/phi-unphi/verify.groovy
@@ -7,8 +7,9 @@ import java.nio.file.Files
 String log = new File(basedir, 'build.log').text;
 assert log.contains("BUILD SUCCESS"): assertionMessage("BUILD FAILED")
 assert log.contains("sin(42.000000) = -0.916522"): assertionMessage("sin(42.000000) = -0.916522 not found")
-assert new File(basedir, "target/generated-sources/eo-phi/org/eolang/hone/App.phi").text
-  .contains("Φ.jeo.opcode.dup(89)"): assertionMessage("We can't find the correct PHI integer representation")
+def phi = new File(basedir, "target/generated-sources/eo-phi/org/eolang/hone/App.phi").text
+assert phi.contains("Φ.jeo.opcode.dup(89)"): assertionMessage("We can't find the correct PHI integer representation")
+assert phi.contains("arg0 ↦ Φ.jeo.param("): assertionMessage("We can't find the correct PHI parameter representation")
 assert new File(basedir, "target/generated-sources/eo-phi/org/eolang/hone/mess/A.phi").text
   .contains("j\$print-3"): assertionMessage("We can't find overloaded method in PHI (with an additional number that is allow us to distinguish between overloaded methods)")
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotations.java
@@ -50,7 +50,7 @@ public final class DirectivesAnnotations implements Iterable<Directive> {
     /**
      * Constructor.
      */
-    DirectivesAnnotations() {
+    public DirectivesAnnotations() {
         this(new ArrayList<>(0));
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParam.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParam.java
@@ -5,8 +5,6 @@
 package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
-import java.util.Random;
-import org.eolang.jeo.representation.DecodedString;
 import org.objectweb.asm.Type;
 import org.xembly.Directive;
 
@@ -15,11 +13,6 @@ import org.xembly.Directive;
  * @since 0.6
  */
 public final class DirectivesMethodParam implements Iterable<Directive> {
-
-    /**
-     * Random number generator.
-     */
-    private static final Random RANDOM = new Random();
 
     /**
      * Index of the parameter.
@@ -73,14 +66,10 @@ public final class DirectivesMethodParam implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "param",
-            String.format(
-                "param-%s-%s-%d-%d-%d",
-                new DecodedString(this.type.toString()).encode(),
-                this.name,
-                this.access,
-                this.index,
-                DirectivesMethodParam.RANDOM.nextInt()
-            ),
+            this.name,
+            new DirectivesValue("index", this.index),
+            new DirectivesValue("access", this.access),
+            new DirectivesValue("type", this.type.toString()),
             this.annotations
         ).iterator();
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java
@@ -47,7 +47,7 @@ public final class XmlParam {
      * @return Type.
      */
     private Type type() {
-        return Type.getType(new EncodedString(this.suffix(1)).decode());
+        return Type.getType(new EncodedString(this.child("type").string()).decode());
     }
 
     /**
@@ -55,7 +55,7 @@ public final class XmlParam {
      * @return Name.
      */
     private String pure() {
-        return this.suffix(2);
+        return this.name();
     }
 
     /**
@@ -63,7 +63,7 @@ public final class XmlParam {
      * @return Access.
      */
     private int access() {
-        return Integer.parseInt(this.suffix(3));
+        return (int) this.child("access").object();
     }
 
     /**
@@ -71,7 +71,7 @@ public final class XmlParam {
      * @return Index.
      */
     private int index() {
-        return Integer.parseInt(this.suffix(4));
+        return (int) this.child("index").object();
     }
 
     /**
@@ -92,14 +92,21 @@ public final class XmlParam {
     }
 
     /**
-     * Get the suffix of the name attribute.
-     * position[0]-position[1]-position[2].
-     * param      -type       -index
-     * @param position Position of the suffix.
-     * @return Suffix.
+     * Child node with the given name.
+     * @param name Name of the child node.
+     * @return Child node.
      */
-    private String suffix(final int position) {
-        return this.name().split("-")[position];
+    private XmlValue child(final String name) {
+        return new XmlValue(
+            this.root.children()
+                .filter(node -> node.attribute("as").map(name::equals).orElse(false))
+                .findFirst()
+                .orElseThrow(
+                    () -> new IllegalStateException(
+                        String.format("Child with attribute 'as'='%s' not found", name)
+                    )
+                )
+        );
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
@@ -44,17 +44,17 @@ final class BytecodeMethodParameterTest {
             Arguments.of(
                 0,
                 Type.INT_TYPE,
-                "/o[contains(@base,'param') and contains(@as,'param-I-arg0-0-0')]"
+                "/o[contains(@base,'param') and contains(@as,'arg0')]"
             ),
             Arguments.of(
                 1,
                 Type.INT_TYPE,
-                "/o[contains(@base,'param') and contains(@as,'param-I-arg1-0-1')]"
+                "/o[contains(@base,'param') and contains(@as,'arg1')]"
             ),
             Arguments.of(
                 2,
                 Type.DOUBLE_TYPE,
-                "/o[contains(@base,'param') and contains(@as,'param-D-arg2-0-2')]"
+                "/o[contains(@base,'param') and contains(@as,'arg2')]"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParametersTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParametersTest.java
@@ -29,8 +29,8 @@ final class BytecodeMethodParametersTest {
             ).xml(),
             XhtmlMatchers.hasXPaths(
                 "/o[contains(@base,'params')]",
-                "/o[contains(@base,'params')]/o[contains(@base,'param') and contains(@as,'param-I-arg0-0-0')]",
-                "/o[contains(@base,'params')]/o[contains(@base,'param') and contains(@as,'param-I-arg1-0-1')]"
+                "/o[contains(@base,'params')]/o[contains(@base,'param') and contains(@as,'arg0')]",
+                "/o[contains(@base,'params')]/o[contains(@base,'param') and contains(@as,'arg1')]"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -126,8 +126,8 @@ final class BytecodeMethodTest {
             xml,
             new HasMethod(method)
                 .inside(clazz)
-                .withParameter("param-I-arg0-0-0")
-                .withParameter("param-I-arg1-0-1")
+                .withParameter("arg0")
+                .withParameter("arg1")
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodParamTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodParamTest.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link DirectivesMethodParam}.
+ * @since 0.9
+ */
+final class DirectivesMethodParamTest {
+
+    @Test
+    void generatesParamDirectivesWithSimpleName() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect that the parameter directives will be generated with a simple name that includes the name",
+            new Xembler(
+                new DirectivesMethodParam(
+                    1, "foo", Opcodes.ACC_PUBLIC, Type.INT_TYPE, new DirectivesAnnotations()
+                )
+            ).xml(),
+            XhtmlMatchers.hasXPath("./o[contains(@base, param) and contains(@as, 'foo')]")
+        );
+    }
+
+    @Test
+    void generatesParamDirectivesWithIndex() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect that the parameter directives will be generated with an index",
+            new Xembler(
+                new DirectivesMethodParam(
+                    2, "bar", Opcodes.ACC_PRIVATE, Type.DOUBLE_TYPE, new DirectivesAnnotations()
+                )
+            ).xml(),
+            XhtmlMatchers.hasXPath(
+                "./o[contains(@base, param)]/o[contains(@base, 'number') and contains(@as, 'index')]"
+            )
+        );
+    }
+
+    @Test
+    void generatesPramDirectivesWithAccessModifier() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect that the parameter directives will be generated with an access modifier",
+            new Xembler(
+                new DirectivesMethodParam(
+                    3, "baz", Opcodes.ACC_PROTECTED, Type.LONG_TYPE, new DirectivesAnnotations()
+                )
+            ).xml(),
+            XhtmlMatchers.hasXPath(
+                "./o[contains(@base, param)]/o[contains(@base, 'number') and contains(@as, 'access')]"
+            )
+        );
+    }
+
+    @Test
+    void generatesParamDirectivesWithType() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect that the parameter directives will be generated with a type",
+            new Xembler(
+                new DirectivesMethodParam(
+                    4,
+                    "qux",
+                    Opcodes.ACC_STATIC,
+                    Type.getType("Lorg/eolang/jeo/representation/directives;"),
+                    new DirectivesAnnotations()
+                )
+            ).xml(),
+            XhtmlMatchers.hasXPath(
+                "./o[contains(@base, param)]/o[contains(@base, 'string') and contains(@as, 'type')]"
+            )
+        );
+    }
+
+    @Test
+    void generatesParamDirectivesWithAnnotations() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect that the parameter directives will be generated with annotations",
+            new Xembler(
+                new DirectivesMethodParam(
+                    5,
+                    "quux",
+                    Opcodes.ACC_ABSTRACT,
+                    Type.FLOAT_TYPE,
+                    new DirectivesAnnotations(
+                        "annotations", new DirectivesAnnotation("Ljava/lang/Override;", true)
+                    )
+                )
+            ).xml(),
+            XhtmlMatchers.hasXPath(
+                "./o[contains(@base, param)]/o[contains(@base, 'seq.of') and contains(@as, 'annotations')]"
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlParamTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlParamTest.java
@@ -4,10 +4,13 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
+import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodParameter;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
@@ -20,7 +23,13 @@ final class XmlParamTest {
 
     @Test
     void convertsToBytecode() throws ImpossibleModificationException {
-        final BytecodeMethodParameter expected = new BytecodeMethodParameter(0, Type.INT_TYPE);
+        final BytecodeMethodParameter expected = new BytecodeMethodParameter(
+            1,
+            "foo",
+            Opcodes.ACC_STATIC,
+            Type.INT_TYPE,
+            new BytecodeAnnotations(new BytecodeAnnotation("Ljava/lang/Deprecated;", true))
+        );
         MatcherAssert.assertThat(
             "Can't convert XML param to bytecode",
             new XmlParam(


### PR DESCRIPTION
This pull request refactors the representation of method parameters in `Φ.jeo.params` to improve optimization capabilities by using structured attributes instead of encoded names. 

Before:
```
param-%5BLjava%2Flang%2FString%3B-arg0-0-0-556384129 ↦ Φ.jeo.param
```

After:
```
arg0 ↦ Φ.jeo.param(
  index ↦ 0,
  access ↦ 0,
  type ↦ "[Ljava/lang/String;"
)
```

Related to #1062