### PR TITLE
build(#1083): update EO language version to 0.56.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
-      <version>0.56.0</version>
+      <version>0.56.2</version>
     </dependency>
     <dependency>
       <groupId>com.github.volodya-lombrozo</groupId>

--- a/src/it/annotations/pom.xml
+++ b/src/it/annotations/pom.xml
@@ -48,7 +48,7 @@
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.56.0</version>
+        <version>0.56.2</version>
         <executions>
           <execution>
             <id>convert-xmir-to-eo</id>

--- a/src/it/bytecode-to-eo/pom.xml
+++ b/src/it/bytecode-to-eo/pom.xml
@@ -54,7 +54,7 @@
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.56.0</version>
+        <version>0.56.2</version>
         <executions>
           <execution>
             <id>convert-xmir-to-phi</id>
@@ -82,7 +82,7 @@
           <plugin>
             <groupId>org.eolang</groupId>
             <artifactId>eo-maven-plugin</artifactId>
-            <version>0.56.0</version>
+            <version>0.56.2</version>
             <executions>
               <execution>
                 <id>convert-xmir-to-eo</id>

--- a/src/it/custom-transformations/pom.xml
+++ b/src/it/custom-transformations/pom.xml
@@ -48,7 +48,7 @@
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.56.0</version>
+        <version>0.56.2</version>
         <executions>
           <execution>
             <id>convert-xmir-to-eo</id>

--- a/src/it/exceptions/pom.xml
+++ b/src/it/exceptions/pom.xml
@@ -66,7 +66,7 @@
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.56.0</version>
+        <version>0.56.2</version>
         <executions>
           <execution>
             <id>convert-xmir-to-eo</id>

--- a/src/it/generics/pom.xml
+++ b/src/it/generics/pom.xml
@@ -48,7 +48,7 @@
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.56.0</version>
+        <version>0.56.2</version>
         <executions>
           <execution>
             <id>convert-xmir-to-eo</id>

--- a/src/it/jna/pom.xml
+++ b/src/it/jna/pom.xml
@@ -188,7 +188,7 @@
           <plugin>
             <groupId>org.eolang</groupId>
             <artifactId>eo-maven-plugin</artifactId>
-            <version>0.56.0</version>
+            <version>0.56.2</version>
             <executions>
               <execution>
                 <id>xmir-to-phi</id>

--- a/src/it/phi-unphi/pom.xml
+++ b/src/it/phi-unphi/pom.xml
@@ -19,7 +19,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <eo.version>0.56.0</eo.version>
+    <eo.version>0.56.2</eo.version>
     <stack-size>256M</stack-size>
     <jeo.disassemble>${project.build.directory}/generated-sources/jeo-disassemble</jeo.disassemble>
     <eo.phi>${project.build.directory}/generated-sources/eo-phi</eo.phi>

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -68,7 +68,7 @@
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.56.0</version>
+        <version>0.56.2</version>
         <executions>
           <execution>
             <id>convert-xmir-to-phi</id>

--- a/src/it/takes/pom.xml
+++ b/src/it/takes/pom.xml
@@ -64,7 +64,7 @@
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.56.0</version>
+        <version>0.56.2</version>
         <executions>
           <execution>
             <id>convert-xmir-to-phi</id>

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesObject.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesObject.java
@@ -95,7 +95,7 @@ public final class DirectivesObject implements Iterable<Directive> {
             .attr("revision", Manifests.read("JEO-Revision"))
             .attr("dob", Manifests.read("JEO-Dob"))
             .attr("time", now)
-            .attr("xsi:noNamespaceSchemaLocation", "https://www.eolang.org/xsd/XMIR-0.56.0.xsd")
+            .attr("xsi:noNamespaceSchemaLocation", "https://www.eolang.org/xsd/XMIR-0.56.2.xsd")
             .add("listing")
             .set(this.listing)
             .up()


### PR DESCRIPTION
Updates EO language dependencies and XMIR schema references from `0.56.0` to `0.56.2` for compatibility.

Closes #1083