### PR TITLE
fix(#1085): Fix typos and markdown lint errors in codebase

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Default state for all rules
+default: true
+
+# Line length : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md013.md
+MD013:
+  line_length: 100
+
+# Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md033.md
+MD033:
+  allowed_elements: [ img ]
+
+# Fenced code blocks should have a language specified : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md040.md
+MD040: false
+
+# First line in a file should be a top-level heading : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md041.md
+MD041: false

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -11,9 +11,3 @@ MD013:
 # Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md033.md
 MD033:
   allowed_elements: [ img ]
-
-# Fenced code blocks should have a language specified : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md040.md
-MD040: false
-
-# First line in a file should be a top-level heading : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md041.md
-MD041: false

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -7,7 +7,3 @@ default: true
 # Line length : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md013.md
 MD013:
   line_length: 100
-
-# Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.33.0/doc/md033.md
-MD033:
-  allowed_elements: [ img ]

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+[default]
+extend-ignore-identifiers-re = [
+    "IFLE", "interfce"
+]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-team@objectionary.com.
+[team@objectionary.com](team@objectionary.com).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -115,8 +115,8 @@ the community.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+version 2.0, available
+at [code_of_conduct.html](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html).
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
@@ -124,5 +124,6 @@ enforcement ladder](https://github.com/mozilla/diversity).
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+[https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq).
+Translations are available at
+[https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jeo-maven-plugin
 
-<img alt="logo" src="https://www.objectionary.com/cactus.svg" height="100px" />
+[![logo](https://www.objectionary.com/cactus-100.svg)](https://www.objectionary.com)
 
 [![Maven Central](https://img.shields.io/maven-central/v/org.eolang/jeo-maven-plugin.svg)](https://maven-badges.herokuapp.com/maven-central/org.eolang/jeo-maven-plugin)
 [![Javadoc](https://www.javadoc.io/badge/org.eolang/jeo-maven-plugin.svg)](https://www.javadoc.io/doc/org.eolang/jeo-maven-plugin)

--- a/README.md
+++ b/README.md
@@ -290,74 +290,74 @@ Below is the full list of these objects, grouped by category:
 
 ### Bytecode Instructions
 
-- **`jeo.opcode.*`**
+* **`jeo.opcode.*`**
   Represents a single bytecode instruction like `aload_0`, `iconst_0`, etc.
 
 ### Classes, Methods, and Fields
 
-- **`jeo.class`**
+* **`jeo.class`**
   Represents a Java class.
-- **`jeo.method`**
+* **`jeo.method`**
   Represents a Java method.
-- **`jeo.field`**
+* **`jeo.field`**
   Represents a Java field.
-- **`jeo.params`**
+* **`jeo.params`**
   Represents method parameters.
-- **`jeo.param`**
+* **`jeo.param`**
   Represents a single method parameter.
-- **`jeo.maxs`**
+* **`jeo.maxs`**
   Represents the maximum stack and local variable sizes.
 
 ### Primitive Values
 
-- **`jeo.int`** - Represents an integer value.
-- **`jeo.bool`** - Represents a boolean value.
-- **`jeo.string`** - Represents a string value.
-- **`jeo.float`** - Represents a float value.
-- **`jeo.double`** - Represents a double value.
-- **`jeo.long`** - Represents a long value.
-- **`jeo.char`** - Represents a char value.
-- **`jeo.short`** - Represents a short value.
-- **`jeo.byte`** - Represents a byte value.
-- **`jeo.bytes`** - Represents a byte array.
+* **`jeo.int`** - Represents an integer value.
+* **`jeo.bool`** - Represents a boolean value.
+* **`jeo.string`** - Represents a string value.
+* **`jeo.float`** - Represents a float value.
+* **`jeo.double`** - Represents a double value.
+* **`jeo.long`** - Represents a long value.
+* **`jeo.char`** - Represents a char value.
+* **`jeo.short`** - Represents a short value.
+* **`jeo.byte`** - Represents a byte value.
+* **`jeo.bytes`** - Represents a byte array.
 
 ### Collections and Complex Types
 
-- **`jeo.nullable`**
+* **`jeo.nullable`**
   Represents an object that can be `null`.
-- **`jeo.array`**
+* **`jeo.array`**
   Represents an array of objects.
-- **`jeo.type`**
+* **`jeo.type`**
   Represents a Java type.
-- **`jeo.seq.*`**
+* **`jeo.seq.*`**
   Represents a sequence of objects with a specific size,
   like `jeo.seq.of0`, `jeo.seq.of1`, etc.
 
 ### Annotations and Metadata
 
-- **`jeo.annotation`**
+* **`jeo.annotation`**
   Represents a Java annotation.
-- **`jeo.annotation-property`**
+* **`jeo.annotation-property`**
   Represents a single annotation element.
-- **`jeo.annotation-default-value`**
+* **`jeo.annotation-default-value`**
   Represents a default value of a Java interface method or annotation property.
-- **`jeo.inner-class`**
+* **`jeo.inner-class`**
   Represents a Java inner class annotation property.
 
 ### Local Variables and Control Flow
 
-- **`jeo.local-variable`**
+* **`jeo.local-variable`**
   Represents a local variable entry.
-- **`jeo.try-catch`**
+* **`jeo.try-catch`**
   Represents a try-catch block.
 
 ### Labels, Handles, Frames
 
-- **`jeo.label`**
+* **`jeo.label`**
   Represents a Java label.
-- **`jeo.handle`**
+* **`jeo.handle`**
   Represents a Java method handle.
-- **`jeo.frame`**
+* **`jeo.frame`**
   Represents a stack frame.
 
 ## How to Build the Plugin
@@ -372,7 +372,6 @@ mvn clean install -Pqulice,long
 Pay attention to the `qulice` profile, which activates the static analysis
 tools. The `long` profile is optional and runs the full test suite, including
 long-running integration tests.
-
 
 ## How to Run Benchmarks
 
@@ -399,7 +398,7 @@ provided they don't violate our quality standards. To avoid frustration,
 before sending us your pull request please run full Maven build:
 
 ```bash
-$ mvn clean install -Pqulice
+mvn clean install -Pqulice
 ```
 
 You will need [Maven 3.3+](https://maven.apache.org) and Java 11+ installed.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# jeo-maven-plugin
+
 <img alt="logo" src="https://www.objectionary.com/cactus.svg" height="100px" />
 
 [![Maven Central](https://img.shields.io/maven-central/v/org.eolang/jeo-maven-plugin.svg)](https://maven-badges.herokuapp.com/maven-central/org.eolang/jeo-maven-plugin)
@@ -13,7 +15,7 @@ the [EO](https://github.com/objectionary/eo)
 programming language.
 The plugin also provides the ability to assemble EO back into Java bytecode.
 
-# How to use
+## How to use
 
 You need at least **Maven 3.1+** and **Java 11+** to run the plugin.
 (Actually, the plugin requires **Java 8+**, but since the main

--- a/src/it/custom-transformations/src/main/java/org/eolang/jeo/Application.java
+++ b/src/it/custom-transformations/src/main/java/org/eolang/jeo/Application.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 public class Application {
     public static void main(String[] args) {
         dynamicDispatch();
-        funcionalInterfaces();
+        functionalInterfaces();
         streams();
     }
 
@@ -40,7 +40,7 @@ public class Application {
         return 8;
     }
 
-    private static void funcionalInterfaces() {
+    private static void functionalInterfaces() {
         Runnable r = () -> System.out.println("Runnable test passed successfully!");
         r.run();
         Predicate<String> p = s -> s.length() > 10;

--- a/src/it/custom-transformations/src/main/java/org/eolang/spring/package-info.java
+++ b/src/it/custom-transformations/src/main/java/org/eolang/spring/package-info.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 /**
- * This package contains all the cases that accidentaly broke `spring-fat` integration test.
+ * This package contains all the cases that accidentally broke `spring-fat` integration test.
  * So, all the identified cases are placed here.
  * @since 0.3
  */

--- a/src/it/jna/README.md
+++ b/src/it/jna/README.md
@@ -1,7 +1,7 @@
 # JNA Usage Test
 
 This integration test was added in order to mitigate the problem
-with JNA usage: https://github.com/objectionary/hone-maven-plugin/issues/58
+with [JNA usage](https://github.com/objectionary/hone-maven-plugin/issues/58)
 
 To run this test exclusively, execute the command below:
 

--- a/src/it/spring-fat/README.md
+++ b/src/it/spring-fat/README.md
@@ -13,7 +13,7 @@ The process is as follows:
 
 1. **Download all dependencies**
 2. **Unpack them**
-3. **Disassemble**: Apply transformation via the `jeo-maven-plugin:dissassemble`
+3. **Disassemble**: Apply transformation via the `jeo-maven-plugin:disassemble`
    goal for all the
    unpacked dependencies
 4. **Assemble**: Apply back transformation via the `jeo-maven-plugin:assemble`

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -35,7 +35,7 @@ public final class BytecodeMethod {
     /**
      * Method Instructions.
      */
-    private final List<BytecodeEntry> instructions;
+    private final List<BytecodeEntry> entries;
 
     /**
      * Method annotations.
@@ -180,7 +180,7 @@ public final class BytecodeMethod {
         final BytecodeAttributes attributes
     ) {
         this.tryblocks = tryblocks;
-        this.instructions = instructions;
+        this.entries = instructions;
         this.annotations = annotations;
         this.properties = properties;
         this.defvalues = defvalues;
@@ -195,7 +195,7 @@ public final class BytecodeMethod {
     public BytecodeMethod withoutMaxs() {
         return new BytecodeMethod(
             this.tryblocks,
-            this.instructions,
+            this.entries,
             this.annotations,
             this.properties,
             this.defvalues,
@@ -229,7 +229,7 @@ public final class BytecodeMethod {
      * @return This object.
      */
     public BytecodeMethod entry(final BytecodeEntry entry) {
-        this.instructions.add(entry);
+        this.entries.add(entry);
         return this;
     }
 
@@ -255,8 +255,8 @@ public final class BytecodeMethod {
      * Method instructions.
      * @return Instructions.
      */
-    public List<BytecodeEntry> intructions() {
-        return Collections.unmodifiableList(this.instructions);
+    public List<BytecodeEntry> instructions() {
+        return Collections.unmodifiableList(this.entries);
     }
 
     /**
@@ -277,7 +277,7 @@ public final class BytecodeMethod {
                 new MethodName(this.properties.name()).xmir()
             ),
             this.properties.directives(this.maxs),
-            this.instructions.stream().map(BytecodeEntry::directives)
+            this.entries.stream().map(BytecodeEntry::directives)
                 .collect(Collectors.toList()),
             this.tryblocks.stream().map(BytecodeEntry::directives)
                 .collect(Collectors.toList()),
@@ -314,7 +314,7 @@ public final class BytecodeMethod {
             if (!this.properties.isAbstract()) {
                 mvisitor.visitCode();
                 this.tryblocks.forEach(block -> block.writeTo(mvisitor, all));
-                this.instructions.forEach(instruction -> instruction.writeTo(mvisitor, all));
+                this.entries.forEach(instruction -> instruction.writeTo(mvisitor, all));
                 final BytecodeMaxs max;
                 if (this.maxs.compute()) {
                     max = this.computeMaxs();
@@ -393,7 +393,7 @@ public final class BytecodeMethod {
      * @return Instructions view in human-readable format.
      */
     String instructionsView() {
-        return this.instructions.stream()
+        return this.entries.stream()
             .map(BytecodeEntry::view)
             .collect(Collectors.joining("\n"));
     }
@@ -404,7 +404,7 @@ public final class BytecodeMethod {
      */
     private int computeStack() {
         return new MaxStack(
-            this.instructions,
+            this.entries,
             this.tryblocks.stream()
                 .filter(BytecodeTryCatchBlock.class::isInstance)
                 .map(BytecodeTryCatchBlock.class::cast)
@@ -419,7 +419,7 @@ public final class BytecodeMethod {
     private int computeLocals() {
         return new MaxLocals(
             this.properties,
-            this.instructions,
+            this.entries,
             this.tryblocks.stream()
                 .filter(BytecodeTryCatchBlock.class::isInstance)
                 .map(BytecodeTryCatchBlock.class::cast)

--- a/src/main/java/org/eolang/jeo/representation/bytecode/package-info.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/package-info.java
@@ -4,7 +4,7 @@
  */
 /**
  * Contains classes for generating bytecode in the form of Java classes.
- * Some sort of API for generating Java classes. Usefull for generating
+ * Some sort of API for generating Java classes. Useful for generating
  * inputs for tests. The classes also used in {@link org.eolang.jeo.representation.xmir} package
  * to generate bytecode from XMIR files.
  *

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValues.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValues.java
@@ -39,12 +39,12 @@ public final class DirectivesValues implements Iterable<Directive> {
 
     /**
      * Constructor.
-     * @param vaues Values themselves.
+     * @param values Values themselves.
      * @param <T> Values type.
      */
     @SafeVarargs
-    <T> DirectivesValues(final T... vaues) {
-        this("", vaues);
+    <T> DirectivesValues(final T... values) {
+        this("", values);
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/asm/AsmProgramTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/AsmProgramTest.java
@@ -46,7 +46,7 @@ final class AsmProgramTest {
                 .top()
                 .methods()
                 .get(1)
-                .intructions()
+                .instructions()
                 .stream()
                 .anyMatch(entry -> entry instanceof BytecodeLabel || entry instanceof BytecodeLine),
             Matchers.is(false)

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesInstructionTest.java
@@ -24,7 +24,7 @@ final class DirectivesInstructionTest {
     @MethodSource("instructions")
     void addsBeautifulComment(final BytecodeInstruction instr, final String comment) {
         MatcherAssert.assertThat(
-            "We expect, that during convertation to XML, we will get a beautiful comment for bytecode instruction",
+            "We expect, that during transformation to XML, we will get a beautiful comment for bytecode instruction",
             new Xembler(instr.directives()).xmlQuietly(),
             Matchers.containsString(comment)
         );

--- a/src/test/resources/maxs/MaxInterface.java
+++ b/src/test/resources/maxs/MaxInterface.java
@@ -6,7 +6,7 @@
 /**
  * This class contains many different methods with different number of local
  * variables and stack elements.
- * Primarly this class is used in {@link BytecodeMethodTest} to test how the
+ * Primarily this class is used in {@link BytecodeMethodTest} to test how the
  * {@link BytecodeMethod} class counts the maxs.
  * @since 0.6
  */

--- a/src/test/resources/maxs/Maxs.java
+++ b/src/test/resources/maxs/Maxs.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
 /**
  * This class contains many different methods with different number of local
  * variables and stack elements.
- * Primarly this class is used in {@link BytecodeMethodTest} to test how the
+ * Primarily this class is used in {@link BytecodeMethodTest} to test how the
  * {@link BytecodeMethod} class counts the maxs.
  * @since 0.6
  */


### PR DESCRIPTION
This PR fixes typos in documentation and code to resolve failing `markdown-lint` and `typos` pipelines, including corrections to method names and comments.

Closes #1085