### PR TITLE
build(#1088): Upgrade Dependencies And Fix Linter Warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.68.0</version>
+    <version>0.69.3</version>
   </parent>
   <groupId>org.eolang</groupId>
   <artifactId>jeo-maven-plugin</artifactId>
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>Saxon-HE</artifactId>
-      <version>12.5</version>
+      <version>12.7</version>
       <scope>runtime</scope>
     </dependency>
     <!--
@@ -605,7 +605,7 @@
           <plugin>
             <groupId>org.codehaus.gmavenplus</groupId>
             <artifactId>gmavenplus-plugin</artifactId>
-            <version>4.1.1</version>
+            <version>4.2.0</version>
             <executions>
               <execution>
                 <phase>verify</phase>


### PR DESCRIPTION
This PR updates dependency versions in `pom.xml` and fixes all linter warnings. 

Closes #1088