### PR TITLE
fix(#1069): update lints dependency to v0.0.50 and refactor validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@
 .idea/
 node_modules/
 target/
+.settings/
+.project
+.classpath
+.factorypath
+

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>lints</artifactId>
-      <version>0.0.46</version>
+      <version>0.0.50</version>
     </dependency>
     <dependency>
       <groupId>org.cactoos</groupId>

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.lints.Defect;
-import org.eolang.lints.Program;
+import org.eolang.lints.Source;
 import org.eolang.parser.StrictXmir;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -136,7 +136,7 @@ public final class JcabiXmlNode implements XmlNode {
     @Override
     public void validate() {
         final Collection<Defect> defects = new ArrayList<>(
-            new Program(new StrictXmir(this.doc)).defects()
+            new Source(new StrictXmir(this.doc)).defects()
         );
         if (!defects.isEmpty()) {
             throw new IllegalStateException(


### PR DESCRIPTION
Updates `org.eolang:lints` dependency from v0.0.46 to v0.0.49 and adjusts code to use the new `Source` class instead of `Program`. Also adds Eclipse IDE files to `.gitignore`.

Closes #1069