### PR TITLE
fix(#1110): Validate opcode type in XmlInstruction to prevent ClassCastException

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlInstruction.java
@@ -68,7 +68,17 @@ public final class XmlInstruction implements XmlBytecodeEntry {
      */
     @EqualsAndHashCode.Include
     private int opcode() {
-        return (int) new XmlValue(this.node.firstChild()).object();
+        final Object value = new XmlValue(this.node.firstChild()).object();
+        if (!(value instanceof Integer)) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Can't parse opcode number from the node '%s', opcode value is '%s', but the opcode number should be an integer",
+                    this.node,
+                    value
+                )
+            );
+        }
+        return (int) value;
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
@@ -5,10 +5,13 @@
 package org.eolang.jeo.representation.xmir;
 
 import org.eolang.jeo.representation.bytecode.BytecodeInstruction;
+import org.eolang.jeo.representation.directives.DirectivesInstruction;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
+import org.xembly.Xembler;
 
 /**
  * Test case for {@link XmlInstruction}.
@@ -56,6 +59,27 @@ final class XmlInstructionTest {
             "Xml Instruction with different content should not be equal, but it was",
             new XmlInstruction(Opcodes.DUP),
             Matchers.not(Matchers.equalTo(XmlInstructionTest.EXPECTED))
+        );
+    }
+
+    @Test
+    void throwsExceptionForInvalidOpcode() {
+        MatcherAssert.assertThat(
+            "Error message should contain invalid opcode number",
+            Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new XmlInstruction(
+                    new JcabiXmlNode(
+                        new Xembler(new DirectivesInstruction(Opcodes.DUP))
+                            .xml()
+                            .replace(".number", ".string")
+                    )
+                ).bytecode(),
+                "Should throw IllegalArgumentException for invalid opcode"
+            ).getMessage(),
+            Matchers.containsString(
+                "opcode value is '@V@\u0000\u0000\u0000\u0000\u0000', but the opcode number should be an integer"
+            )
         );
     }
 }


### PR DESCRIPTION
Adds validation for XML opcode values to ensure they are integers before casting, with a descriptive error message when invalid.

Related to #1110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for invalid opcode values, ensuring users receive clear error messages if an opcode is not an integer.
- **Tests**
  - Added a test to verify that an appropriate error is thrown when an invalid opcode is encountered in XML instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->