### PR TITLE
feat(#1123): add omitComments option to disable XMIR comments by default

### DIFF
--- a/src/it/annotations/verify.groovy
+++ b/src/it/annotations/verify.groovy
@@ -13,11 +13,15 @@ assert log.contains("Verifying all the XMIR files before assembling")
 assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/annotations/JeoAnnotation.xmir').exists()
 File app = new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/annotations/AnnotationsApplication.xmir')
 assert app.exists()
+// Check that XMIR contains expected elements.
 assert !app.text.contains("<listing>") : "Listings are disabled by default (see the omitListings option), but it is still present"
+// Check formatting of the XMIR file.
 app.eachLine { line ->
   if(line.contains("meta")) {
     def spaces = line.takeWhile { it == ' ' }.size()
     assert spaces % 2 == 0 : "Line has incorrect indentation (${spaces} spaces): $line"
   }
 }
+// Check that XMIR does not contain comments.
+assert !app.text.contains("<!--") : "comments in generated XMIR are disabled by default (see the 'omitComments' option), but they are present"
 true

--- a/src/it/bytecode-to-eo/pom.xml
+++ b/src/it/bytecode-to-eo/pom.xml
@@ -28,6 +28,7 @@
         <configuration>
           <xmirVerification>true</xmirVerification>
           <omitListings>false</omitListings>
+          <omitComments>false</omitComments>
           <prettyXmir>false</prettyXmir>
         </configuration>
         <executions>

--- a/src/it/bytecode-to-eo/verify.groovy
+++ b/src/it/bytecode-to-eo/verify.groovy
@@ -20,4 +20,5 @@ app.eachLine { line ->
     assert spaces % 3 == 0 : "Line has incorrect indentation (${spaces} spaces): $line"
   }
 }
+assert app.text.contains("<!--") : "We enabled comments in the XMIR file using 'omitComments=false' option, but they are absent"
 true

--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -131,6 +131,23 @@ public final class DisassembleMojo extends AbstractMojo {
     private boolean omitListings;
 
     /**
+     * Flag to omit XML comments in generated XMIR files.
+     * <p>
+     * When enabled, no comments will be generated in the XMIR output, which can be
+     * useful for production builds where comments are not needed and may reduce file size.
+     * When disabled, XML comments will be included to provide debugging information.
+     * </p>
+     *
+     * @since 0.11.0
+     * @checkstyle MemberNameCheck (6 lines)
+     */
+    @Parameter(
+        property = "jeo.disassemble.omitComments",
+        defaultValue = "true"
+    )
+    private boolean omitComments;
+
+    /**
      * Flag to enable pretty-printing of XMIR files.
      * <p>
      *     When enabled, the generated XMIR files will be formatted with indentation (2 spaces) and
@@ -173,10 +190,13 @@ public final class DisassembleMojo extends AbstractMojo {
                 Logger.info(this, "Disassemble mojo is disabled, skipping");
             } else {
                 final boolean listings = !this.omitListings;
+                final boolean comments = !this.omitComments;
                 Logger.info(
-                    this, "Disassembling is started with mode '%s' (with listings = '%b')",
+                    this,
+                    "Disassembling is started with mode '%s' (with listings = '%b', comments = '%b')",
                     this.mode,
-                    listings
+                    listings,
+                    comments
                 );
                 new Disassembler(
                     this.sourcesDir.toPath(),
@@ -184,7 +204,8 @@ public final class DisassembleMojo extends AbstractMojo {
                     new DisassembleParams(
                         DisassembleMode.fromString(this.mode),
                         listings,
-                        this.prettyXmir
+                        this.prettyXmir,
+                        comments
                     )
                 ).disassemble();
                 if (this.xmirVerification) {

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -18,8 +18,9 @@ import org.cactoos.scalar.Unchecked;
 import org.eolang.jeo.representation.asm.AsmProgram;
 import org.eolang.jeo.representation.asm.DisassembleParams;
 import org.eolang.jeo.representation.bytecode.Bytecode;
-import org.eolang.jeo.representation.directives.DirectivesObject;
+import org.eolang.jeo.representation.directives.DirectivesWithoutComments;
 import org.objectweb.asm.ClassReader;
+import org.xembly.Directive;
 import org.xembly.ImpossibleModificationException;
 
 /**
@@ -101,9 +102,12 @@ public final class BytecodeRepresentation {
         } else {
             listing = "";
         }
-        final DirectivesObject directives = new AsmProgram(this.input.value())
+        Iterable<Directive> directives = new AsmProgram(this.input.value())
             .bytecode(params.asmMode())
             .directives(listing);
+        if (!params.includeComments()) {
+            directives = new DirectivesWithoutComments(directives);
+        }
         try {
             final XML measured = new MeasuredEo(directives).asXml();
             final String res;

--- a/src/main/java/org/eolang/jeo/representation/MeasuredEo.java
+++ b/src/main/java/org/eolang/jeo/representation/MeasuredEo.java
@@ -6,7 +6,7 @@ package org.eolang.jeo.representation;
 
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
-import org.eolang.jeo.representation.directives.DirectivesObject;
+import org.xembly.Directive;
 import org.xembly.Directives;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
@@ -24,22 +24,14 @@ final class MeasuredEo {
     /**
      * Original transformation.
      */
-    private final XML xmir;
+    private final Iterable<Directive> directives;
 
     /**
      * Constructor.
      * @param directives Directives to build the EO program from
      */
-    MeasuredEo(final DirectivesObject directives) {
-        this(new XMLDocument(new Xembler(directives).xmlQuietly()));
-    }
-
-    /**
-     * Constructor.
-     * @param xmir Original XMIR representation
-     */
-    private MeasuredEo(final XML xmir) {
-        this.xmir = xmir;
+    MeasuredEo(final Iterable<Directive> directives) {
+        this.directives = directives;
     }
 
     /**
@@ -49,13 +41,14 @@ final class MeasuredEo {
      */
     XML asXml() throws ImpossibleModificationException {
         final long start = System.currentTimeMillis();
+        final XML doc = new XMLDocument(new Xembler(this.directives).xmlQuietly());
         final long end = System.currentTimeMillis();
         return new XMLDocument(
             new Xembler(
                 new Directives()
                     .xpath("/program[@ms]/@ms")
                     .set(String.format("%d", end - start))
-            ).apply(this.xmir.deepCopy())
+            ).apply(doc.inner())
         );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/PrettyXml.java
+++ b/src/main/java/org/eolang/jeo/representation/PrettyXml.java
@@ -31,7 +31,7 @@ public final class PrettyXml {
      * Constructor.
      * @param xml XML content as an XML object
      */
-    public PrettyXml(final XML xml) {
+    PrettyXml(final XML xml) {
         this(xml.toString());
     }
 

--- a/src/main/java/org/eolang/jeo/representation/asm/DisassembleParams.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DisassembleParams.java
@@ -27,11 +27,17 @@ public final class DisassembleParams {
     private final boolean pretty;
 
     /**
+     * Whether to omit comments in the output.
+     * <p>When true, comments will not be included in the disassembled output.</p>
+     */
+    private final boolean comments;
+
+    /**
      * Constructor with default parameters.
      * <p>Uses DEBUG mode, listings disabled, and pretty-printing enabled.</p>
      */
     public DisassembleParams() {
-        this(DisassembleMode.SHORT, false, true);
+        this(DisassembleMode.SHORT, false, true, false);
     }
 
     /**
@@ -40,15 +46,19 @@ public final class DisassembleParams {
      * @param mode Disassemble mode
      * @param listings Whether to include listings in the output
      * @param pretty Whether to pretty-print the output
+     * @param comments Whether to include comments in the output
+     * @checkstyle ParameterNumberCheck (10 lines)
      */
     public DisassembleParams(
         final DisassembleMode mode,
         final boolean listings,
-        final boolean pretty
+        final boolean pretty,
+        final boolean comments
     ) {
         this.mode = mode;
         this.listings = listings;
         this.pretty = pretty;
+        this.comments = comments;
     }
 
     /**
@@ -73,5 +83,13 @@ public final class DisassembleParams {
      */
     public boolean prettyPrint() {
         return this.pretty;
+    }
+
+    /**
+     * Whether to include comments in the output.
+     * @return True if comments should be included, false otherwise
+     */
+    public boolean includeComments() {
+        return this.comments;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesWithoutComments.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesWithoutComments.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.Iterator;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+/**
+ * Directives without comments.
+ * <p>
+ *     This class provides an iterable collection of directives that excludes comments.
+ * </p>
+ * <p>
+ *     Note: In case of performance issues, we can invert this class and implement
+ *     DirectivesWithComments that will add comments to the directives.
+ * </p>
+ * @since 0.11.0
+ */
+public final class DirectivesWithoutComments implements Iterable<Directive> {
+
+    /**
+     * Directives object that contains comments.
+     */
+    private final Directives directives;
+
+    /**
+     * Constructor.
+     * @param directives Iterable of directives.
+     */
+    public DirectivesWithoutComments(final Iterable<Directive> directives) {
+        this(new Directives(directives));
+    }
+
+    /**
+     * Constructor.
+     * @param directives Directives object.
+     */
+    private DirectivesWithoutComments(final Directives directives) {
+        this.directives = directives;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        return this.directives.xpath("//comment()").remove().iterator();
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesWithoutCommentsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesWithoutCommentsTest.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.Directive;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link DirectivesWithoutComments}.
+ * @since 0.11.0
+ */
+final class DirectivesWithoutCommentsTest {
+
+    @Test
+    void removesComments() {
+        final DirectivesValue with = new DirectivesValue("data");
+        final Iterable<Directive> without = new DirectivesWithoutComments(with);
+        MatcherAssert.assertThat(
+            String.format("Plain directives should contain comments, but they do not %s", with),
+            new Xembler(with).xmlQuietly(),
+            Matchers.containsString("<!--")
+        );
+        MatcherAssert.assertThat(
+            "Directives without comments do not contain comments",
+            new Xembler(without).xmlQuietly(),
+            Matchers.not(Matchers.containsString("<!--"))
+        );
+    }
+}


### PR DESCRIPTION
Adds `jeo.disassemble.omitComments` parameter to control XML comments in generated XMIR files, with default value `true`.

Related to #1123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for including or omitting XML comments in generated XMIR files, configurable via build properties.
  * Introduced filtering to remove XML comments from XMIR output when desired.

* **Bug Fixes**
  * Improved validation to ensure correct indentation and absence of comments when comments are disabled.

* **Tests**
  * Added and updated tests to verify correct inclusion or exclusion of XML comments and proper formatting in XMIR files.

* **Refactor**
  * Simplified internal representations and constructors for more efficient handling of directives and XML generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->