### PR TITLE
refactor(#1143): replace 'as' attributes with 'name' in jeo objects

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesEoObject.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesEoObject.java
@@ -69,6 +69,7 @@ public final class DirectivesEoObject implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesClosedObject(
             new EoFqn(this.base).fqn(),
+            "",
             this.name,
             this.inner.stream().reduce(new Directives(), Directives::append)
         ).iterator();

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesJeoObject.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesJeoObject.java
@@ -108,6 +108,7 @@ public final class DirectivesJeoObject implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesAbsractObject(
             new JeoFqn(this.base).fqn(),
+            "",
             this.name,
             this.inner.stream().reduce(new Directives(), Directives::append)
         ).iterator();

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesNumber.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesNumber.java
@@ -46,6 +46,7 @@ final class DirectivesNumber implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesClosedObject(
             new EoFqn("number").fqn(),
+            "",
             this.name,
             new DirectivesBytes(this.hex)
         ).iterator();

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAbstractObject.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAbstractObject.java
@@ -46,12 +46,8 @@ final class XmlAbstractObject {
      */
     Optional<String> base() {
         return this.node.children().findFirst()
-            .filter(child -> child.attribute("as").map("base"::equals).orElse(false))
-            .map(
-                child -> {
-                    return new XmlValue(child).string();
-                }
-            );
+            .filter(child -> child.attribute("name").map("base"::equals).orElse(false))
+            .map(child -> new XmlValue(child).string());
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAnnotations.java
@@ -24,7 +24,15 @@ public class XmlAnnotations {
      * @param xmlnode XML node.
      */
     XmlAnnotations(final XmlNode xmlnode) {
-        this.node = new XmlJeoObject(xmlnode);
+        this(new XmlJeoObject(xmlnode));
+    }
+
+    /**
+     * Constructor.
+     * @param node XML Jeo object node.
+     */
+    XmlAnnotations(final XmlJeoObject node) {
+        this.node = node;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttributes.java
@@ -30,7 +30,7 @@ public final class XmlAttributes {
      * Constructor.
      * @param node XML sequence node containing attributes.
      */
-    private XmlAttributes(final XmlSeq node) {
+    XmlAttributes(final XmlSeq node) {
         this.node = node;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -117,7 +117,9 @@ public final class XmlClass {
      */
     private Optional<XmlAnnotations> annotations() {
         return this.node.children()
-            .filter(o -> o.attribute("as").map("annotations"::equals).orElse(false))
+            .map(XmlJeoObject::new)
+            .filter(XmlJeoObject::named)
+            .filter(object -> "annotations".equals(object.name()))
             .findFirst()
             .map(XmlAnnotations::new);
     }
@@ -158,7 +160,9 @@ public final class XmlClass {
      */
     private Optional<XmlAttributes> attributes() {
         return this.node.children()
-            .filter(o -> o.attribute("as").map("attributes"::equals).orElse(false))
+            .map(XmlSeq::new)
+            .filter(XmlSeq::named)
+            .filter(seq -> "attributes".equals(seq.name()))
             .findFirst()
             .map(XmlAttributes::new);
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
@@ -53,18 +53,21 @@ final class XmlClassProperties {
      * @return Access modifiers.
      */
     private int access() {
-        final XmlNode value = this.clazz.children()
-            .filter(node -> node.attribute("as").map("access"::equals).orElse(false))
-            .findFirst()
-            .orElseThrow(
-                () -> new IllegalStateException(
-                    String.format(
-                        "The '%s' node doesn't have 'access' attribute, but it should have one",
-                        this.clazz
+        return (int) new XmlValue(
+            this.clazz.children()
+                .map(XmlEoObject::new)
+                .filter(XmlEoObject::named)
+                .filter(node -> node.name().contains("access"))
+                .findFirst()
+                .orElseThrow(
+                    () -> new IllegalStateException(
+                        String.format(
+                            "The '%s' node doesn't have 'access' attribute, but it should have one",
+                            this.clazz
+                        )
                     )
                 )
-            );
-        return (int) new XmlValue(value).object();
+        ).object();
     }
 
     /**
@@ -72,7 +75,7 @@ final class XmlClassProperties {
      * @return Signature.
      */
     private String signature() {
-        return this.child("signature")
+        return this.eoChild("signature")
             .map(XmlValue::new)
             .map(XmlValue::string)
             .filter(s -> !s.isEmpty())
@@ -84,7 +87,7 @@ final class XmlClassProperties {
      * @return Supername.
      */
     private String supername() {
-        return this.child("supername")
+        return this.eoChild("supername")
             .map(XmlValue::new)
             .map(XmlValue::string)
             .filter(s -> !s.isEmpty())
@@ -96,7 +99,7 @@ final class XmlClassProperties {
      * @return Interfaces.
      */
     private String[] interfaces() {
-        return this.child("interfaces")
+        return this.jeoChild("interfaces")
             .map(
                 node -> new XmlSeq(node)
                     .children()
@@ -111,7 +114,7 @@ final class XmlClassProperties {
      * @return Bytecode version.
      */
     private int version() {
-        return this.child("version")
+        return this.eoChild("version")
             .map(XmlValue::new)
             .map(XmlValue::object)
             .map(Integer.class::cast)
@@ -123,9 +126,24 @@ final class XmlClassProperties {
      * @param name Name of the child node.
      * @return Child node.
      */
-    private Optional<XmlNode> child(final String name) {
-        return this.clazz.children().filter(
-            child -> child.attribute("as").map(name::equals).orElse(false)
-        ).findFirst();
+    private Optional<XmlEoObject> eoChild(final String name) {
+        return this.clazz.children()
+            .map(XmlEoObject::new)
+            .filter(XmlEoObject::named)
+            .filter(node -> node.name().equals(name))
+            .findFirst();
+    }
+
+    /**
+     * Retrieve jeo object child by name.
+     * @param name Name of the child node.
+     * @return Optional child node.
+     */
+    private Optional<XmlJeoObject> jeoChild(final String name) {
+        return this.clazz.children()
+            .map(XmlJeoObject::new)
+            .filter(XmlJeoObject::named)
+            .filter(node -> name.equals(node.name()))
+            .findFirst();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClosedObject.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClosedObject.java
@@ -4,9 +4,7 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Closed object in XMIR format.
@@ -41,22 +39,6 @@ final class XmlClosedObject {
      */
     Optional<String> optbase() {
         return this.node.attribute("base");
-    }
-
-    /**
-     * Get the child node by index.
-     * @param index Index of the child node.
-     * @return Optional child node.
-     */
-    Optional<XmlNode> child(final int index) {
-        final Optional<XmlNode> result;
-        final List<XmlNode> children = this.node.children().collect(Collectors.toList());
-        if (index < 0 || index >= children.size()) {
-            result = Optional.empty();
-        } else {
-            result = Optional.ofNullable(children.get(index));
-        }
-        return result;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlEoObject.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlEoObject.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+/**
+ * This is EO object in XML representation.
+ * <p>
+ *     Mirrors {@link org.eolang.jeo.representation.directives.DirectivesEoObject}
+ * </p>
+ * @since 0.11.0
+ */
+public final class XmlEoObject {
+
+    /**
+     * Inner XML node representing the EO object.
+     */
+    private final XmlNode inner;
+
+    /**
+     * Constructor.
+     * @param inner XML node representing the EO object.
+     */
+    XmlEoObject(final XmlNode inner) {
+        this.inner = inner;
+    }
+
+    /**
+     * Retrieve the name of the EO object.
+     * @return Name of the EO object.
+     */
+    public String name() {
+        return this.inner.attribute("name")
+            .orElseThrow(
+                () -> new IllegalStateException(
+                    String.format("Attribute 'name' not found in %s", this.inner)
+                )
+            );
+    }
+
+    /**
+     * Retrieve the inner XML node representing the EO object.
+     * @return XML node of the EO object.
+     */
+    public XmlNode node() {
+        return this.inner;
+    }
+
+    /**
+     * Whether the EO object has a name attribute.
+     * @return True if the EO object has a name attribute, false otherwise.
+     */
+    boolean named() {
+        return this.inner.attribute("name").isPresent();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -73,13 +73,7 @@ public class XmlField {
      * @return Name.
      */
     private String name() {
-        return new PrefixedName(
-            this.node.attribute("as").orElseThrow(
-                () -> new IllegalStateException(
-                    String.format("Can't find field name in '%s'", this.node)
-                )
-            )
-        ).decode();
+        return new PrefixedName(this.node.name()).decode();
     }
 
     /**
@@ -129,9 +123,9 @@ public class XmlField {
     private Optional<XmlAnnotations> annotations() {
         final String name = String.format("annotations-%s", this.name());
         return this.node.children()
-            .filter(
-                child -> child.attribute("as").map(name::equals).orElse(false)
-            )
+            .map(XmlJeoObject::new)
+            .filter(XmlJeoObject::named)
+            .filter(object -> name.equals(object.name()))
             .findFirst()
             .map(XmlAnnotations::new);
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlJeoObject.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlJeoObject.java
@@ -35,6 +35,23 @@ final class XmlJeoObject {
         this.origin = origin;
     }
 
+    @Override
+    public String toString() {
+        return this.origin.toString();
+    }
+
+    /**
+     * Retrieve the name of the Jeo object.
+     * @return Name of the Jeo object.
+     */
+    public String name() {
+        return this.origin.attribute("name").orElseThrow(
+            () -> new IllegalStateException(
+                String.format("Attribute 'name' not found in %s", this.origin)
+            )
+        );
+    }
+
     /**
      * Base of the Jeo object.
      * @return Optional containing the base of the Jeo object if present, otherwise empty.
@@ -61,12 +78,11 @@ final class XmlJeoObject {
     }
 
     /**
-     * Retrieve an attribute by name.
-     * @param name Name of the attribute to retrieve.
-     * @return Optional containing the attribute value if present, otherwise empty.
+     * Whether this XML Jeo object has a name attribute.
+     * @return True if the object has a name attribute, false otherwise.
      */
-    public Optional<String> attribute(final String name) {
-        return this.origin.attribute(name);
+    boolean named() {
+        return this.origin.attribute("name").isPresent();
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMaxs.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMaxs.java
@@ -26,18 +26,9 @@ public final class XmlMaxs {
 
     /**
      * Constructor.
-     *
-     * @param node XML node.
-     */
-    XmlMaxs(final XmlNode node) {
-        this(new XmlJeoObject(node));
-    }
-
-    /**
-     * Constructor.
      * @param node XML Jeo object node representing the maxs.
      */
-    private XmlMaxs(final XmlJeoObject node) {
+    XmlMaxs(final XmlJeoObject node) {
         this.node = node;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlParam.java
@@ -43,7 +43,7 @@ public final class XmlParam {
     public BytecodeMethodParameter bytecode() {
         return new BytecodeMethodParameter(
             this.index(),
-            this.pure(),
+            this.name(),
             this.access(),
             this.type(),
             this.annotations()
@@ -62,8 +62,8 @@ public final class XmlParam {
      * Pure name of the parameter.
      * @return Name.
      */
-    private String pure() {
-        return this.name();
+    private String name() {
+        return this.root.name();
     }
 
     /**
@@ -88,11 +88,9 @@ public final class XmlParam {
      */
     private BytecodeAnnotations annotations() {
         return this.root.children()
-            .filter(
-                node -> node.attribute("as")
-                    .map(name -> name.startsWith("param-annotations-"))
-                    .orElse(false)
-            )
+            .map(XmlJeoObject::new)
+            .filter(XmlJeoObject::named)
+            .filter(node -> node.name().startsWith("param-annotations-"))
             .findFirst()
             .map(XmlAnnotations::new)
             .map(XmlAnnotations::bytecode)
@@ -107,7 +105,7 @@ public final class XmlParam {
     private XmlValue child(final String name) {
         return new XmlValue(
             this.root.children()
-                .filter(node -> node.attribute("as").map(name::equals).orElse(false))
+                .filter(node -> XmlParam.hasName(node, name))
                 .findFirst()
                 .orElseThrow(
                     () -> new IllegalStateException(
@@ -121,14 +119,12 @@ public final class XmlParam {
     }
 
     /**
-     * Name attribute of the parameter.
-     * @return Name attribute.
+     * Check if the node has the specified name.
+     * @param node XML node to check.
+     * @param name Name to check against the node's attributes.
+     * @return True if the node has the specified name, false otherwise.
      */
-    private String name() {
-        return this.root.attribute("as").orElseThrow(
-            () -> new IllegalStateException(
-                String.format("'name' attribute is not present in xml param %n%s%n", this.root)
-            )
-        );
+    private static boolean hasName(final XmlNode node, final String name) {
+        return node.attribute("name").map(name::equals).orElse(false);
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlSeq.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlSeq.java
@@ -32,8 +32,16 @@ final class XmlSeq {
      * Constructor.
      * @param origin XML Jeo object representing the sequence.
      */
-    private XmlSeq(final XmlJeoObject origin) {
+    XmlSeq(final XmlJeoObject origin) {
         this.origin = origin;
+    }
+
+    /**
+     * Name of the sequence.
+     * @return Name of the sequence.
+     */
+    public String name() {
+        return this.origin.name();
     }
 
     /**
@@ -42,5 +50,13 @@ final class XmlSeq {
      */
     public Stream<XmlNode> children() {
         return this.origin.children();
+    }
+
+    /**
+     * Whether the sequence is named.
+     * @return True if the sequence has a name attribute, false otherwise.
+     */
+    boolean named() {
+        return this.origin.named();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
@@ -52,6 +52,14 @@ public final class XmlValue {
      * Constructor.
      * @param node XML node.
      */
+    public XmlValue(final XmlEoObject node) {
+        this(node.node());
+    }
+
+    /**
+     * Constructor.
+     * @param node XML node.
+     */
     public XmlValue(final XmlNode node) {
         this.node = node;
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAbsractObjectTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAbsractObjectTest.java
@@ -32,7 +32,7 @@ final class DirectivesAbsractObjectTest {
                     DirectivesAbsractObjectTest.BASE, Collections.emptyList()
                 )
             ).xmlQuietly(),
-            XhtmlMatchers.hasXPath("/o[not(@base)]/o[@as='base']")
+            XhtmlMatchers.hasXPath("/o[not(@base)]/o[@name='base']")
         );
     }
 
@@ -45,7 +45,7 @@ final class DirectivesAbsractObjectTest {
                     DirectivesAbsractObjectTest.BASE, "asValue", Collections.emptyList()
                 )
             ).xmlQuietly(),
-            XhtmlMatchers.hasXPath("/o[@as='asValue' and not(@base)]/o[@as='base']")
+            XhtmlMatchers.hasXPath("/o[@as='asValue' and not(@base)]/o[@name='base']")
         );
     }
 
@@ -62,7 +62,7 @@ final class DirectivesAbsractObjectTest {
                 )
             ).xmlQuietly(),
             Matchers.allOf(
-                XhtmlMatchers.hasXPath("/o[@as='asValue' and @name='nameValue']/o[@as='base']"),
+                XhtmlMatchers.hasXPath("/o[@as='asValue' and @name='nameValue']/o[@name='base']"),
                 XhtmlMatchers.hasXPath("/o[@as='asValue' and @name='nameValue']/inner")
             )
         );
@@ -78,7 +78,7 @@ final class DirectivesAbsractObjectTest {
                 )
             ).xmlQuietly(),
             Matchers.allOf(
-                XhtmlMatchers.hasXPath("/o/o[@as='base']"),
+                XhtmlMatchers.hasXPath("/o/o[@name='base']"),
                 XhtmlMatchers.hasXPath("/o/inner")
             )
         );
@@ -93,7 +93,7 @@ final class DirectivesAbsractObjectTest {
                     DirectivesAbsractObjectTest.BASE, "", "", Collections.emptyList()
                 )
             ).xmlQuietly(),
-            XhtmlMatchers.hasXPath("/o[not(@as) and not(@name)]/o[@as='base']")
+            XhtmlMatchers.hasXPath("/o[not(@as) and not(@name)]/o[@name='base']")
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java
@@ -5,7 +5,6 @@
 package org.eolang.jeo.representation.directives;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import org.eolang.jeo.representation.bytecode.Codec;
 import org.eolang.jeo.representation.bytecode.JavaCodec;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -31,7 +30,6 @@ final class DirectivesAnnotationsTest {
     @Test
     void returnsSingleAnnotation() throws ImpossibleModificationException {
         final String annotation = "Ljava/lang/Override;";
-        final Codec codec = new JavaCodec();
         MatcherAssert.assertThat(
             "Must return single annotation with correct descriptor and visibility",
             new Xembler(
@@ -39,12 +37,12 @@ final class DirectivesAnnotationsTest {
             ).xml(),
             XhtmlMatchers.hasXPaths(
                 new JeoBaseXpath("./o", "seq.of1").toXpath(),
-                "/o[contains(@as,'annotations')]/o",
+                "/o[contains(@name,'annotations')]/o",
                 String.format(
-                    "/o[contains(@as,'annotations')]/o/o[2][contains(@base,'string')]/o[1]/o[text()='%s']",
-                    new DirectivesValue(annotation).hex(codec)
+                    "/o[contains(@name,'annotations')]/o/o[2][contains(@base,'string')]/o[1]/o[text()='%s']",
+                    new DirectivesValue(annotation).hex(new JavaCodec())
                 ),
-                "/o[contains(@as,'annotations')]/o/o[3][contains(@base,'true')]"
+                "/o[contains(@name,'annotations')]/o/o[3][contains(@base,'true')]"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesArrayAnnotationValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesArrayAnnotationValueTest.java
@@ -6,12 +6,7 @@ package org.eolang.jeo.representation.directives;
 
 import com.jcabi.matchers.XhtmlMatchers;
 import java.util.Collections;
-import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
-import org.eolang.jeo.representation.bytecode.BytecodeArrayAnnotationValue;
-import org.eolang.jeo.representation.xmir.NativeXmlNode;
-import org.eolang.jeo.representation.xmir.XmlAnnotationValue;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
@@ -42,29 +37,4 @@ final class DirectivesArrayAnnotationValueTest {
         );
     }
 
-    @Test
-    void createsAnnotationArrayProperty() throws ImpossibleModificationException {
-        final String name = "name";
-        final String descriptor = "java/lang/Override";
-        final boolean visible = true;
-        MatcherAssert.assertThat(
-            "Incorrect array annotation property",
-            new XmlAnnotationValue(
-                new NativeXmlNode(
-                    new Xembler(
-                        new DirectivesArrayAnnotationValue(
-                            name,
-                            Collections.singletonList(new DirectivesAnnotation(descriptor, visible))
-                        )
-                    ).xml()
-                )
-            ).bytecode(),
-            Matchers.equalTo(
-                new BytecodeArrayAnnotationValue(
-                    name,
-                    Collections.singletonList(new BytecodeAnnotation(descriptor, visible))
-                )
-            )
-        );
-    }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAttributesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAttributesTest.java
@@ -27,7 +27,7 @@ final class DirectivesAttributesTest {
                 )
             ).xml(),
             XhtmlMatchers.hasXPaths(
-                "./o[contains(@as, 'attributes')]",
+                "./o[contains(@name, 'attributes')]",
                 new JeoBaseXpath("./o", "seq.of2").toXpath(),
                 new JeoBaseXpath("./o/o", "first").toXpath(),
                 new JeoBaseXpath("./o/o", "second").toXpath()

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassPropertiesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassPropertiesTest.java
@@ -34,12 +34,12 @@ final class DirectivesClassPropertiesTest {
                     ).up()
             ).xml(),
             XhtmlMatchers.hasXPaths(
-                "/o/o[contains(@base,'number') and contains(@as,'version')]",
-                "/o/o[contains(@base,'number') and contains(@as,'access')]",
-                "/o/o[contains(@base,'string') and contains(@as,'signature')]",
-                "/o/o[contains(@base,'string') and contains(@as,'supername')]",
+                "/o/o[contains(@base,'number') and contains(@name,'version')]",
+                "/o/o[contains(@base,'number') and contains(@name,'access')]",
+                "/o/o[contains(@base,'string') and contains(@name,'signature')]",
+                "/o/o[contains(@base,'string') and contains(@name,'supername')]",
                 new JeoBaseXpath("./o/o", "seq.of1").toXpath(),
-                "/o/o[contains(@as,'interfaces')]"
+                "/o/o[contains(@name,'interfaces')]"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -50,13 +50,13 @@ final class DirectivesClassTest {
             ).xml(),
             XhtmlMatchers.hasXPaths(
                 "/o[@name='Neo']",
-                "/o[@name='Neo']/o[contains(@as,'version')]",
-                "/o[@name='Neo']/o[contains(@as,'access')]",
-                "/o[@name='Neo']/o[contains(@as,'signature')]",
-                "/o[@name='Neo']/o[contains(@as,'supername')]",
-                "/o[@name='Neo']/o[contains(@as,'interfaces')]",
-                "/o[@name='Neo']/o[contains(@as,'annotations')]",
-                "/o[@name='Neo']/o[contains(@as,'attributes')]"
+                "/o[@name='Neo']/o[contains(@name,'version')]",
+                "/o[@name='Neo']/o[contains(@name,'access')]",
+                "/o[@name='Neo']/o[contains(@name,'signature')]",
+                "/o[@name='Neo']/o[contains(@name,'supername')]",
+                "/o[@name='Neo']/o[contains(@name,'interfaces')]",
+                "/o[@name='Neo']/o[contains(@name,'annotations')]",
+                "/o[@name='Neo']/o[contains(@name,'attributes')]"
             )
         );
     }
@@ -89,7 +89,7 @@ final class DirectivesClassTest {
                 new XMLDocument(xml)
             ),
             xml,
-            XhtmlMatchers.hasXPath("/o[@name='Neo']/o[contains(@as,'method')]")
+            XhtmlMatchers.hasXPath("/o[@name='Neo']/o[contains(@name,'method')]")
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesFieldTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesFieldTest.java
@@ -34,11 +34,11 @@ final class DirectivesFieldTest {
             xml,
             XhtmlMatchers.hasXPaths(
                 new JeoBaseXpath("/o", "field").toXpath(),
-                "/o[contains(@as,'unknown')]",
-                "/o/o[@as='access-unknown']",
-                "/o/o[@as='descriptor-unknown']",
-                "/o/o[@as='signature-unknown']",
-                "/o/o[contains(@base,'number') and @as='value-unknown']"
+                "/o[contains(@name,'unknown')]",
+                "/o/o[@name='access-unknown']",
+                "/o/o[@name='descriptor-unknown']",
+                "/o/o[@name='signature-unknown']",
+                "/o/o[contains(@base,'number') and @name='value-unknown']"
             )
         );
     }
@@ -62,11 +62,11 @@ final class DirectivesFieldTest {
             xml,
             XhtmlMatchers.hasXPaths(
                 new JeoBaseXpath("/o", "field").toXpath(),
-                "/o[contains(@as,'serialVersionUID')]",
-                "/o/o[@as='access-serialVersionUID']",
-                "/o/o[@as='descriptor-serialVersionUID']",
-                "/o/o[@as='signature-serialVersionUID']",
-                "/o/o[@as='value-serialVersionUID']"
+                "/o[contains(@name,'serialVersionUID')]",
+                "/o/o[@name='access-serialVersionUID']",
+                "/o/o[@name='descriptor-serialVersionUID']",
+                "/o/o[@name='signature-serialVersionUID']",
+                "/o/o[@name='value-serialVersionUID']"
             )
         );
     }
@@ -91,7 +91,7 @@ final class DirectivesFieldTest {
             ).xml(),
             XhtmlMatchers.hasXPaths(
                 new JeoBaseXpath("/o", "field").toXpath(),
-                String.format("/o[contains(@as,'%s')]", original)
+                String.format("/o[contains(@name,'%s')]", original)
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodParamTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodParamTest.java
@@ -30,7 +30,7 @@ final class DirectivesMethodParamTest {
                     1, "foo", Opcodes.ACC_PUBLIC, Type.INT_TYPE, new DirectivesAnnotations()
                 )
             ).xml(),
-            XhtmlMatchers.hasXPath("./o[contains(@base, param) and contains(@as, 'foo')]")
+            XhtmlMatchers.hasXPath("./o[contains(@base, param) and contains(@name, 'foo')]")
         );
     }
 
@@ -44,7 +44,7 @@ final class DirectivesMethodParamTest {
                 )
             ).xml(),
             XhtmlMatchers.hasXPath(
-                "./o[contains(@base, param)]/o[contains(@base, 'number') and contains(@as, 'index')]"
+                "./o[contains(@base, param)]/o[contains(@base, 'number') and contains(@name, 'index')]"
             )
         );
     }
@@ -59,7 +59,7 @@ final class DirectivesMethodParamTest {
                 )
             ).xml(),
             XhtmlMatchers.hasXPath(
-                "./o[contains(@base, param)]/o[contains(@base, 'number') and contains(@as, 'access')]"
+                "./o[contains(@base, param)]/o[contains(@base, 'number') and contains(@name, 'access')]"
             )
         );
     }
@@ -78,7 +78,7 @@ final class DirectivesMethodParamTest {
                 )
             ).xml(),
             XhtmlMatchers.hasXPath(
-                "./o[contains(@base, param)]/o[contains(@base, 'string') and contains(@as, 'type')]"
+                "./o[contains(@base, param)]/o[contains(@base, 'string') and contains(@name, 'type')]"
             )
         );
     }
@@ -100,7 +100,7 @@ final class DirectivesMethodParamTest {
             ).xml(),
             XhtmlMatchers.hasXPaths(
                 new JeoBaseXpath("./o", "param").toXpath(),
-                "./o/o[contains(@as, 'annotations')]"
+                "./o/o[contains(@name, 'annotations')]"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -7,13 +7,7 @@ package org.eolang.jeo.representation.directives;
 import com.jcabi.matchers.XhtmlMatchers;
 import java.util.Collections;
 import org.eolang.jeo.representation.NumberedName;
-import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
-import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
-import org.eolang.jeo.representation.bytecode.BytecodeMaxs;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
-import org.eolang.jeo.representation.bytecode.BytecodeMethodProperties;
-import org.eolang.jeo.representation.xmir.NativeXmlNode;
-import org.eolang.jeo.representation.xmir.XmlMethod;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -31,64 +25,11 @@ import org.xembly.Xembler;
 final class DirectivesMethodTest {
 
     @Test
-    void transformsToXmir() throws ImpossibleModificationException {
-        final String name = "Hello";
-        final int access = 100;
-        final String descriptor = "()I";
-        final String signature = "";
-        MatcherAssert.assertThat(
-            "We expect that directives will generate correct method",
-            new XmlMethod(
-                new NativeXmlNode(
-                    new Xembler(
-                        new DirectivesMethod(
-                            name,
-                            new DirectivesMethodProperties(access, descriptor, signature)
-                        )
-                    ).xml()
-                )
-            ).bytecode(),
-            Matchers.equalTo(
-                new BytecodeMethod(
-                    new BytecodeMethodProperties(name, descriptor, signature, access),
-                    new BytecodeMaxs()
-                )
-            )
-        );
-    }
-
-    @Test
-    void transformsAnnotationsToXmir() throws ImpossibleModificationException {
-        final String descriptor = "Consumer";
-        final boolean visible = true;
-        final String name = "foo";
-        MatcherAssert.assertThat(
-            "We expect that annotation dirictes will be added to the method",
-            new XmlMethod(
-                new NativeXmlNode(
-                    new Xembler(
-                        new DirectivesMethod(name)
-                            .withAnnotation(new DirectivesAnnotation(descriptor, visible))
-                    ).xml()
-                )
-            ).bytecode(),
-            Matchers.equalTo(
-                new BytecodeMethod(
-                    name,
-                    new BytecodeAnnotations(
-                        new BytecodeAnnotation(descriptor, visible)
-                    )
-                )
-            )
-        );
-    }
-
-    @Test
     void addsPrefixToTheMethodName() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "We expect that 'j$' prefix will be added to the method name",
             new Xembler(new BytecodeMethod("φTerm").directives(1)).xml(),
-            XhtmlMatchers.hasXPaths("./o[contains(@as, 'j$φTerm')]")
+            XhtmlMatchers.hasXPaths("./o[contains(@name, 'j$φTerm')]")
         );
     }
 
@@ -147,7 +88,7 @@ final class DirectivesMethodTest {
             ).xml(),
             XhtmlMatchers.hasXPaths(
                 new JeoBaseXpath("/o", "method").toXpath(),
-                "./o[contains(@as,'checks1063')]/o[@as='body']"
+                "./o[contains(@name,'checks1063')]/o[@name='body']"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesSeqTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesSeqTest.java
@@ -35,9 +35,9 @@ final class DirectivesSeqTest {
             ).xml(),
             XhtmlMatchers.hasXPaths(
                 new JeoBaseXpath("./o", "seq.of2").toXpath(),
-                "/o[contains(@as,'seq')]",
-                "/o[contains(@as,'seq')]/o[contains(@base,'string')]/o[contains(@base, 'bytes')]/o[text()='31-']",
-                "/o[contains(@as,'seq')]/o[contains(@base,'string')]/o[contains(@base, 'bytes')]/o[text()='32-']"
+                "/o[contains(@name,'seq')]",
+                "/o[contains(@name,'seq')]/o[contains(@base,'string')]/o[contains(@base, 'bytes')]/o[text()='31-']",
+                "/o[contains(@name,'seq')]/o[contains(@base,'string')]/o[contains(@base, 'bytes')]/o[text()='32-']"
             )
         );
     }
@@ -52,7 +52,7 @@ final class DirectivesSeqTest {
             new Xembler(actual).xml(),
             XhtmlMatchers.hasXPaths(
                 new JeoBaseXpath("./o", String.format("seq.of%d", expected)).toXpath(),
-                "/o[contains(@as,'seq')]"
+                "/o[contains(@name,'seq')]"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
@@ -45,7 +45,7 @@ final class DirectivesValueTest {
             ),
             xml,
             XhtmlMatchers.hasXPath(
-                "./o[contains(@base,'number') and @as='access']/o[contains(@base, 'bytes')]/text()"
+                "./o[contains(@base,'number') and @name='access']/o[contains(@base, 'bytes')]/text()"
             )
         );
     }
@@ -63,7 +63,7 @@ final class DirectivesValueTest {
             XhtmlMatchers.hasXPaths(
                 new JeoBaseXpath("./o", base).toXpath(),
                 String.format(
-                    "./o[@as='access']/o[contains(@base,'number')]/o[contains(@base,'bytes')]/o[text()='%s']",
+                    "./o[@name='access']/o[contains(@base,'number')]/o[contains(@base,'bytes')]/o[text()='%s']",
                     bytes
                 )
             )
@@ -82,7 +82,7 @@ final class DirectivesValueTest {
             xml,
             XhtmlMatchers.hasXPaths(
                 String.format(
-                    "./o[contains(@base,'number') and @as='access']/o[contains(@base,'bytes')]/o[text()='%s']",
+                    "./o[contains(@base,'number') and @name='access']/o[contains(@base,'bytes')]/o[text()='%s']",
                     bytes
                 )
             )
@@ -101,7 +101,7 @@ final class DirectivesValueTest {
             ).xml(),
             XhtmlMatchers.hasXPaths(
                 new JeoBaseXpath("./o", "label").toXpath(),
-                "./o/o[contains(@base,'org.eolang.bytes')]/o[text()='73-6F-6D-65-2D-72-61-6E-64-6F-6D']"
+                "./o/o[contains(@base,'bytes')]/o[text()='73-6F-6D-65-2D-72-61-6E-64-6F-6D']"
             )
         );
     }
@@ -112,7 +112,7 @@ final class DirectivesValueTest {
             "Converts boolean to XML",
             new Xembler(new DirectivesValue(true)).xmlQuietly(),
             XhtmlMatchers.hasXPath(
-                "./o[contains(@base,'org.eolang.true')]"
+                "./o[contains(@base,'true')]"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValuesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValuesTest.java
@@ -29,8 +29,8 @@ final class DirectivesValuesTest {
             new Xembler(new DirectivesValues("name", "value")).xml(),
             XhtmlMatchers.hasXPaths(
                 new JeoBaseXpath("./o", "seq.of1").toXpath(),
-                "./o[contains(@as,'name')]",
-                "./o[contains(@as,'name')]/o/o/o[text()='76-61-6C-75-65']"
+                "./o[contains(@name,'name')]",
+                "./o[contains(@name,'name')]/o/o/o[text()='76-61-6C-75-65']"
             )
         );
     }
@@ -43,7 +43,7 @@ final class DirectivesValuesTest {
                 new Xembler(
                     new DirectivesValues("", "some-value")
                 ).xmlQuietly()
-            ).attribute("as").orElseThrow(
+            ).attribute("name").orElseThrow(
                 () -> new IllegalStateException("Name attribute is absent")
             ),
             Matchers.matchesRegex("^[^0-9].*")

--- a/src/test/java/org/eolang/jeo/representation/directives/JeoBaseXpath.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/JeoBaseXpath.java
@@ -41,7 +41,7 @@ final class JeoBaseXpath {
      */
     String toXpath() {
         return String.format(
-            "%s/o[@as='base' and contains(@base,'string')]/o[contains(@base, 'bytes')]/o[contains(text(),'%s')]",
+            "%s/o[@name='base' and contains(@base,'string')]/o[contains(@base, 'bytes')]/o[contains(text(),'%s')]",
             this.element,
             new DirectivesValue(this.base).hex(new JavaCodec())
         );

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlAnnotationValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlAnnotationValueTest.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import java.util.Collections;
+import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
+import org.eolang.jeo.representation.bytecode.BytecodeArrayAnnotationValue;
+import org.eolang.jeo.representation.directives.DirectivesAnnotation;
+import org.eolang.jeo.representation.directives.DirectivesArrayAnnotationValue;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link XmlAnnotationValue}.
+ * @since 0.11.0
+ */
+final class XmlAnnotationValueTest {
+
+    @Test
+    void createsAnnotationArrayProperty() throws ImpossibleModificationException {
+        final String name = "name";
+        final String descriptor = "java/lang/Override";
+        final boolean visible = true;
+        MatcherAssert.assertThat(
+            "Incorrect array annotation property",
+            new XmlAnnotationValue(
+                new NativeXmlNode(
+                    new Xembler(
+                        new DirectivesArrayAnnotationValue(
+                            name,
+                            Collections.singletonList(new DirectivesAnnotation(descriptor, visible))
+                        )
+                    ).xml()
+                )
+            ).bytecode(),
+            Matchers.equalTo(
+                new BytecodeArrayAnnotationValue(
+                    name,
+                    Collections.singletonList(new BytecodeAnnotation(descriptor, visible))
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
This PR replaces all usages of the `as` attribute with `name` in `Q.jeo.*` objects to comply with the EO language specification.

Closes #1143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new class for representing EO objects in XML form, with methods for accessing object names and attributes.
  * Introduced new constructors and methods for improved handling of XML-based representations and values.

* **Refactor**
  * Updated XML node filtering throughout the codebase to use the `name` attribute instead of `as` for improved consistency and clarity.
  * Enhanced internal logic to wrap XML nodes in domain-specific objects before filtering, increasing type safety and maintainability.
  * Adjusted constructor and method visibility for better encapsulation and package access.

* **Bug Fixes**
  * Corrected XPath expressions and attribute checks in tests to align with updated XML attribute naming conventions.

* **Tests**
  * Added new tests for annotation array properties and bytecode transformation from XML representations.
  * Removed or updated outdated tests to reflect changes in XML structure and attribute usage.

* **Chores**
  * Removed unused imports and obsolete code related to deprecated XML attribute handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->