### PR TITLE
feat(#1144): enable XMIR verification in integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>lints</artifactId>
-      <version>0.0.50</version>
+      <version>0.0.53</version>
     </dependency>
     <dependency>
       <groupId>org.cactoos</groupId>

--- a/src/it/annotations/pom.xml
+++ b/src/it/annotations/pom.xml
@@ -28,7 +28,7 @@
         <artifactId>jeo-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>
-          <xmirVerification>false</xmirVerification>
+          <xmirVerification>true</xmirVerification>
         </configuration>
         <executions>
           <execution>

--- a/src/it/bytecode-to-eo/pom.xml
+++ b/src/it/bytecode-to-eo/pom.xml
@@ -26,7 +26,7 @@
         <artifactId>jeo-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>
-          <xmirVerification>false</xmirVerification>
+          <xmirVerification>true</xmirVerification>
           <omitListings>false</omitListings>
           <omitComments>false</omitComments>
           <prettyXmir>false</prettyXmir>

--- a/src/it/custom-transformations/pom.xml
+++ b/src/it/custom-transformations/pom.xml
@@ -28,15 +28,7 @@
         <artifactId>jeo-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>
-          <!--
-            @todo #1130:90min Enable XMIR Verification
-             The XMIR verification is disabled for now, because it fails
-             due to recent significant changes in the generated XMIR format.
-             We should enable it back. Don't forget to remove the
-             xmirVerification property from the configuration below
-             and all of the rest integration tests.
-          -->
-          <xmirVerification>false</xmirVerification>
+          <xmirVerification>true</xmirVerification>
         </configuration>
         <executions>
           <execution>

--- a/src/it/exceptions/pom.xml
+++ b/src/it/exceptions/pom.xml
@@ -46,7 +46,7 @@
         <artifactId>jeo-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>
-          <xmirVerification>false</xmirVerification>
+          <xmirVerification>true</xmirVerification>
           <omitComments>false</omitComments>
         </configuration>
         <executions>

--- a/src/it/generics/pom.xml
+++ b/src/it/generics/pom.xml
@@ -28,7 +28,7 @@
         <artifactId>jeo-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>
-          <xmirVerification>false</xmirVerification>
+          <xmirVerification>true</xmirVerification>
         </configuration>
         <executions>
           <execution>

--- a/src/it/phi-unphi/pom.xml
+++ b/src/it/phi-unphi/pom.xml
@@ -43,7 +43,7 @@
                   See more details here:
                   https://github.com/objectionary/eo/issues/3812
               -->
-              <xmirVerification>false</xmirVerification>
+              <xmirVerification>true</xmirVerification>
             </configuration>
             <goals>
               <goal>disassemble</goal>

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -46,7 +46,7 @@
         <artifactId>jeo-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>
-          <xmirVerification>false</xmirVerification>
+          <xmirVerification>true</xmirVerification>
         </configuration>
         <executions>
           <execution>

--- a/src/it/takes/pom.xml
+++ b/src/it/takes/pom.xml
@@ -37,7 +37,7 @@
         <artifactId>jeo-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>
-          <xmirVerification>false</xmirVerification>
+          <xmirVerification>true</xmirVerification>
           <omitComments>false</omitComments>
         </configuration>
         <dependencies>

--- a/src/it/variable-names/pom.xml
+++ b/src/it/variable-names/pom.xml
@@ -37,7 +37,7 @@
         <version>@project.version@</version>
         <configuration>
           <mode>debug</mode>
-          <xmirVerification>false</xmirVerification>
+          <xmirVerification>true</xmirVerification>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesObject.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesObject.java
@@ -95,7 +95,7 @@ public final class DirectivesObject implements Iterable<Directive> {
             .attr("revision", Manifests.read("JEO-Revision"))
             .attr("dob", Manifests.read("JEO-Dob"))
             .attr("time", now)
-            .attr("xsi:noNamespaceSchemaLocation", "https://www.eolang.org/xsd/XMIR-0.56.2.xsd");
+            .attr("xsi:noNamespaceSchemaLocation", "https://www.eolang.org/xsd/XMIR-0.57.0.xsd");
         if (!this.listing.isEmpty()) {
             directives.add("listing").set(this.listing).up();
         }

--- a/src/test/java/org/eolang/jeo/XmirFilesTest.java
+++ b/src/test/java/org/eolang/jeo/XmirFilesTest.java
@@ -18,7 +18,6 @@ import org.eolang.jeo.representation.bytecode.BytecodeObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -28,10 +27,6 @@ import org.junit.jupiter.api.io.TempDir;
  * including retrieval, validation, and error handling.
  *
  * @since 0.1.0
- * @todo #1130:90min Enable {@link #verifiesXmirFilesGeneratedFromBytecode} test.
- *  It is currently disabled because it requires updating the objectionary/lints dependency.
- *  Once the dependency is updated, this test should be enabled to ensure
- *  correctness of XMIR files generated from bytecode.
  */
 final class XmirFilesTest {
 
@@ -98,7 +93,6 @@ final class XmirFilesTest {
     }
 
     @Test
-    @Disabled
     void verifiesXmirFilesGeneratedFromBytecode(@TempDir final Path temp) throws IOException {
         Files.write(
             temp.resolve("MethodByte.xmir"),


### PR DESCRIPTION
Enables XMIR verification in all integration tests and updates `lints` dependency to version `0.0.53`.

Closes #1144

Also fixes https://github.com/objectionary/jeo-maven-plugin/issues/1147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency version to improve build tooling.
  * Enabled XMIR verification across multiple integration test modules.
  * Updated the XML schema version referenced in generated files.
* **Bug Fixes**
  * Improved XML validation by filtering out specific non-critical defects.
* **Tests**
  * Re-enabled a previously disabled test for XMIR file verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->