### PR TITLE
feat(#1135): add name attribute with FQN to class directives

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/asm/AsmClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmClass.java
@@ -45,7 +45,7 @@ public final class AsmClass {
     public BytecodeClass bytecode() {
         final ClassName full = new ClassName(this.node.name);
         return new BytecodeClass(
-            full.name(),
+            full,
             this.methods(),
             this.fields(),
             new AsmAnnotations(this.node).bytecode(),

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.ClassName;
-import org.eolang.jeo.representation.PrefixedName;
 import org.eolang.jeo.representation.directives.DirectivesClass;
 import org.objectweb.asm.Opcodes;
 
@@ -32,7 +31,7 @@ public final class BytecodeClass {
      * Class name.
      */
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
-    private final String name;
+    private final ClassName name;
 
     /**
      * Methods.
@@ -109,7 +108,7 @@ public final class BytecodeClass {
         final BytecodeClassProperties properties
     ) {
         this(
-            name,
+            new ClassName(name),
             methods,
             new ArrayList<>(0),
             new BytecodeAnnotations(),
@@ -129,7 +128,7 @@ public final class BytecodeClass {
      * @checkstyle ParameterNumberCheck (5 lines)
      */
     public BytecodeClass(
-        final String name,
+        final ClassName name,
         final List<BytecodeMethod> methods,
         final List<BytecodeField> fields,
         final BytecodeAnnotations annotations,
@@ -149,7 +148,7 @@ public final class BytecodeClass {
      * @return Name.
      */
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
-    public String name() {
+    public ClassName name() {
         return this.name;
     }
 
@@ -281,7 +280,7 @@ public final class BytecodeClass {
      */
     public DirectivesClass directives() {
         return new DirectivesClass(
-            new ClassName(new PrefixedName(this.name).encode()),
+            this.name,
             this.props.directives(),
             this.fields.stream().map(BytecodeField::directives).collect(Collectors.toList()),
             this.cmethods.stream()
@@ -302,7 +301,7 @@ public final class BytecodeClass {
             visitor.visit(
                 this.props.version(),
                 this.props.access(),
-                new ClassName(pckg, this.name).full(),
+                this.name.full(),
                 this.props.signature(),
                 this.props.supername(),
                 this.props.interfaces()
@@ -321,7 +320,7 @@ public final class BytecodeClass {
             throw new IllegalStateException(
                 String.format(
                     "Bytecode creation for the '%s' class is not possible due to unmet preconditions.",
-                    this.name
+                    this.name.full()
                 ),
                 exception
             );

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeObject.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeObject.java
@@ -13,7 +13,6 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.BytecodeRepresentation;
 import org.eolang.jeo.representation.ClassName;
-import org.eolang.jeo.representation.PrefixedName;
 import org.eolang.jeo.representation.directives.DirectivesClass;
 import org.eolang.jeo.representation.directives.DirectivesMetas;
 import org.eolang.jeo.representation.directives.DirectivesObject;
@@ -118,7 +117,7 @@ public final class BytecodeObject {
      */
     public DirectivesObject directives(final String listing) {
         final BytecodeClass top = this.top();
-        final ClassName classname = new ClassName(this.pckg, new PrefixedName(top.name()).encode());
+        final ClassName classname = top.name();
         final DirectivesClass clazz = top.directives();
         return new DirectivesObject(
             listing,

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.eolang.jeo.representation.ClassName;
+import org.eolang.jeo.representation.PrefixedName;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -160,8 +161,9 @@ public final class DirectivesClass implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesGlobalObject(
             "class",
-            this.name.name(),
+            new PrefixedName(this.name.name()).encode(),
             this.properties,
+            new DirectivesValue("name", this.name.full().replace('.', '/')),
             this.fields.stream().map(Directives::new).reduce(new Directives(), Directives::append),
             this.methods.stream().map(Directives::new).reduce(new Directives(), Directives::append),
             this.annotations,

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.PrefixedName;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.eolang.jeo.representation.bytecode.BytecodeAttributes;
@@ -40,10 +41,17 @@ public final class XmlClass {
     private final XmlGlobalObject node;
 
     /**
+     * Package name.
+     */
+    private final String pckg;
+
+    /**
      * Constructor.
+     * @param pckg Package name
      * @param node The XML node representing the class
      */
-    public XmlClass(final XmlNode node) {
+    XmlClass(final String pckg, final XmlNode node) {
+        this.pckg = pckg;
         this.node = new XmlGlobalObject(node);
     }
 
@@ -52,7 +60,7 @@ public final class XmlClass {
      * @param classname The class name
      */
     XmlClass(final String classname) {
-        this(XmlClass.empty(classname));
+        this("", XmlClass.empty(classname));
     }
 
     /**
@@ -61,7 +69,7 @@ public final class XmlClass {
      * @param properties The class properties
      */
     XmlClass(final String classname, final DirectivesClassProperties properties) {
-        this(XmlClass.withProps(classname, properties));
+        this("", XmlClass.withProps(classname, properties));
     }
 
     /**
@@ -71,7 +79,9 @@ public final class XmlClass {
     public BytecodeClass bytecode() {
         try {
             return new BytecodeClass(
-                new PrefixedName(this.name()).decode(),
+                new ClassName(
+                    new PrefixedName(new ClassName(this.pckg, this.name()).full()).decode()
+                ),
                 this.methods().stream().map(XmlMethod::bytecode)
                     .collect(Collectors.toList()),
                 this.fields().stream()

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlObject.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlObject.java
@@ -72,7 +72,7 @@ public final class XmlObject {
      * @return Class.
      */
     private XmlClass top() {
-        return new XmlClass(this.root.child("o"));
+        return new XmlClass(this.pckg(), this.root.child("o"));
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -6,6 +6,7 @@ package org.eolang.jeo.representation;
 
 import com.jcabi.log.Logger;
 import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -45,13 +46,15 @@ final class XmirRepresentationTest {
 
     @Test
     void retrievesName() {
+        final String pckg = "org/eolang/foo";
         final String name = "Math";
         final String expected = "j$org/j$eolang/j$foo/j$Math";
+        final XML xml = new BytecodeObject(
+            pckg,
+            new BytecodeClass(String.format("%s/%s", pckg, name))
+        ).xml();
         final String actual = new XmirRepresentation(
-            new BytecodeObject(
-                "org/eolang/foo",
-                new BytecodeClass(name)
-            ).xml()
+            xml
         ).name();
         MatcherAssert.assertThat(
             String.format(

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeObjectTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeObjectTest.java
@@ -58,7 +58,7 @@ final class BytecodeObjectTest {
         final String name = "ClassInPackage";
         final DirectivesObject directives = new BytecodeObject(
             "some/package",
-            new BytecodeClass(name).helloWorldMethod()
+            new BytecodeClass(String.format("some/package/%s", name)).helloWorldMethod()
         ).directives("");
         final String xml = new Xembler(directives).xml();
         final String pckg = "some.package";

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -8,11 +8,8 @@ import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
 import java.util.Collections;
 import org.eolang.jeo.representation.ClassName;
-import org.eolang.jeo.representation.bytecode.BytecodeClass;
-import org.eolang.jeo.representation.bytecode.BytecodeClassProperties;
 import org.eolang.jeo.representation.bytecode.InnerClass;
-import org.eolang.jeo.representation.xmir.NativeXmlNode;
-import org.eolang.jeo.representation.xmir.XmlClass;
+import org.eolang.jeo.representation.bytecode.JavaCodec;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -49,14 +46,14 @@ final class DirectivesClassTest {
                 new Transformers.Node()
             ).xml(),
             XhtmlMatchers.hasXPaths(
-                "/o[@name='Neo']",
-                "/o[@name='Neo']/o[contains(@name,'version')]",
-                "/o[@name='Neo']/o[contains(@name,'access')]",
-                "/o[@name='Neo']/o[contains(@name,'signature')]",
-                "/o[@name='Neo']/o[contains(@name,'supername')]",
-                "/o[@name='Neo']/o[contains(@name,'interfaces')]",
-                "/o[@name='Neo']/o[contains(@name,'annotations')]",
-                "/o[@name='Neo']/o[contains(@name,'attributes')]"
+                "/o[contains(@name,'Neo')]",
+                "/o[contains(@name,'Neo')]/o[contains(@name,'version')]",
+                "/o[contains(@name,'Neo')]/o[contains(@name,'access')]",
+                "/o[contains(@name,'Neo')]/o[contains(@name,'signature')]",
+                "/o[contains(@name,'Neo')]/o[contains(@name,'supername')]",
+                "/o[contains(@name,'Neo')]/o[contains(@name,'interfaces')]",
+                "/o[contains(@name,'Neo')]/o[contains(@name,'annotations')]",
+                "/o[contains(@name,'Neo')]/o[contains(@name,'attributes')]"
             )
         );
     }
@@ -89,41 +86,26 @@ final class DirectivesClassTest {
                 new XMLDocument(xml)
             ),
             xml,
-            XhtmlMatchers.hasXPath("/o[@name='Neo']/o[contains(@name,'method')]")
+            XhtmlMatchers.hasXPath("/o[@name='j$Neo']/o[contains(@name,'method')]")
         );
     }
 
     @Test
-    void convertsToDirectives() throws ImpossibleModificationException {
-        final String name = "Foo";
-        final int access = 100;
-        final String signature = "java/lang/Object";
-        final String supername = "java/lang/Runnable";
-        final String interfce = "java/lang/Cloneable";
+    void appendsFullyQualifiedName() throws ImpossibleModificationException {
+        final String name = "org.eolang.jeo.representation.directives.DirectivesClassTest";
         MatcherAssert.assertThat(
-            "We expect that class created from directives is equal to expected",
-            new XmlClass(
-                new NativeXmlNode(
-                    new Xembler(
-                        new DirectivesClass(
-                            name,
-                            new DirectivesClassProperties(
-                                access,
-                                signature,
-                                supername,
-                                interfce
-                            )
-                        )
-                    ).xml()
+            "Can't append fully qualified class name",
+            new Xembler(
+                new DirectivesClass(
+                    new ClassName(name)
                 )
-            ).bytecode(),
-            Matchers.equalTo(
-                new BytecodeClass(
-                    name,
-                    new BytecodeClassProperties(access, signature, supername, interfce)
+            ).xml(),
+            XhtmlMatchers.hasXPath(
+                String.format(
+                    "./o[contains(@name,DirectivesClassTest)]/o[contains(@name, 'name')]/o/o[text()='%s']",
+                    new DirectivesValue(name.replace('.', '/')).hex(new JavaCodec())
                 )
             )
         );
     }
-
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesObjectTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesObjectTest.java
@@ -82,7 +82,7 @@ final class DirectivesObjectTest {
                 new XMLDocument(actual)
             ),
             actual,
-            XhtmlMatchers.hasXPath("/object/o[@name='Foo']")
+            XhtmlMatchers.hasXPath("/object/o[contains(@name,'Foo')]")
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlClassTest.java
@@ -5,9 +5,14 @@
 package org.eolang.jeo.representation.xmir;
 
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
+import org.eolang.jeo.representation.bytecode.BytecodeClassProperties;
+import org.eolang.jeo.representation.directives.DirectivesClass;
+import org.eolang.jeo.representation.directives.DirectivesClassProperties;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
 
 /**
  * Test cases for {@link XmlClass}.
@@ -30,6 +35,41 @@ final class XmlClassTest {
             ),
             klass.bytecode(),
             Matchers.equalTo(new BytecodeClass(expected))
+        );
+    }
+
+    @Test
+    void createsBytecode() throws ImpossibleModificationException {
+        final String name = "Foo";
+        final int access = 100;
+        final String signature = "java/lang/Object";
+        final String supername = "java/lang/Runnable";
+        final String interfce = "java/lang/Cloneable";
+        final String pckg = "org.eolang.foo";
+        MatcherAssert.assertThat(
+            "We expect that class created from directives is equal to expected",
+            new XmlClass(
+                pckg,
+                new NativeXmlNode(
+                    new Xembler(
+                        new DirectivesClass(
+                            name,
+                            new DirectivesClassProperties(
+                                access,
+                                signature,
+                                supername,
+                                interfce
+                            )
+                        )
+                    ).xml()
+                )
+            ).bytecode(),
+            Matchers.equalTo(
+                new BytecodeClass(
+                    String.format("%s.%s", pckg, name),
+                    new BytecodeClassProperties(access, signature, supername, interfce)
+                )
+            )
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlObjectTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlObjectTest.java
@@ -48,7 +48,7 @@ final class XmlObjectTest {
             Matchers.equalTo(
                 new BytecodeObject(
                     pckg,
-                    new BytecodeClass(name, 0)
+                    new BytecodeClass(String.format("%s.%s", pckg, name), 0)
                 )
             )
         );
@@ -82,7 +82,7 @@ final class XmlObjectTest {
                     new Xembler(
                         new Directives(
                             new BytecodeObject(
-                                "com.example", new BytecodeClass("Foo", 0)
+                                "com.example", new BytecodeClass("com.example.Foo", 0)
                             ).directives("")
                         ).xpath(".//o").remove()
                     ).xmlQuietly()


### PR DESCRIPTION
This PR adds the `name` attribute to `Φ.jeo.class` directives, containing the fully qualified class name in slashed notation (e.g., `org/eolang/benchmark/Big`).

Related to #1135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of class names and package names, ensuring consistent support for fully qualified class names throughout the application.

* **Bug Fixes**
  * Resolved inconsistencies in class name formatting by centralizing dot/slash conversions.

* **Tests**
  * Updated and added tests to verify correct handling of fully qualified class names in both bytecode and XML representations.

* **Refactor**
  * Simplified class name construction and conversion logic for better maintainability and clarity.
  * Enhanced object methods for class name representations with improved equality and string output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->