### PR TITLE
feat(#1156): add random name generation for XMIR objects

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotationAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotationAnnotationValue.java
@@ -50,6 +50,7 @@ public final class DirectivesAnnotationAnnotationValue implements Iterable<Direc
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "annotation-property",
+            new RandName("annotation").toString(),
             Stream.concat(
                 Stream.of(
                     new DirectivesValue("ANNOTATION"),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesArrayAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesArrayAnnotationValue.java
@@ -43,6 +43,7 @@ public final class DirectivesArrayAnnotationValue implements Iterable<Directive>
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "annotation-property",
+            new RandName("array").toString(),
             Stream.concat(
                 Stream.of(
                     new DirectivesValue("ARRAY"),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java
@@ -22,6 +22,11 @@ public final class DirectivesAttribute implements Iterable<Directive> {
     private final String base;
 
     /**
+     * Name of the attribute.
+     */
+    private final String name;
+
+    /**
      * Data to store.
      */
     private final List<Iterable<Directive>> data;
@@ -42,7 +47,19 @@ public final class DirectivesAttribute implements Iterable<Directive> {
      * @param data Properties of an attribute.
      */
     private DirectivesAttribute(final String base, final List<Iterable<Directive>> data) {
+        this(base, new RandName("attr").toString(), data);
+    }
+
+    /**
+     * Constructor.
+     * @param base The base of the attribute.
+     * @param name The name of the attribute.
+     * @param data Properties of an attribute.
+     */
+    public DirectivesAttribute(
+        final String base, final String name, final List<Iterable<Directive>> data) {
         this.base = base;
+        this.name = name;
         this.data = data;
     }
 
@@ -50,6 +67,7 @@ public final class DirectivesAttribute implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             this.base,
+            this.name,
             this.data.stream().map(Directives::new).toArray(Directives[]::new)
         ).iterator();
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesEnumAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesEnumAnnotationValue.java
@@ -49,6 +49,7 @@ public final class DirectivesEnumAnnotationValue implements Iterable<Directive> 
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "annotation-property",
+            new RandName("enum").toString(),
             new DirectivesValue("ENUM"),
             new DirectivesValue(Optional.ofNullable(this.name).orElse("")),
             new DirectivesValue(this.descriptor),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesFrame.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesFrame.java
@@ -73,6 +73,7 @@ public final class DirectivesFrame implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "frame",
+            new RandName("frame").toString(),
             new DirectivesValue(this.name("type"), this.type),
             new DirectivesValue(this.name("nlocal"), this.nlocal),
             new DirectivesValues(this.name("locals"), this.locals),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesHandle.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesHandle.java
@@ -32,6 +32,7 @@ public final class DirectivesHandle implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "handle",
+            new RandName("handle").toString(),
             new DirectivesValue(this.handle.getTag()),
             new DirectivesValue(this.handle.getOwner()),
             new DirectivesValue(this.handle.getName()),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
@@ -46,6 +46,7 @@ public final class DirectivesInstruction implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             this.base(),
+            new RandName("instruction").toString(),
             Stream.concat(
                 Stream.of(
                     new DirectivesComment(this.comment()),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesJeoObject.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesJeoObject.java
@@ -44,34 +44,6 @@ public final class DirectivesJeoObject implements Iterable<Directive> {
     /**
      * Constructor.
      * @param base The base of the object.
-     * @param inner Inner components.
-     */
-    @SafeVarargs
-    public DirectivesJeoObject(final String base, final Iterable<Directive>... inner) {
-        this(base, Arrays.stream(inner).map(Directives::new).collect(Collectors.toList()));
-    }
-
-    /**
-     * Constructor.
-     * @param base The base of the object.
-     * @param inner Inner components.
-     */
-    public DirectivesJeoObject(final String base, final Directives... inner) {
-        this(base, Arrays.asList(inner));
-    }
-
-    /**
-     * Constructor.
-     * @param base The base of the object.
-     * @param inner Inner components.
-     */
-    public DirectivesJeoObject(final String base, final List<Directives> inner) {
-        this(base, "", inner);
-    }
-
-    /**
-     * Constructor.
-     * @param base The base of the object.
      * @param name The name of the object.
      * @param inner Inner components.
      */

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesPlainAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesPlainAnnotationValue.java
@@ -89,6 +89,7 @@ public final class DirectivesPlainAnnotationValue implements Iterable<Directive>
         }
         return new DirectivesJeoObject(
             "annotation-property",
+            new RandName("plain").toString(),
             new DirectivesValue("PLAIN"),
             new DirectivesValue(Optional.ofNullable(this.name).orElse("")),
             res

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesTryCatch.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesTryCatch.java
@@ -65,6 +65,7 @@ public final class DirectivesTryCatch implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "trycatch",
+            new RandName("trycatch").toString(),
             Stream.of(
                 this.start.directives(),
                 this.end.directives(),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesType.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesType.java
@@ -31,6 +31,7 @@ public final class DirectivesType implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "type",
+            new RandName("type").toString(),
             new DirectivesValue(this.type.getDescriptor())
         ).iterator();
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/RandName.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/RandName.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+/**
+ * Random name.
+ * @since 0.11.1
+ */
+public final class RandName {
+
+    /**
+     * Global name counter.
+     */
+    private static final Supplier<Long> GLOBAL = new AtomicLong(0)::incrementAndGet;
+
+    /**
+     * Suffix for the name.
+     */
+    private final String suffix;
+
+    /**
+     * Number generator for the name.
+     */
+    private final Supplier<Long> number;
+
+    /**
+     * Constructor.
+     * @param suffix Suffix for the name.
+     */
+    public RandName(final String suffix) {
+        this(suffix, RandName.GLOBAL);
+    }
+
+    /**
+     * Constructor.
+     * @param suffix Suffix for the name.
+     * @param number Number generator for the name.
+     */
+    private RandName(final String suffix, final Supplier<Long> number) {
+        this.suffix = suffix;
+        this.number = number;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s%d", this.suffix, this.number.get());
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.jeo.representation;
 
+import com.jcabi.matchers.XhtmlMatchers;
 import org.cactoos.io.ResourceOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -30,6 +31,21 @@ final class BytecodeRepresentationTest {
             new BytecodeRepresentation(new ResourceOf(BytecodeRepresentationTest.METHOD_BYTE))
                 .toXmir().xpath("/object/o/@name").get(0),
             Matchers.equalTo(new PrefixedName("MethodByte").encode())
+        );
+    }
+
+    @Test
+    void generatesXmlWithCorrectObjectAttributes() {
+        MatcherAssert.assertThat(
+            "XMIR objects should have either 'name' or 'base' attribute, or both",
+            new BytecodeRepresentation(
+                new ResourceOf(BytecodeRepresentationTest.METHOD_BYTE)
+            ).toXmir().toString(),
+            Matchers.not(
+                XhtmlMatchers.hasXPath(
+                    "//o[not(@base) and not(@name) and not(parent::*[@base='Q.org.eolang.bytes'])]"
+                )
+            )
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionTest.java
@@ -10,6 +10,8 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
+import org.xembly.Directive;
+import org.xembly.Directives;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
@@ -24,19 +26,37 @@ final class BytecodeInstructionTest {
         MatcherAssert.assertThat(
             "We expect that the bytecode instruction argument with type 'Type' will be wrapped in sting, see https://github.com/objectionary/jeo-maven-plugin/issues/1125",
             new Xembler(
-                new BytecodeInstruction(
-                    Opcodes.LDC,
-                    Type.getType(Integer.class)
-                ).directives()
+                BytecodeInstructionTest.withoutNames(
+                    new BytecodeInstruction(
+                        Opcodes.LDC,
+                        Type.getType(Integer.class)
+                    ).directives()
+                )
             ).xml(),
             Matchers.equalTo(
                 new Xembler(
-                    new DirectivesInstruction(
-                        Opcodes.LDC,
-                        Type.getType(Integer.class)
+                    BytecodeInstructionTest.withoutNames(
+                        new DirectivesInstruction(
+                            Opcodes.LDC,
+                            Type.getType(Integer.class)
+                        )
                     )
                 ).xml()
             )
         );
+    }
+
+    /**
+     * Set the name attribute to empty for all elements in the directives.
+     * This was added to compare generated XMIR independently of the names, generated
+     * randomly by {@link org.eolang.jeo.representation.directives.RandName}.
+     * <p>
+     *     <a href="https://github.com/objectionary/jeo-maven-plugin/issues/1156">Issue #1156</a>
+     * </p>
+     * @param directives Directives to process
+     * @return Directives with empty names
+     */
+    private static Directives withoutNames(final Iterable<Directive> directives) {
+        return new Directives(directives).xpath("//o").attr("name", "");
     }
 }


### PR DESCRIPTION
This PR ensures all XMIR `<o>` elements have either a `@name` or `@base` attribute by generating random names for directives objects when needed. Fixes illegal XMIR structure.

Related to #1156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unique, randomly generated names to various object representations for improved identification.
  * Introduced a utility for generating thread-safe, incrementing name strings.

* **Bug Fixes**
  * Ensured that all generated XML object representations include either a `name` or `base` attribute, except for specific cases.

* **Tests**
  * Added a test to verify that XML representations conform to the new attribute requirements.
  * Updated tests to normalize randomly generated names for consistent XML comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->