### PR TITLE
fix(#1160): ensure all formation objects have names in directives

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
@@ -141,7 +141,7 @@ enum DataType {
                         String.format(
                             "Unknown data type of %s, class is %s",
                             data,
-                            Optional.ofNullable(data)
+                            Optional.of(data)
                                 .map(Object::getClass)
                                 .map(Class::getName)
                                 .orElse("Nullable")

--- a/src/main/java/org/eolang/jeo/representation/bytecode/InnerClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/InnerClass.java
@@ -80,10 +80,10 @@ public final class InnerClass implements BytecodeAttribute {
     public DirectivesAttribute directives() {
         return new DirectivesAttribute(
             "inner-class",
-            new DirectivesValue("", this.name),
-            new DirectivesValue("", this.outer),
-            new DirectivesValue("", this.inner),
-            new DirectivesValue("", this.access)
+            new DirectivesValue("name", this.name),
+            new DirectivesValue("outer", this.outer),
+            new DirectivesValue("inner", this.inner),
+            new DirectivesValue("access", this.access)
         );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/LocalVariable.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/LocalVariable.java
@@ -119,10 +119,10 @@ public final class LocalVariable implements BytecodeAttribute {
     public DirectivesAttribute directives() {
         return new DirectivesAttribute(
             "local-variable",
-            new DirectivesValue("", this.index),
-            new DirectivesValue("", this.name),
-            new DirectivesValue("", this.descriptor),
-            new DirectivesValue("", this.signature),
+            new DirectivesValue("index", this.index),
+            new DirectivesValue("name", this.name),
+            new DirectivesValue("descr", this.descriptor),
+            new DirectivesValue("signature", this.signature),
             this.start.directives(),
             this.end.directives()
         );

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesBytes.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesBytes.java
@@ -22,18 +22,44 @@ public final class DirectivesBytes implements Iterable<Directive> {
     private final String hex;
 
     /**
+     * Name of the object.
+     */
+    private final String name;
+
+    /**
      * Constructor.
      * @param hex Hex representation of bytes.
      */
     public DirectivesBytes(final String hex) {
+        this(hex, "");
+    }
+
+    /**
+     * Constructor.
+     * @param hex Hex representation of bytes.
+     * @param name Name of the object.
+     */
+    public DirectivesBytes(final String hex, final String name) {
         this.hex = hex;
+        this.name = name;
     }
 
     @Override
     public Iterator<Directive> iterator() {
-        return new DirectivesClosedObject(
-            "Q.org.eolang.bytes",
-            new Directives().add("o").set(this.hex).up()
-        ).iterator();
+        final DirectivesClosedObject directives;
+        if (this.name.isEmpty()) {
+            directives = new DirectivesClosedObject(
+                "Q.org.eolang.bytes",
+                new Directives().add("o").set(this.hex).up()
+            );
+        } else {
+            directives = new DirectivesClosedObject(
+                "Q.org.eolang.bytes",
+                "",
+                this.name,
+                new Directives().add("o").set(this.hex).up()
+            );
+        }
+        return directives.iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -62,7 +62,7 @@ public final class DirectivesValue implements Iterable<Directive> {
      * @param <T> Data type.
      */
     public <T> DirectivesValue(final T data) {
-        this("", data);
+        this(new RandName("val").toString(), data);
     }
 
     /**
@@ -87,6 +87,12 @@ public final class DirectivesValue implements Iterable<Directive> {
         this.value = value;
     }
 
+    /**
+     * Iterator of directives.
+     * @return Iterator of directives.
+     * @checkstyle CyclomaticComplexityCheck (50 lines)
+     * @checkstyle NoJavadocForOverriddenMethodsCheck (50 lines)
+     */
     @Override
     public Iterator<Directive> iterator() {
         final String type = this.type();
@@ -108,6 +114,9 @@ public final class DirectivesValue implements Iterable<Directive> {
                 } else {
                     res = this.jeoObject(type, new PlainLongCodec(codec));
                 }
+                break;
+            case "nullable":
+                res = this.nullable(type, codec);
                 break;
             case "string":
                 res = this.eoObject(type, codec);
@@ -164,6 +173,21 @@ public final class DirectivesValue implements Iterable<Directive> {
             this.name,
             new DirectivesComment(this.comment()),
             new DirectivesBytes(this.hex(codec))
+        );
+    }
+
+    /**
+     * Nullable object.
+     * @param base Base of the object, usually "nullable".
+     * @param codec Codec to use for bytes encoding.
+     * @return JEO object directives for nullable type.
+     */
+    private DirectivesJeoObject nullable(final String base, final Codec codec) {
+        return new DirectivesJeoObject(
+            base,
+            this.name,
+            new DirectivesComment(this.comment()),
+            new DirectivesBytes(this.hex(codec), new RandName("null").toString())
         );
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValues.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValues.java
@@ -9,6 +9,7 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.xembly.Directive;
@@ -39,16 +40,6 @@ public final class DirectivesValues implements Iterable<Directive> {
 
     /**
      * Constructor.
-     * @param values Values themselves.
-     * @param <T> Values type.
-     */
-    @SafeVarargs
-    <T> DirectivesValues(final T... values) {
-        this("", values);
-    }
-
-    /**
-     * Constructor.
      * @param name Group of values name.
      * @param vals Values themselves.
      * @param <T> Values type.
@@ -61,11 +52,17 @@ public final class DirectivesValues implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
+        final AtomicInteger index = new AtomicInteger(0);
         return new DirectivesSeq(
             this.nonEmptyName(),
             Arrays.stream(this.values)
                 .filter(Objects::nonNull)
-                .map(DirectivesValue::new)
+                .map(
+                    value -> new DirectivesValue(
+                        String.format("x%d", index.getAndIncrement()),
+                        value
+                    )
+                )
                 .collect(Collectors.toList())
         ).iterator();
     }

--- a/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
@@ -49,6 +49,21 @@ final class BytecodeRepresentationTest {
         );
     }
 
+    /**
+     * This test was added to mitigate the issue:
+     * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/1160">Issue #1160</a>.
+     */
+    @Test
+    void generatesXmlWithFormationsThatCIncludeObjectsWithNames() {
+        MatcherAssert.assertThat(
+            "A formation must only include objects with names.",
+            new BytecodeRepresentation(
+                new ResourceOf(BytecodeRepresentationTest.METHOD_BYTE)
+            ).toXmir().toString(),
+            Matchers.not(XhtmlMatchers.hasXPath("//o[not(@base)]/o[not(@name)]"))
+        );
+    }
+
     @Test
     void retrievesName() {
         final ResourceOf input = new ResourceOf(BytecodeRepresentationTest.METHOD_BYTE);


### PR DESCRIPTION
This PR ensures all objects in XMIR formations have proper names by adding name attributes to directives and values. Fixes illegal nameless objects in formations.

Related to #1160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for named objects in bytecode XML representations.
  * Introduced handling and representation for nullable types in object directives.

* **Bug Fixes**
  * Ensured all formation elements in generated XML include a name attribute when required.

* **Tests**
  * Added a test to verify that XML output does not contain unnamed formation objects, addressing a related issue.

* **Refactor**
  * Improved labeling of attributes in directives for inner classes and local variables, making them more descriptive.
  * Enhanced internal naming for values in directive collections for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->