### PR TITLE
fix(#1163): ensure all formation children have name attribute

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabel.java
@@ -14,6 +14,7 @@ import lombok.ToString;
 import org.eolang.jeo.representation.asm.AsmLabels;
 import org.eolang.jeo.representation.directives.DirectivesEoObject;
 import org.eolang.jeo.representation.directives.DirectivesValue;
+import org.eolang.jeo.representation.directives.RandName;
 import org.objectweb.asm.MethodVisitor;
 import org.xembly.Directive;
 
@@ -64,7 +65,7 @@ public final class BytecodeLabel implements BytecodeEntry {
     public Iterable<Directive> directives() {
         final Iterable<Directive> result;
         if (Objects.isNull(this.identifier)) {
-            result = new DirectivesEoObject("nop");
+            result = new DirectivesEoObject("nop", new RandName("nop").toString());
         } else {
             result = new DirectivesValue(this);
         }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesEoObject.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesEoObject.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.jeo.representation.directives;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -37,19 +36,13 @@ public final class DirectivesEoObject implements Iterable<Directive> {
     /**
      * Constructor.
      * @param base The base of the object.
-     */
-    public DirectivesEoObject(final String base) {
-        this(base, "", new ArrayList<>(0));
-    }
-
-    /**
-     * Constructor.
-     * @param base The base of the object.
      * @param name The name of the object.
      * @param inner Inner components.
      */
     @SafeVarargs
-    DirectivesEoObject(final String base, final String name, final Iterable<Directive>... inner) {
+    public DirectivesEoObject(
+        final String base, final String name, final Iterable<Directive>... inner
+    ) {
         this(base, name, Arrays.stream(inner).map(Directives::new).collect(Collectors.toList()));
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesTryCatch.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesTryCatch.java
@@ -85,7 +85,7 @@ public final class DirectivesTryCatch implements Iterable<Directive> {
         if (Objects.nonNull(value)) {
             result = new DirectivesValue(value);
         } else {
-            result = new DirectivesEoObject("nop");
+            result = new DirectivesEoObject("nop", new RandName("nop").toString());
         }
         return result;
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -203,7 +203,7 @@ public final class DirectivesValue implements Iterable<Directive> {
             base,
             this.name,
             new DirectivesComment(this.comment()),
-            new DirectivesBytes(this.hex(codec))
+            new DirectivesBytes(this.hex(codec), new RandName(base).toString())
         );
     }
 
@@ -232,7 +232,7 @@ public final class DirectivesValue implements Iterable<Directive> {
             base,
             this.name,
             new DirectivesComment(this.comment()),
-            new DirectivesNumber(this.hex(codec))
+            new DirectivesNumber(new RandName("number").toString(), this.hex(codec))
         );
     }
 


### PR DESCRIPTION
This PR ensures all formation children in XMIR representation have names by using `RandName` for `nop` operations and other anonymous objects, fixing illegal XMIR formations.

Related to #1163