### PR TITLE
feat(#1177): save method names as attribute values

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -140,9 +140,10 @@ public final class DirectivesMethod implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
+        final String mname = this.name.toString();
         return new DirectivesJeoObject(
             "method",
-            new PrefixedName(this.name.toString()).encode(),
+            new PrefixedName(mname).encode(),
             Stream.concat(
                 Stream.of(
                     this.properties,
@@ -155,7 +156,10 @@ public final class DirectivesMethod implements Iterable<Directive> {
                 ),
                 Stream.concat(
                     this.dvalue.stream(),
-                    Stream.of(this.attributes)
+                    Stream.of(
+                        this.attributes,
+                        new DirectivesValue("name", mname)
+                    )
                 )
             ).map(Directives::new).collect(Collectors.toList())
         ).iterator();

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -8,6 +8,7 @@ import com.jcabi.matchers.XhtmlMatchers;
 import java.util.Collections;
 import org.eolang.jeo.representation.NumberedName;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
+import org.eolang.jeo.representation.bytecode.JavaCodec;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,22 @@ final class DirectivesMethodTest {
             "We expect that 'j$' prefix will be added to the method name",
             new Xembler(new BytecodeMethod("φTerm").directives(1)).xml(),
             XhtmlMatchers.hasXPaths("./o[contains(@name, 'j$φTerm')]")
+        );
+    }
+
+    @Test
+    void savesMethodNameAsAttributeValue() {
+        final String foo = "foo";
+        MatcherAssert.assertThat(
+            "We expect that the method name will be saved as an attribute value",
+            new Xembler(new DirectivesMethod(foo)).xmlQuietly(),
+            XhtmlMatchers.hasXPath(
+                String.format(
+                    "./o[contains(@name,'%s')]/o[@name='name']/o/o[text()='%s']",
+                    foo,
+                    new DirectivesValue(foo).hex(new JavaCodec())
+                )
+            )
         );
     }
 


### PR DESCRIPTION
This PR ensures method names are stored as attribute values in the XMIR representation by adding a `name` directive with the method name as its value. Similar to #1135, this makes method names visible as strings rather than attribute names.

Related to #1177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The method name is now included as an attribute value in the XML representation.
* **Tests**
  * Added a test to verify that the method name is correctly saved and encoded as an attribute value in the XML output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->