### PR TITLE
fix(#1177): extract method names from XML attribute values

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -13,7 +13,6 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.MethodName;
 import org.eolang.jeo.representation.NumberedName;
-import org.eolang.jeo.representation.PrefixedName;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.eolang.jeo.representation.bytecode.BytecodeAttributes;
 import org.eolang.jeo.representation.bytecode.BytecodeMaxs;
@@ -190,13 +189,22 @@ public final class XmlMethod {
      * @return Name.
      */
     private String name() {
-        return new MethodName(
-            new PrefixedName(
-                new NumberedName(
-                    this.node.name()
-                ).plain()
-            ).decode()
-        ).bytecode();
+        return this.node.children()
+            .map(XmlEoObject::new)
+            .filter(XmlEoObject::named)
+            .filter(xml -> "name".equals(xml.name()))
+            .map(XmlValue::new)
+            .map(XmlValue::string)
+            .map(NumberedName::new)
+            .map(NumberedName::plain)
+            .map(MethodName::new)
+            .map(MethodName::bytecode)
+            .findFirst()
+            .orElseThrow(
+                () -> new IllegalStateException(
+                    String.format("Method '%s' doesn't have a name", this.node.name())
+                )
+            );
     }
 
     /**


### PR DESCRIPTION
This PR modifies `XmlMethod` to retrieve method names as attribute values instead of attribute names

Related to #1177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of method name extraction for better reliability and maintainability. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->