### PR TITLE
feat(#1172): replace base attribute with @ in delegate objects

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesDelegateObject.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesDelegateObject.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.Iterator;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+/**
+ * Directives for an EO object that delegates to another object.
+ * <p>
+ *     Alternative representations of the same idea:
+ *     - {@link DirectivesClosedObject} - a closed object with a base attribute,
+ *     - {@link DirectivesAbsractObject} - an abstract object with a base attribute,
+ * </p>
+ * @since 0.12.0
+ */
+public final class DirectivesDelegateObject implements Iterable<Directive> {
+
+    /**
+     * The name of the abstract object.
+     */
+    private final String base;
+
+    /**
+     * Attribute 'as' of the abstract object.
+     * @checkstyle MemberNameCheck (2 lines)
+     */
+    private final String as;
+
+    /**
+     * Attribute 'name' of the abstract object.
+     */
+    private final String name;
+
+    /**
+     * Inner components of the abstract object.
+     */
+    private final Iterable<Directive> internal;
+
+    /**
+     * Constructor.
+     * @param base The 'base' attribute of the abstract object.
+     * @param internal Inner components of the abstract object.
+     */
+    DirectivesDelegateObject(final String base, final Iterable<Directive> internal) {
+        this(base, "", internal);
+    }
+
+    /**
+     * Constructor.
+     * @param base The 'base' attribute of the abstract object.
+     * @param as The 'as' attribute of the abstract object.
+     * @param directives Inner components of the abstract object.
+     * @checkstyle ParameterNameCheck (5 lines)
+     */
+    DirectivesDelegateObject(
+        final String base,
+        final String as,
+        final Iterable<Directive> directives
+    ) {
+        this(base, as, "", directives);
+    }
+
+    /**
+     * Constructor.
+     * @param base The 'base' attribute of the abstract object.
+     * @param as The 'as' attribute of the abstract object.
+     * @param name The 'name' attribute of the abstract object.
+     * @param internal Inner components of the abstract object.
+     * @checkstyle ParameterNameCheck (5 lines)
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    public DirectivesDelegateObject(
+        final String base,
+        final String as,
+        final String name,
+        final Iterable<Directive> internal
+    ) {
+        this.base = base;
+        this.as = as;
+        this.name = name;
+        this.internal = internal;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        final Directives directives = new Directives().add("o");
+        if (!this.as.isEmpty()) {
+            directives.attr("as", this.as);
+        }
+        if (!this.name.isEmpty()) {
+            directives.attr("name", this.name);
+        }
+        directives.append(new DirectivesSimpleDelegate(this.base));
+        if (this.internal.iterator().hasNext()) {
+            directives.append(this.internal);
+        }
+        directives.up();
+        return directives.iterator();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesGlobalObject.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesGlobalObject.java
@@ -62,7 +62,7 @@ public final class DirectivesGlobalObject implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        return new DirectivesAbsractObject(
+        return new DirectivesDelegateObject(
             new JeoFqn(this.base).fqn(),
             "",
             this.name,

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesJeoObject.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesJeoObject.java
@@ -78,7 +78,7 @@ public final class DirectivesJeoObject implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        return new DirectivesAbsractObject(
+        return new DirectivesDelegateObject(
             new JeoFqn(this.base).fqn(),
             "",
             this.name,

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesSimpleDelegate.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesSimpleDelegate.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.Iterator;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+/**
+ * Simple EO delegate object.
+ * <p>
+ *     Trivial object that represents a simple EO delegate object
+ *     with an attribute 'base' and a name '@'.
+ * </p>
+ * @since 0.12.0
+ */
+public final class DirectivesSimpleDelegate implements Iterable<Directive> {
+
+    /**
+     * Base of the object.
+     */
+    private final String base;
+
+    /**
+     * Constructor.
+     * @param base The 'base' attribute of the abstract object.
+     */
+    public DirectivesSimpleDelegate(final String base) {
+        this.base = base;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        return new Directives().add("o")
+            .attr("base", this.base)
+            .attr("name", "@")
+            .up()
+            .iterator();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -40,7 +40,8 @@ public final class JcabiXmlNode implements XmlNode {
             "no-attribute-formation",
             "redundant-object",
             "duplicate-names-in-diff-context",
-            "unit-test-missing"
+            "unit-test-missing",
+            "sparse-decoration"
         )
     );
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClassProperties.java
@@ -55,8 +55,8 @@ final class XmlClassProperties {
     private int access() {
         return (int) new XmlValue(
             this.clazz.children()
-                .map(XmlEoObject::new)
-                .filter(XmlEoObject::named)
+                .map(XmlNamedObject::new)
+                .filter(XmlNamedObject::named)
                 .filter(node -> node.name().contains("access"))
                 .findFirst()
                 .orElseThrow(
@@ -126,10 +126,10 @@ final class XmlClassProperties {
      * @param name Name of the child node.
      * @return Child node.
      */
-    private Optional<XmlEoObject> eoChild(final String name) {
+    private Optional<XmlNamedObject> eoChild(final String name) {
         return this.clazz.children()
-            .map(XmlEoObject::new)
-            .filter(XmlEoObject::named)
+            .map(XmlNamedObject::new)
+            .filter(XmlNamedObject::named)
             .filter(node -> node.name().equals(name))
             .findFirst();
     }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlDelegateObject.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlDelegateObject.java
@@ -10,53 +10,55 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Abstract XML object representation.
+ * Xml representation of an EO delegate object.
  * <p>
- * This class keeps the base attribute as a separate object (argument) instead of XML attribute.
- * This class is similar to {@link XmlClosedObject}.
+ *     Alternative representations of the same idea:
+ *     - {@link XmlClosedObject} - a closed object with a base attribute,
+ *     - {@link XmlAbstractObject} - an abstract object with a base attribute,
  * </p>
  * <p>
- *     Mirrors from {@link org.eolang.jeo.representation.directives.DirectivesAbsractObject}
+ *     Mirrors:
+ *     - {@link org.eolang.jeo.representation.directives.DirectivesDelegateObject}.
  * </p>
- * @since 0.11.0
+ * @since 0.12.0
  */
-final class XmlAbstractObject implements XmlEoObject {
+public final class XmlDelegateObject implements XmlEoObject {
 
     /**
-     * XML node of the closed object.
+     * Inner XML node representing the delegate object.
      */
-    private final XmlNode node;
+    private final XmlNode inner;
 
     /**
      * Constructor.
-     * @param node XML node of the closed object.
+     * @param inner XML node representing the delegate object
      */
-    XmlAbstractObject(final XmlNode node) {
-        this.node = node;
+    XmlDelegateObject(final XmlNode inner) {
+        this.inner = inner;
     }
 
     @Override
     public String toString() {
-        return this.node.toString();
+        return this.inner.toString();
     }
 
     @Override
     public Optional<String> base() {
-        return this.node.children().findFirst()
-            .filter(child -> child.attribute("name").map("base"::equals).orElse(false))
-            .map(child -> new XmlValue(child).string());
+        return this.inner.children().findFirst()
+            .filter(child -> child.attribute("name").map("@"::equals).orElse(false))
+            .map(child -> new XmlSimpleDelegate(child).base());
     }
 
     @Override
     public Optional<String> attribute(final String name) {
-        return this.node.attribute(name);
+        return this.inner.attribute(name);
     }
 
     @Override
     public Optional<XmlNode> child(final int index) {
         final int indx = index + 1;
         final Optional<XmlNode> result;
-        final List<XmlNode> children = this.node.children().collect(Collectors.toList());
+        final List<XmlNode> children = this.inner.children().collect(Collectors.toList());
         if (indx < 0 || indx >= children.size()) {
             result = Optional.empty();
         } else {
@@ -67,12 +69,12 @@ final class XmlAbstractObject implements XmlEoObject {
 
     @Override
     public Stream<XmlNode> children() {
-        final List<XmlNode> collect = this.node.children().collect(Collectors.toList());
+        final List<XmlNode> collect = this.inner.children().collect(Collectors.toList());
         if (collect.isEmpty()) {
             throw new IllegalStateException(
                 String.format(
                     "The '%s' node doesn't have any children, but it should have at least one",
-                    this.node
+                    this.inner
                 )
             );
         }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlEoObject.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlEoObject.java
@@ -4,54 +4,38 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import java.util.Optional;
+import java.util.stream.Stream;
+
 /**
- * This is EO object in XML representation.
- * <p>
- *     Mirrors {@link org.eolang.jeo.representation.directives.DirectivesEoObject}
- * </p>
- * @since 0.11.0
+ * XML EO object representation.
+ * @since 0.12.0
  */
-public final class XmlEoObject {
+interface XmlEoObject {
 
     /**
-     * Inner XML node representing the EO object.
+     * Get the option type of the object.
+     * @return Optional type.
      */
-    private final XmlNode inner;
+    Optional<String> base();
 
     /**
-     * Constructor.
-     * @param inner XML node representing the EO object.
+     * Get the attribute by name.
+     * @param name Name of the attribute.
+     * @return Optional attribute value.
      */
-    XmlEoObject(final XmlNode inner) {
-        this.inner = inner;
-    }
+    Optional<String> attribute(String name);
 
     /**
-     * Retrieve the name of the EO object.
-     * @return Name of the EO object.
+     * Get the child node by index.
+     * @param index Index of the child node.
+     * @return Optional child node.
      */
-    public String name() {
-        return this.inner.attribute("name")
-            .orElseThrow(
-                () -> new IllegalStateException(
-                    String.format("Attribute 'name' not found in %s", this.inner)
-                )
-            );
-    }
+    Optional<XmlNode> child(int index);
 
     /**
-     * Retrieve the inner XML node representing the EO object.
-     * @return XML node of the EO object.
+     * Retrieve the children of the XML node.
+     * @return Stream of child nodes.
      */
-    public XmlNode node() {
-        return this.inner;
-    }
-
-    /**
-     * Whether the EO object has a name attribute.
-     * @return True if the EO object has a name attribute, false otherwise.
-     */
-    boolean named() {
-        return this.inner.attribute("name").isPresent();
-    }
+    Stream<XmlNode> children();
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlGlobalObject.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlGlobalObject.java
@@ -19,21 +19,21 @@ final class XmlGlobalObject {
     /**
      * Abstract XML object representation.
      */
-    private final XmlAbstractObject origin;
+    private final XmlEoObject origin;
 
     /**
      * Constructor.
      * @param node XML node representing the global object.
      */
     XmlGlobalObject(final XmlNode node) {
-        this(new XmlAbstractObject(node));
+        this(new XmlDelegateObject(node));
     }
 
     /**
      * Constructor.
      * @param origin XML abstract object representing the global object.
      */
-    private XmlGlobalObject(final XmlAbstractObject origin) {
+    private XmlGlobalObject(final XmlEoObject origin) {
         this.origin = origin;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlJeoObject.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlJeoObject.java
@@ -17,21 +17,21 @@ final class XmlJeoObject {
     /**
      * Origin XML node.
      */
-    private final XmlAbstractObject origin;
+    private final XmlEoObject origin;
 
     /**
      * Constructor.
      * @param node XML node.
      */
     XmlJeoObject(final XmlNode node) {
-        this(new XmlAbstractObject(node));
+        this(new XmlDelegateObject(node));
     }
 
     /**
      * Constructor.
      * @param origin XML abstract object.
      */
-    private XmlJeoObject(final XmlAbstractObject origin) {
+    private XmlJeoObject(final XmlEoObject origin) {
         this.origin = origin;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -190,8 +190,8 @@ public final class XmlMethod {
      */
     private String name() {
         return this.node.children()
-            .map(XmlEoObject::new)
-            .filter(XmlEoObject::named)
+            .map(XmlNamedObject::new)
+            .filter(XmlNamedObject::named)
             .filter(xml -> "name".equals(xml.name()))
             .map(XmlValue::new)
             .map(XmlValue::string)
@@ -313,10 +313,10 @@ public final class XmlMethod {
      * @param name Name.
      * @return Child.
      */
-    private XmlEoObject child(final String name) {
+    private XmlNamedObject child(final String name) {
         return this.node.children()
-            .map(XmlEoObject::new)
-            .filter(XmlEoObject::named)
+            .map(XmlNamedObject::new)
+            .filter(XmlNamedObject::named)
             .filter(object -> object.name().contains(name))
             .findFirst()
             .orElseThrow(

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlNamedObject.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlNamedObject.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+/**
+ * This is EO object in XML representation.
+ * <p>
+ *     Mirrors {@link org.eolang.jeo.representation.directives.DirectivesEoObject}
+ * </p>
+ * @since 0.11.0
+ */
+public final class XmlNamedObject {
+
+    /**
+     * Inner XML node representing the EO object.
+     */
+    private final XmlNode inner;
+
+    /**
+     * Constructor.
+     * @param inner XML node representing the EO object.
+     */
+    XmlNamedObject(final XmlNode inner) {
+        this.inner = inner;
+    }
+
+    /**
+     * Retrieve the name of the EO object.
+     * @return Name of the EO object.
+     */
+    public String name() {
+        return this.inner.attribute("name")
+            .orElseThrow(
+                () -> new IllegalStateException(
+                    String.format("Attribute 'name' not found in %s", this.inner)
+                )
+            );
+    }
+
+    /**
+     * Retrieve the inner XML node representing the EO object.
+     * @return XML node of the EO object.
+     */
+    public XmlNode node() {
+        return this.inner;
+    }
+
+    /**
+     * Whether the EO object has a name attribute.
+     * @return True if the EO object has a name attribute, false otherwise.
+     */
+    boolean named() {
+        return this.inner.attribute("name").isPresent();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlSimpleDelegate.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlSimpleDelegate.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+/**
+ * Xml representation of a simple EO delegate object.
+ * <p>
+ *     Mirrors {@link org.eolang.jeo.representation.directives.DirectivesSimpleDelegate}
+ * </p>
+ * @since 0.12.0
+ */
+public final class XmlSimpleDelegate {
+
+    /**
+     * Inner XML node representing the delegate object.
+     */
+    private final XmlNode inner;
+
+    /**
+     * Constructor.
+     * @param node XML node representing the delegate object
+     */
+    XmlSimpleDelegate(final XmlNode node) {
+        this.inner = node;
+    }
+
+    /**
+     * Base of the delegate object.
+     * @return Base of the delegate object.
+     */
+    public String base() {
+        return this.inner.attribute("base").orElseThrow(
+            () -> new IllegalStateException(
+                String.format(
+                    "Base attribute is not set in the XML node %s",
+                    this.inner
+                )
+            )
+        );
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlValue.java
@@ -52,7 +52,7 @@ public final class XmlValue {
      * Constructor.
      * @param node XML node.
      */
-    public XmlValue(final XmlEoObject node) {
+    public XmlValue(final XmlNamedObject node) {
         this(node.node());
     }
 

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesDelegateObjectTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesDelegateObjectTest.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link DirectivesDelegateObject}.
+ * @since 0.12.0
+ */
+final class DirectivesDelegateObjectTest {
+    /**
+     * Base attribute.
+     */
+    private static final String BASE = "maxs";
+
+    @Test
+    void generatesValidXmlRepresentationWithBase() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect the delegate object to have the base attribute",
+            new Xembler(
+                new DirectivesDelegateObject(
+                    DirectivesDelegateObjectTest.BASE,
+                    new DirectivesValue(1)
+                )
+            ).xml(),
+            XhtmlMatchers.hasXPath(
+                String.format("o/o[@base='%s' and @name='@']", DirectivesDelegateObjectTest.BASE)
+            )
+        );
+    }
+
+    @Test
+    void generatesValidXmlRepresentationWithBaseAndAs() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect the delegate object to have base and as attributes",
+            new Xembler(
+                new DirectivesDelegateObject(
+                    DirectivesDelegateObjectTest.BASE,
+                    "asValue",
+                    new DirectivesValue(1)
+                )
+            ).xml(),
+            XhtmlMatchers.hasXPath(
+                String.format(
+                    "o[@as='asValue']/o[@base='%s' and @name='@']",
+                    DirectivesDelegateObjectTest.BASE
+                )
+            )
+        );
+    }
+
+    @Test
+    void generatesValidXmlRepresentationWithBaseAsAndName() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect the delegate object to have base, as, and name attributes",
+            new Xembler(
+                new DirectivesDelegateObject(
+                    DirectivesDelegateObjectTest.BASE,
+                    "as",
+                    "name",
+                    new DirectivesValue(1)
+                )
+            ).xml(),
+            XhtmlMatchers.hasXPath(
+                String.format(
+                    "o[@as='as' and @name='name']/o[@base='%s' and @name='@']",
+                    DirectivesDelegateObjectTest.BASE
+                )
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesSimpleDelegateTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesSimpleDelegateTest.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Transformers;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link DirectivesSimpleDelegate}.
+ * @since 0.12.0
+ */
+final class DirectivesSimpleDelegateTest {
+
+    @Test
+    void generatesDirectivesWithBaseAndName() throws ImpossibleModificationException {
+        final String base = "test-base";
+        MatcherAssert.assertThat(
+            "The generated XML should match the expected format",
+            new Xembler(new DirectivesSimpleDelegate(base), new Transformers.Node()).xml(),
+            Matchers.is(Matchers.equalTo(String.format("<o base=\"%s\" name=\"@\"/>", base)))
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/JeoBaseXpath.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/JeoBaseXpath.java
@@ -4,8 +4,6 @@
  */
 package org.eolang.jeo.representation.directives;
 
-import org.eolang.jeo.representation.bytecode.JavaCodec;
-
 /**
  * XPath for the base of an object.
  * This class is the response to the frequent changes in a way we represent 'base' attribute in
@@ -40,10 +38,6 @@ final class JeoBaseXpath {
      * @return String base.
      */
     String toXpath() {
-        return String.format(
-            "%s/o[@name='base' and contains(@base,'string')]/o[contains(@base, 'bytes')]/o[contains(text(),'%s')]",
-            this.element,
-            new DirectivesValue(this.base).hex(new JavaCodec())
-        );
+        return String.format("%s/o[@name='@' and contains(@base,'%s')]", this.element, this.base);
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlDelegateObjectTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlDelegateObjectTest.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import java.util.Collections;
+import java.util.stream.Stream;
+import org.eolang.jeo.representation.directives.DirectivesDelegateObject;
+import org.eolang.jeo.representation.directives.DirectivesValue;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link XmlDelegateObject}.
+ * @since 0.12.0
+ */
+final class XmlDelegateObjectTest {
+
+    @Test
+    void parsesBaseOfDelegateObject() {
+        final String base = "object-type-delegate";
+        MatcherAssert.assertThat(
+            "We expect the delegate object to save base as a first parameter",
+            new XmlDelegateObject(
+                new JcabiXmlNode(
+                    new Xembler(
+                        new DirectivesDelegateObject(
+                            base,
+                            "as-attr",
+                            "name-attr",
+                            Collections.emptyList()
+                        )
+                    ).xmlQuietly()
+                )
+            ).base().orElseThrow(AssertionError::new),
+            Matchers.equalTo(base)
+        );
+    }
+
+    @Test
+    void retrievesNameOfDelegateObject() {
+        final String name = "delegate-object-name";
+        MatcherAssert.assertThat(
+            "We expect the delegate object to save name as a second parameter",
+            new XmlDelegateObject(
+                new JcabiXmlNode(
+                    new Xembler(
+                        new DirectivesDelegateObject(
+                            "base-attr",
+                            "as-attr",
+                            name,
+                            Collections.emptyList()
+                        )
+                    ).xmlQuietly()
+                )
+            ).attribute("name").orElseThrow(AssertionError::new),
+            Matchers.equalTo(name)
+        );
+    }
+
+    @Test
+    void retrievesFirstChildOfDelegateObject() {
+        final String child = "child-object";
+        MatcherAssert.assertThat(
+            "We expect the delegate object to have a child",
+            new XmlValue(
+                new XmlDelegateObject(
+                    new JcabiXmlNode(
+                        new Xembler(
+                            new DirectivesDelegateObject(
+                                "base-attr",
+                                "as-attr",
+                                "name-attr",
+                                new DirectivesValue(child)
+                            )
+                        ).xmlQuietly()
+                    )
+                ).child(0).orElseThrow(AssertionError::new)
+            ).string(),
+            Matchers.equalTo(child)
+        );
+    }
+
+    @Test
+    void retrievesAllChildrenOfDelegateObject() {
+        MatcherAssert.assertThat(
+            "We expect the delegate object to have multiple children",
+            new XmlDelegateObject(
+                new JcabiXmlNode(
+                    new Xembler(
+                        new DirectivesDelegateObject(
+                            "base-attr",
+                            "as-attr",
+                            "name-attr",
+                            Stream.of(
+                                new DirectivesValue("first-child"),
+                                new DirectivesValue("second-child")
+                            ).map(Directives::new).reduce(new Directives(), Directives::append)
+                        )
+                    ).xmlQuietly()
+                )
+            ).children().count(),
+            Matchers.equalTo(2L)
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
@@ -72,13 +72,13 @@ final class XmlInstructionTest {
                     new JcabiXmlNode(
                         new Xembler(new DirectivesInstruction(Opcodes.DUP))
                             .xml()
-                            .replace("64-75-70", "31-31-31")
+                            .replace("dup", "unknown")
                     )
                 ).bytecode(),
                 "Should throw an exception for invalid opcode"
             ).getMessage(),
             Matchers.containsString(
-                "Unknown opcode name: 111"
+                "Unknown opcode name: unknown"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlSimpleDelegateTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlSimpleDelegateTest.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import org.eolang.jeo.representation.directives.DirectivesSimpleDelegate;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link XmlSimpleDelegate}.
+ * @since 0.12.0
+ */
+final class XmlSimpleDelegateTest {
+
+    @Test
+    void parsesBaseAttribute() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "Expected the base attribute to be 'test-base'",
+            new XmlSimpleDelegate(
+                new JcabiXmlNode(new Xembler(new DirectivesSimpleDelegate("test-base")).xml())
+            ).base(),
+            Matchers.equalTo("test-base")
+        );
+    }
+}


### PR DESCRIPTION
Refactors EO object representation to use `@` attribute instead of nested `base` objects, aligning with EO object model standards.

Related to #1172