### PR TITLE
feat(#1191): convert label representation from bytes to string

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLabel.java
@@ -12,9 +12,7 @@ import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.asm.AsmLabels;
-import org.eolang.jeo.representation.directives.DirectivesEoObject;
-import org.eolang.jeo.representation.directives.DirectivesValue;
-import org.eolang.jeo.representation.directives.RandName;
+import org.eolang.jeo.representation.directives.DirectivesLabel;
 import org.objectweb.asm.MethodVisitor;
 import org.xembly.Directive;
 
@@ -63,13 +61,7 @@ public final class BytecodeLabel implements BytecodeEntry {
 
     @Override
     public Iterable<Directive> directives() {
-        final Iterable<Directive> result;
-        if (Objects.isNull(this.identifier)) {
-            result = new DirectivesEoObject("nop", new RandName("nop").toString());
-        } else {
-            result = new DirectivesValue(this);
-        }
-        return result;
+        return new DirectivesLabel(this.identifier);
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
@@ -68,11 +68,6 @@ enum DataType {
     BYTES("bytes", byte[].class),
 
     /**
-     * Label.
-     */
-    LABEL("label", BytecodeLabel.class),
-
-    /**
      * Type reference.
      */
     TYPE_REFERENCE("type", Type.class),

--- a/src/main/java/org/eolang/jeo/representation/bytecode/EoCodec.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/EoCodec.java
@@ -42,7 +42,6 @@ public final class EoCodec implements Codec {
             case CHAR:
             case STRING:
             case BYTES:
-            case LABEL:
             case TYPE_REFERENCE:
             case CLASS_REFERENCE:
             case NULL:
@@ -72,7 +71,6 @@ public final class EoCodec implements Codec {
             case CHAR:
             case STRING:
             case BYTES:
-            case LABEL:
             case TYPE_REFERENCE:
             case CLASS_REFERENCE:
             case NULL:

--- a/src/main/java/org/eolang/jeo/representation/bytecode/JavaCodec.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/JavaCodec.java
@@ -58,9 +58,6 @@ public final class JavaCodec implements Codec {
             case BYTES:
                 result = byte[].class.cast(value);
                 break;
-            case LABEL:
-                result = BytecodeLabel.class.cast(value).uid().getBytes(StandardCharsets.UTF_8);
-                break;
             case TYPE_REFERENCE:
                 result = JavaCodec.typeBytes(value);
                 break;
@@ -111,9 +108,6 @@ public final class JavaCodec implements Codec {
                 break;
             case BYTES:
                 result = bytes;
-                break;
-            case LABEL:
-                result = new BytecodeLabel(new String(bytes, StandardCharsets.UTF_8));
                 break;
             case TYPE_REFERENCE:
                 result = Type.getType(String.format(new String(bytes, StandardCharsets.UTF_8)));

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesLabel.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.Iterator;
+import java.util.Objects;
+import org.xembly.Directive;
+
+/**
+ * Directives of a Java label in EO language.
+ * @since 0.12.0
+ */
+public final class DirectivesLabel implements Iterable<Directive> {
+
+    /**
+     * Simple string identifier.
+     */
+    private final String identifier;
+
+    /**
+     * Default constructor.
+     * @param identifier Identifier for the label.
+     */
+    public DirectivesLabel(final String identifier) {
+        this.identifier = identifier;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        final Iterable<Directive> result;
+        if (Objects.isNull(this.identifier)) {
+            result = new DirectivesEoObject("nop", new RandName("nop").toString());
+        } else {
+            result = new DirectivesJeoObject(
+                "label",
+                new RandName("l").toString(),
+                new DirectivesValue(this.identifier)
+            );
+        }
+        return result.iterator();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesOperand.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesOperand.java
@@ -5,6 +5,7 @@
 package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
+import org.eolang.jeo.representation.bytecode.BytecodeEntry;
 import org.eolang.jeo.representation.bytecode.BytecodeLabel;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
@@ -34,7 +35,9 @@ public final class DirectivesOperand implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         final Iterator<Directive> result;
         if (this.raw instanceof Label) {
-            result = new BytecodeLabel(this.raw.toString()).directives().iterator();
+            result = new DirectivesLabel(this.raw.toString()).iterator();
+        } else if (this.raw instanceof BytecodeLabel) {
+            result = ((BytecodeEntry) this.raw).directives().iterator();
         } else if (this.raw instanceof Handle) {
             result = new DirectivesHandle((Handle) this.raw).iterator();
         } else if (this.raw instanceof Type) {

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValues.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValues.java
@@ -12,6 +12,8 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.eolang.jeo.representation.bytecode.BytecodeEntry;
+import org.eolang.jeo.representation.bytecode.BytecodeLabel;
 import org.xembly.Directive;
 
 /**
@@ -58,10 +60,18 @@ public final class DirectivesValues implements Iterable<Directive> {
             Arrays.stream(this.values)
                 .filter(Objects::nonNull)
                 .map(
-                    value -> new DirectivesValue(
-                        String.format("x%d", index.getAndIncrement()),
-                        value
-                    )
+                    value -> {
+                        final Iterable<Directive> result;
+                        if (value instanceof BytecodeLabel) {
+                            result = ((BytecodeEntry) value).directives();
+                        } else {
+                            result = new DirectivesValue(
+                                String.format("x%d", index.getAndIncrement()),
+                                value
+                            );
+                        }
+                        return result;
+                    }
                 )
                 .collect(Collectors.toList())
         ).iterator();

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLabel.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import java.nio.charset.StandardCharsets;
 import org.eolang.jeo.representation.bytecode.BytecodeLabel;
 
 /**
@@ -31,9 +30,9 @@ public final class XmlLabel implements XmlBytecodeEntry {
      * @return Bytecode label.
      */
     public BytecodeLabel bytecode() {
-        return new BytecodeLabel(
-            new String(
-                (byte[]) new XmlValue(
+        try {
+            return new BytecodeLabel(
+                new XmlValue(
                     this.node.children()
                         .findFirst()
                         .orElseThrow(
@@ -41,9 +40,13 @@ public final class XmlLabel implements XmlBytecodeEntry {
                                 "Label node must have at least one child"
                             )
                         )
-                ).object(),
-                StandardCharsets.UTF_8
-            )
-        );
+                ).string()
+            );
+        } catch (final ClassCastException exception) {
+            throw new IllegalStateException(
+                String.format("Incorrect label node: %n%s", this.node),
+                exception
+            );
+        }
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlTryCatchEntry.java
@@ -113,8 +113,7 @@ public final class XmlTryCatchEntry implements XmlBytecodeEntry {
                     .map(XmlTryCatchEntry.NOP::equals)
                     .orElse(false)
             )
-            .map(XmlValue::new)
-            .map(XmlValue::object)
-            .map(BytecodeLabel.class::cast);
+            .map(XmlLabel::new)
+            .map(XmlLabel::bytecode);
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/JavaCodecTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/JavaCodecTest.java
@@ -54,7 +54,6 @@ final class JavaCodecTest {
             {'a', DataType.CHAR, new byte[]{0, 97}},
             {new byte[]{0, 1, 2, 3}, DataType.BYTES, new byte[]{0, 1, 2, 3}},
             {"hello, world!", DataType.STRING, "hello, world!".getBytes(StandardCharsets.UTF_8)},
-            {new BytecodeLabel("label"), DataType.LABEL, "label".getBytes(StandardCharsets.UTF_8)},
             {
                 Type.getType(Object.class),
                 DataType.TYPE_REFERENCE,

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesLabelTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesLabelTest.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link DirectivesLabel}.
+ * @since 0.12.0
+ */
+final class DirectivesLabelTest {
+
+    @Test
+    void createsCorrectXmlLabel() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "Expected XML to contain a label directive with the identifier 'test-label'",
+            new Xembler(new DirectivesLabel("test-label")).xml(),
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "label").toXpath()
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
@@ -6,7 +6,6 @@ package org.eolang.jeo.representation.directives;
 
 import com.jcabi.matchers.XhtmlMatchers;
 import java.util.stream.Stream;
-import org.eolang.jeo.representation.bytecode.BytecodeLabel;
 import org.eolang.jeo.representation.bytecode.Codec;
 import org.eolang.jeo.representation.bytecode.JavaCodec;
 import org.hamcrest.MatcherAssert;
@@ -17,7 +16,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.objectweb.asm.Type;
 import org.xembly.ImpossibleModificationException;
-import org.xembly.Transformers;
 import org.xembly.Xembler;
 
 /**
@@ -85,23 +83,6 @@ final class DirectivesValueTest {
                     "./o[contains(@base,'number') and @name='access']/o[contains(@base,'bytes')]/o[text()='%s']",
                     bytes
                 )
-            )
-        );
-    }
-
-    @Test
-    void convertsLabel() throws ImpossibleModificationException {
-        MatcherAssert.assertThat(
-            "Converts label to XML",
-            new Xembler(
-                new DirectivesValue(
-                    new BytecodeLabel("some-random")
-                ),
-                new Transformers.Node()
-            ).xml(),
-            XhtmlMatchers.hasXPaths(
-                new JeoBaseXpath("./o", "label").toXpath(),
-                "./o/o[contains(@base,'bytes')]/o[text()='73-6F-6D-65-2D-72-61-6E-64-6F-6D']"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlValueTest.java
@@ -5,7 +5,6 @@
 package org.eolang.jeo.representation.xmir;
 
 import java.util.stream.Stream;
-import org.eolang.jeo.representation.bytecode.BytecodeLabel;
 import org.eolang.jeo.representation.directives.DirectivesValue;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -97,8 +96,7 @@ final class XmlValueTest {
             Arguments.of(Short.MIN_VALUE),
             Arguments.of(Byte.MAX_VALUE),
             Arguments.of(Byte.MIN_VALUE),
-            Arguments.of("org/eolang/jeo/representation/HexDataTest"),
-            Arguments.of(new BytecodeLabel("some"))
+            Arguments.of("org/eolang/jeo/representation/HexDataTest")
         );
     }
 }


### PR DESCRIPTION
Refactors label representation to use `string` instead of `bytes` for better readability in XMIR output. Simplifies label handling across the codebase.

Related to #1191