### PR TITLE
refactor(#1171): shorten attribute names for better readability

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotationAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotationAnnotationValue.java
@@ -50,7 +50,7 @@ public final class DirectivesAnnotationAnnotationValue implements Iterable<Direc
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "annotation-property",
-            new RandName("annotation").toString(),
+            new RandName("a").toString(),
             Stream.concat(
                 Stream.of(
                     new DirectivesValue("ANNOTATION"),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesArrayAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesArrayAnnotationValue.java
@@ -43,7 +43,7 @@ public final class DirectivesArrayAnnotationValue implements Iterable<Directive>
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "annotation-property",
-            new RandName("array").toString(),
+            new RandName("a").toString(),
             Stream.concat(
                 Stream.of(
                     new DirectivesValue("ARRAY"),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttribute.java
@@ -47,7 +47,7 @@ public final class DirectivesAttribute implements Iterable<Directive> {
      * @param data Properties of an attribute.
      */
     private DirectivesAttribute(final String base, final List<Iterable<Directive>> data) {
-        this(base, new RandName("attr").toString(), data);
+        this(base, new RandName("a").toString(), data);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesEnumAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesEnumAnnotationValue.java
@@ -49,7 +49,7 @@ public final class DirectivesEnumAnnotationValue implements Iterable<Directive> 
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "annotation-property",
-            new RandName("enum").toString(),
+            new RandName("e").toString(),
             new DirectivesValue("ENUM"),
             new DirectivesValue(Optional.ofNullable(this.name).orElse("")),
             new DirectivesValue(this.descriptor),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesFrame.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesFrame.java
@@ -73,7 +73,7 @@ public final class DirectivesFrame implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "frame",
-            new RandName("frame").toString(),
+            new RandName("f").toString(),
             new DirectivesValue(this.name("type"), this.type),
             new DirectivesValue(this.name("nlocal"), this.nlocal),
             new DirectivesValues(this.name("locals"), this.locals),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesHandle.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesHandle.java
@@ -32,7 +32,7 @@ public final class DirectivesHandle implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "handle",
-            new RandName("handle").toString(),
+            new RandName("h").toString(),
             new DirectivesValue(this.handle.getTag()),
             new DirectivesValue(this.handle.getOwner()),
             new DirectivesValue(this.handle.getName()),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesInstruction.java
@@ -46,7 +46,7 @@ public final class DirectivesInstruction implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             this.base(),
-            new RandName("instruction").toString(),
+            new RandName("i").toString(),
             Stream.concat(
                 Stream.of(new DirectivesComment(this.comment())),
                 Arrays.stream(this.arguments).map(DirectivesOperand::new)

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesLabel.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesLabel.java
@@ -31,7 +31,7 @@ public final class DirectivesLabel implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         final Iterable<Directive> result;
         if (Objects.isNull(this.identifier)) {
-            result = new DirectivesEoObject("nop", new RandName("nop").toString());
+            result = new DirectivesEoObject("nop", new RandName("n").toString());
         } else {
             result = new DirectivesJeoObject(
                 "label",

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesPlainAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesPlainAnnotationValue.java
@@ -89,7 +89,7 @@ public final class DirectivesPlainAnnotationValue implements Iterable<Directive>
         }
         return new DirectivesJeoObject(
             "annotation-property",
-            new RandName("plain").toString(),
+            new RandName("p").toString(),
             new DirectivesValue("PLAIN"),
             new DirectivesValue(Optional.ofNullable(this.name).orElse("")),
             res

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesTryCatch.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesTryCatch.java
@@ -65,7 +65,7 @@ public final class DirectivesTryCatch implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "trycatch",
-            new RandName("trycatch").toString(),
+            new RandName("t").toString(),
             Stream.of(
                 this.start.directives(),
                 this.end.directives(),
@@ -85,7 +85,7 @@ public final class DirectivesTryCatch implements Iterable<Directive> {
         if (Objects.nonNull(value)) {
             result = new DirectivesValue(value);
         } else {
-            result = new DirectivesEoObject("nop", new RandName("nop").toString());
+            result = new DirectivesEoObject("nop", new RandName("n").toString());
         }
         return result;
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesType.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesType.java
@@ -31,7 +31,7 @@ public final class DirectivesType implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "type",
-            new RandName("type").toString(),
+            new RandName("t").toString(),
             new DirectivesValue(this.type.getDescriptor())
         ).iterator();
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -62,7 +62,7 @@ public final class DirectivesValue implements Iterable<Directive> {
      * @param <T> Data type.
      */
     public <T> DirectivesValue(final T data) {
-        this(new RandName("val").toString(), data);
+        this(new RandName("v").toString(), data);
     }
 
     /**
@@ -187,7 +187,7 @@ public final class DirectivesValue implements Iterable<Directive> {
             base,
             this.name,
             new DirectivesComment(this.comment()),
-            new DirectivesBytes(this.hex(codec), new RandName("null").toString())
+            new DirectivesBytes(this.hex(codec), new RandName("n").toString())
         );
     }
 
@@ -203,7 +203,7 @@ public final class DirectivesValue implements Iterable<Directive> {
             base,
             this.name,
             new DirectivesComment(this.comment()),
-            new DirectivesBytes(this.hex(codec), new RandName(base).toString())
+            new DirectivesBytes(this.hex(codec), new RandName("j").toString())
         );
     }
 
@@ -232,7 +232,7 @@ public final class DirectivesValue implements Iterable<Directive> {
             base,
             this.name,
             new DirectivesComment(this.comment()),
-            new DirectivesNumber(new RandName("number").toString(), this.hex(codec))
+            new DirectivesNumber(new RandName("n").toString(), this.hex(codec))
         );
     }
 


### PR DESCRIPTION
Shortens generated attribute names from descriptive (like `instruction2353`) to single-letter prefixes (like `i2353`) to improve readability.

Related to #1171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Shortened the prefixes used for generating internal random names across various components, resulting in more concise identifiers within the system. No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->