### PR TITLE
fix(#1175): filter only .xmir files in XmirFiles.all()

### DIFF
--- a/src/main/java/org/eolang/jeo/XmirFiles.java
+++ b/src/main/java/org/eolang/jeo/XmirFiles.java
@@ -40,14 +40,18 @@ final class XmirFiles {
      */
     public Stream<Path> all() {
         final Path path = this.root;
-        try {
-            return Files.walk(path).filter(Files::isRegularFile);
+        final Stream.Builder<Path> builder = Stream.builder();
+        try (Stream<Path> all = Files.walk(path)) {
+            all.filter(Files::isRegularFile)
+                .filter(f -> f.getFileName().toString().endsWith(".xmir"))
+                .forEach(builder::add);
         } catch (final IOException exception) {
             throw new IllegalStateException(
                 String.format("Can't read folder '%s'", path),
                 exception
             );
         }
+        return builder.build();
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/XmirFilesTest.java
+++ b/src/test/java/org/eolang/jeo/XmirFilesTest.java
@@ -53,6 +53,26 @@ final class XmirFilesTest {
     }
 
     @Test
+    void ignoresNonXmlFiles(@TempDir final Path temp) throws IOException {
+        final Path directory = temp.resolve(Paths.get("xmirs"));
+        Files.createDirectories(directory);
+        Files.write(
+            directory.resolve("first.xmir"),
+            new BytecodeObject(new BytecodeClass("org.jeo.First")).xml().toString()
+                .getBytes(StandardCharsets.UTF_8)
+        );
+        Files.write(
+            directory.resolve("second.txt"),
+            "rendom text".getBytes(StandardCharsets.UTF_8)
+        );
+        MatcherAssert.assertThat(
+            "We expect that all files except XMIR files are ignored",
+            new XmirFiles(temp).all().collect(Collectors.toList()),
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
     void retrievesEmptyObjectsIfFolderIsEmpty(@TempDir final Path temp) throws IOException {
         Files.createDirectories(temp.resolve("some-path"));
         MatcherAssert.assertThat(


### PR DESCRIPTION
This PR modifies `XmirFiles` to only process `.xmir` files, ignoring other file types in the directory. Fixes issue with `jeo:assemble` attempting to read non-XMIR files.

Related to #1175