### PR TITLE
fix(#1176): ensure disassembler overwrites existing XMIR files completely

### DIFF
--- a/src/test/java/org/eolang/jeo/representation/DisassemblerTest.java
+++ b/src/test/java/org/eolang/jeo/representation/DisassemblerTest.java
@@ -5,8 +5,12 @@
 package org.eolang.jeo.representation;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
 import java.util.List;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.bytes.UncheckedBytes;
@@ -26,13 +30,21 @@ import org.junit.jupiter.api.io.TempDir;
  */
 final class DisassemblerTest {
 
+    /**
+     * Bytecode class name.
+     */
+    private static final String CLASS_NAME = "MethodByte.class";
+
+    /**
+     * Bytecode of a java class.
+     */
+    private static final byte[] BYTECODE = new UncheckedBytes(
+        new BytesOf(new ResourceOf(DisassemblerTest.CLASS_NAME))
+    ).asBytes();
+
     @Test
     void transpilesSuccessfullyWithoutComments(@TempDir final Path temp) throws IOException {
-        final String name = "MethodByte.class";
-        Files.write(
-            temp.resolve(name),
-            new UncheckedBytes(new BytesOf(new ResourceOf(name))).asBytes()
-        );
+        Files.write(temp.resolve(DisassemblerTest.CLASS_NAME), DisassemblerTest.BYTECODE);
         new Disassembler(
             temp, temp, new DisassembleParams(DisassembleMode.SHORT, false, true, false)
         ).disassemble();
@@ -41,7 +53,10 @@ final class DisassemblerTest {
             .resolve("jeo")
             .resolve("MethodByte.xmir");
         MatcherAssert.assertThat(
-            String.format("Can't find the transpiled file for the class '%s'.", name),
+            String.format(
+                "Can't find the transpiled file for the class '%s'.",
+                DisassemblerTest.CLASS_NAME
+            ),
             Files.exists(disassembled),
             Matchers.is(true)
         );
@@ -65,11 +80,7 @@ final class DisassemblerTest {
 
     @Test
     void transpilesWithComments(@TempDir final Path temp) throws IOException {
-        final String name = "MethodByte.class";
-        Files.write(
-            temp.resolve(name),
-            new UncheckedBytes(new BytesOf(new ResourceOf(name))).asBytes()
-        );
+        Files.write(temp.resolve(DisassemblerTest.CLASS_NAME), DisassemblerTest.BYTECODE);
         new Disassembler(
             temp, temp, new DisassembleParams(DisassembleMode.SHORT, true, true, true)
         ).disassemble();
@@ -83,6 +94,48 @@ final class DisassemblerTest {
             "The XMIR file should contain comments",
             lines.stream().anyMatch(line -> line.contains("<!--")),
             Matchers.is(true)
+        );
+    }
+
+    /**
+     * This test was added to check the 1176 issue.
+     * <p>
+     * You can read more about it right here:
+     * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/1176">link</a>
+     * </p>
+     * <p>
+     * Pay attention!
+     * {@link Files#setLastModifiedTime(Path, FileTime)} is used here in order to avoid
+     * retrieving disassemble results from the cache.
+     * </p>
+     * @param temp Temp directory where we make disassembling.
+     * @throws IOException In case of any writing or reading error.
+     */
+    @Test
+    void overwritesExistingXmir(@TempDir final Path temp) throws IOException {
+        Files.write(temp.resolve(DisassemblerTest.CLASS_NAME), DisassemblerTest.BYTECODE);
+        new Disassembler(temp, temp).disassemble();
+        final Path disassembled = temp.resolve("org")
+            .resolve("eolang")
+            .resolve("jeo")
+            .resolve("MethodByte.xmir");
+        final String appended = "<bottomline>I'm still here</bottomline>";
+        Files.write(
+            disassembled,
+            appended.getBytes(StandardCharsets.UTF_8),
+            StandardOpenOption.APPEND
+        );
+        MatcherAssert.assertThat(
+            "We expect the XMIR file contain appended text",
+            new String(Files.readAllBytes(disassembled), StandardCharsets.UTF_8),
+            Matchers.containsString(appended)
+        );
+        Files.setLastModifiedTime(disassembled, FileTime.from(Instant.EPOCH));
+        new Disassembler(temp, temp).disassemble();
+        MatcherAssert.assertThat(
+            "We expect the appended text to be disappeared after the second disassembling",
+            new String(Files.readAllBytes(disassembled), StandardCharsets.UTF_8),
+            Matchers.not(Matchers.containsString(appended))
         );
     }
 }


### PR DESCRIPTION
Fixes #1176 by ensuring `jeo:disassemble` properly overwrites existing `.xmir` files instead of corrupting them when the new content is shorter than the old one.

Fixes #1176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test code reuse for disassembler functionality.
  * Added a new test to ensure XMIR files are correctly overwritten during disassembly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->