### PR TITLE
feat(#1205): Add include/exclude filters for jeo:disassemble

### DIFF
--- a/src/it/excludes-includes/README.md
+++ b/src/it/excludes-includes/README.md
@@ -1,0 +1,11 @@
+# Excludes and Includes Integration Test
+
+This integration test verifies the functionality of the `excludes` and
+`includes`options in the `jeo-maven-plugin`. It ensures that the plugin
+correctly chooses Java class files (`.class`) based on the specified patterns.
+
+If you need to run only this test, use the following command:
+
+```shell
+mvn clean integration-test -Dinvoker.test=excludes-includes -DskipTests
+```

--- a/src/it/excludes-includes/invoker.properties
+++ b/src/it/excludes-includes/invoker.properties
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+invoker.goals=clean process-classes -e

--- a/src/it/excludes-includes/pom.xml
+++ b/src/it/excludes-includes/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eolang</groupId>
+  <artifactId>jeo-excludes-includes-it</artifactId>
+  <version>@project.version@</version>
+  <packaging>jar</packaging>
+  <description>
+    This integration test verifies the functionality of the 'excludes' and
+    'includes' options in the `jeo-maven-plugin`. It ensures that the plugin
+    correctly chooses Java class files ('.class') based on the specified patterns.
+    If you need to run only this test, use the following command:
+    "mvn clean integration-test -Dinvoker.test=excludes-includes -DskipTests"
+  </description>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <stack-size>256M</stack-size>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <executions>
+          <execution>
+            <phase>
+              process-classes
+            </phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>org.eolang.jeo.ei.Application</mainClass>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>jeo-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <xmirVerification>true</xmirVerification>
+          <omitComments>false</omitComments>
+          <excludes>
+            <exclude>ignored/**/*.class</exclude>
+          </excludes>
+          <includes>
+            <include>**/Included.class</include>
+          </includes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bytecode-to-eo</id>
+            <goals>
+              <goal>disassemble</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>eo-to-bytecode</id>
+            <goals>
+              <goal>assemble</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>eo-maven-plugin</artifactId>
+        <version>0.57.2</version>
+        <executions>
+          <execution>
+            <id>convert-xmir-to-eo</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>xmir-to-phi</goal>
+            </goals>
+            <configuration>
+              <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
+              <phiOutputDir>${project.build.directory}/generated-sources/jeo-eo</phiOutputDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/excludes-includes/src/main/java/org/eolang/jeo/ei/Application.java
+++ b/src/it/excludes-includes/src/main/java/org/eolang/jeo/ei/Application.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.ei;
+
+import org.eolang.jeo.ei.included.Included;
+import org.eolang.jeo.ei.included.NotIncluded;
+import org.eolang.jeo.ei.ignored.Ignored;
+import org.eolang.jeo.ei.ignored.deep.DeeplyIgnored;
+
+/**
+ * Application Entry Point That Uses Different Exception Handlers.
+ * @since 0.1
+ */
+public class Application {
+    public static void main(String[] args) throws Exception {
+        new Included().say();
+        new NotIncluded().say();
+        new Ignored().say();
+        new DeeplyIgnored().say();
+    }
+}

--- a/src/it/excludes-includes/src/main/java/org/eolang/jeo/ei/ignored/Ignored.java
+++ b/src/it/excludes-includes/src/main/java/org/eolang/jeo/ei/ignored/Ignored.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.ei.ignored;
+
+public class Ignored {
+
+    public void say(){
+        System.out.println("ignored class successfully invoked!");
+    }
+}

--- a/src/it/excludes-includes/src/main/java/org/eolang/jeo/ei/ignored/deep/DeeplyIgnored.java
+++ b/src/it/excludes-includes/src/main/java/org/eolang/jeo/ei/ignored/deep/DeeplyIgnored.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.ei.ignored.deep;
+
+public class DeeplyIgnored {
+
+    public void say(){
+        System.out.println("deeply ignored class successfully invoked!");
+    }
+}

--- a/src/it/excludes-includes/src/main/java/org/eolang/jeo/ei/included/Included.java
+++ b/src/it/excludes-includes/src/main/java/org/eolang/jeo/ei/included/Included.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.ei.included;
+
+public class Included {
+
+    public void say(){
+        System.out.println("included class successfully invoked!");
+    }
+}

--- a/src/it/excludes-includes/src/main/java/org/eolang/jeo/ei/included/NotIncluded.java
+++ b/src/it/excludes-includes/src/main/java/org/eolang/jeo/ei/included/NotIncluded.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.ei.included;
+
+public class NotIncluded {
+
+    public void say(){
+        System.out.println("not included class successfully invoked!");
+    }
+}

--- a/src/it/excludes-includes/verify.groovy
+++ b/src/it/excludes-includes/verify.groovy
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+String log = new File(basedir, 'build.log').text;
+assert log.contains("BUILD SUCCESS")
+
+assert log.contains("Total 1 files were disassembled")
+assert log.contains("Included.class disassembled")
+
+assert log.contains("Total 1 files were assembled")
+assert log.contains("Included.xmir assembled")
+
+assert log.contains("included class successfully invoked!")
+assert log.contains("not included class successfully invoked!")
+assert log.contains("ignored class successfully invoked!")
+assert log.contains("deeply ignored class successfully invoked!")
+true

--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -6,6 +6,7 @@ package org.eolang.jeo;
 
 import com.jcabi.log.Logger;
 import java.io.File;
+import java.util.Set;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -13,6 +14,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.cactoos.set.SetOf;
 import org.eolang.jeo.representation.asm.DisassembleMode;
 import org.eolang.jeo.representation.asm.DisassembleParams;
 
@@ -182,6 +184,28 @@ public final class DisassembleMojo extends AbstractMojo {
     )
     private boolean xmirVerification;
 
+    /**
+     * Set of inclusion GLOB filters for finding .class files
+     * in the {@link #sourcesDir} directory.
+     *
+     * @since 0.13.0
+     * @checkstyle MemberNameCheck (15 lines)
+     */
+    @Parameter(property = "jeo.disassemble.includes")
+    @SuppressWarnings("PMD.ImmutableField")
+    private Set<String> includes = new SetOf<>("**/*.class");
+
+    /**
+     * Set of exclusion GLOB filters for finding .class files
+     * in the {@link #sourcesDir} directory.
+     *
+     * @since 0.13.0
+     * @checkstyle MemberNameCheck (7 lines)
+     */
+    @Parameter(property = "jeo.disassemble.excludes")
+    @SuppressWarnings("PMD.ImmutableField")
+    private Set<String> excludes = new SetOf<>();
+
     @Override
     public void execute() throws MojoExecutionException {
         try {
@@ -207,7 +231,7 @@ public final class DisassembleMojo extends AbstractMojo {
                         this.prettyXmir,
                         comments
                     )
-                ).disassemble();
+                ).disassemble(new GlobFilter(this.includes, this.excludes));
                 if (this.xmirVerification) {
                     Logger.info(this, "Verifying all the XMIR files after disassembling");
                     new XmirFiles(this.outputDir.toPath()).verify();

--- a/src/main/java/org/eolang/jeo/Disassembler.java
+++ b/src/main/java/org/eolang/jeo/Disassembler.java
@@ -8,6 +8,7 @@ import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.asm.DisassembleParams;
 
@@ -20,7 +21,7 @@ import org.eolang.jeo.representation.asm.DisassembleParams;
  * disassembly modes for various levels of detail.</p>
  * @since 0.1.0
  */
-public class Disassembler {
+public final class Disassembler {
 
     /**
      * Project compiled classes.
@@ -67,8 +68,10 @@ public class Disassembler {
 
     /**
      * Disassemble all bytecode files.
+     * @param filters Optional filters to apply on class files
      */
-    public void disassemble() {
+    @SafeVarargs
+    public final void disassemble(final Predicate<Path>... filters) {
         final String process = "Disassembling";
         final String disassembled = "disassembled";
         final Stream<Path> stream = new Summary(
@@ -77,7 +80,7 @@ public class Disassembler {
             this.classes,
             this.target,
             new ParallelTranslator(this::disassemble)
-        ).apply(new BytecodeClasses(this.classes).all());
+        ).apply(new BytecodeClasses(this.classes, filters).all());
         stream.forEach(this::log);
         stream.close();
     }

--- a/src/main/java/org/eolang/jeo/GlobFilter.java
+++ b/src/main/java/org/eolang/jeo/GlobFilter.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Filter that matches paths against a set of glob patterns.
+ * <p>
+ *     Excludes patterns take precedence over includes patterns.
+ * </p>
+ * Returns true if the path matches any of the include patterns and does not match any of
+ * the exclude patterns.
+ * @since 0.13.0
+ */
+public final class GlobFilter implements Predicate<Path> {
+
+    /**
+     * Includes glob patterns.
+     */
+    private final Set<String> includes;
+
+    /**
+     * Excludes glob patterns.
+     */
+    private final Set<String> excludes;
+
+    /**
+     * Ctor.
+     *
+     * @param includes Glob patterns to include
+     * @param excludes Glob patterns to exclude
+     */
+    GlobFilter(final Set<String> includes, final Set<String> excludes) {
+        this.includes = includes;
+        this.excludes = excludes;
+    }
+
+    @Override
+    public boolean test(final Path path) {
+        final Set<PathMatcher> whitelist = this.includes.stream()
+            .map(GlobFilter::matcher)
+            .collect(Collectors.toSet());
+        final Set<PathMatcher> blacklist = this.excludes.stream()
+            .map(GlobFilter::matcher)
+            .collect(Collectors.toSet());
+        final boolean included;
+        if (blacklist.stream().anyMatch(m -> m.matches(path))) {
+            included = false;
+        } else {
+            included = whitelist.isEmpty() || whitelist.stream()
+                .anyMatch(matcher -> matcher.matches(path));
+        }
+        return included;
+    }
+
+    /**
+     * Create a PathMatcher for the given glob pattern.
+     * @param pattern Glob pattern to match
+     * @return PathMatcher for the glob pattern
+     */
+    private static PathMatcher matcher(final String pattern) {
+        return FileSystems.getDefault().getPathMatcher(
+            String.format("glob:%s", pattern)
+        );
+    }
+}

--- a/src/main/java/org/eolang/jeo/XmirFiles.java
+++ b/src/main/java/org/eolang/jeo/XmirFiles.java
@@ -41,15 +41,17 @@ final class XmirFiles {
     public Stream<Path> all() {
         final Path path = this.root;
         final Stream.Builder<Path> builder = Stream.builder();
-        try (Stream<Path> all = Files.walk(path)) {
-            all.filter(Files::isRegularFile)
-                .filter(f -> f.getFileName().toString().endsWith(".xmir"))
-                .forEach(builder::add);
-        } catch (final IOException exception) {
-            throw new IllegalStateException(
-                String.format("Can't read folder '%s'", path),
-                exception
-            );
+        if (Files.exists(path)) {
+            try (Stream<Path> all = Files.walk(path)) {
+                all.filter(Files::isRegularFile)
+                    .filter(f -> f.getFileName().toString().endsWith(".xmir"))
+                    .forEach(builder::add);
+            } catch (final IOException exception) {
+                throw new IllegalStateException(
+                    String.format("Can't read folder '%s'", path),
+                    exception
+                );
+            }
         }
         return builder.build();
     }

--- a/src/test/java/org/eolang/jeo/GlobFilterTest.java
+++ b/src/test/java/org/eolang/jeo/GlobFilterTest.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test for {@link GlobFilter}.
+ * @since 0.13.0
+ */
+final class GlobFilterTest {
+
+    /**
+     * Applies the glob filter to a path and checks if it matches the expected result.
+     * @param description Description of the test case
+     * @param includes Set of glob patterns to include
+     * @param excludes Set of glob patterns to exclude
+     * @param path Path to test against the glob patterns
+     * @param expected Expected result of the filter test
+     * @checkstyle ParameterNumberCheck (20 lines)
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("cases")
+    @DisplayName("Test GlobFilter behavior")
+    void appliesGlobFilter(
+        final String description,
+        final Set<String> includes,
+        final Set<String> excludes,
+        final Path path,
+        final boolean expected
+    ) {
+        MatcherAssert.assertThat(
+            "We expect the filter to match the path correctly",
+            new GlobFilter(includes, excludes).test(path),
+            Matchers.is(expected)
+        );
+    }
+
+    /**
+     * Test cases for GlobFilter.
+     * @return Stream of test cases
+     */
+    static Stream<Arguments> cases() {
+        return Stream.of(
+            Arguments.of(
+                "Included by pattern",
+                GlobFilterTest.setOf("**/*.java"),
+                GlobFilterTest.setOf(),
+                Paths.get("src/Included.java"),
+                true
+            ),
+            Arguments.of(
+                "Excluded takes precedence",
+                GlobFilterTest.setOf("**/*.java"),
+                GlobFilterTest.setOf("src/**"),
+                Paths.get("src/Excluded.java"),
+                false
+            ),
+            Arguments.of(
+                "Included, not excluded",
+                GlobFilterTest.setOf("src/**/*.java"),
+                GlobFilterTest.setOf("**/test/**"),
+                Paths.get("src/main/Main.java"),
+                true
+            ),
+            Arguments.of(
+                "Only excluded",
+                GlobFilterTest.setOf(),
+                GlobFilterTest.setOf("**/*.class"),
+                Paths.get("target/classes/Main.class"),
+                false
+            ),
+            Arguments.of(
+                "Not matched by includes",
+                GlobFilterTest.setOf("**/*.java"),
+                GlobFilterTest.setOf(),
+                Paths.get("README.md"),
+                false
+            ),
+            Arguments.of(
+                "No includes: allow all except excluded",
+                GlobFilterTest.setOf(),
+                GlobFilterTest.setOf("**/*.tmp"),
+                Paths.get("build/output.log"),
+                true
+            ),
+            Arguments.of(
+                "No includes and excluded match",
+                GlobFilterTest.setOf(),
+                GlobFilterTest.setOf("**/*.tmp"),
+                Paths.get("build/output.tmp"),
+                false
+            ),
+            Arguments.of(
+                "Empty includes and excludes",
+                GlobFilterTest.setOf(),
+                GlobFilterTest.setOf(),
+                Paths.get("any/path/file.txt"),
+                true
+            )
+        );
+    }
+
+    /**
+     * Set of strings for test cases.
+     * @param values Values to include in the set
+     * @return Set of strings
+     */
+    private static Set<String> setOf(final String... values) {
+        return Stream.of(values).collect(java.util.stream.Collectors.toSet());
+    }
+}

--- a/src/test/java/org/eolang/jeo/XmirFilesTest.java
+++ b/src/test/java/org/eolang/jeo/XmirFilesTest.java
@@ -83,11 +83,11 @@ final class XmirFilesTest {
     }
 
     @Test
-    void throwsExceptionIfFolderDoesNotExist(@TempDir final Path temp) {
-        Assertions.assertThrows(
-            IllegalStateException.class,
-            () -> new XmirFiles(temp.resolve("missing")).all(),
-            "Exception was not thrown when folder does not exist"
+    void returnsNothingIfFolderDoesNotExist(@TempDir final Path temp) {
+        MatcherAssert.assertThat(
+            "Objects were not retrieved, we expected empty list",
+            new XmirFiles(temp.resolve("missing")).all().collect(Collectors.toList()),
+            Matchers.empty()
         );
     }
 


### PR DESCRIPTION
This PR adds `includes` and `excludes` configuration options to the `jeo:disassemble` goal, allowing filtering of `.class` files during disassembly. The implementation includes integration tests verifying the pattern matching behavior.

Related to #1205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying include and exclude patterns for selecting class files during disassembly.
  * Introduced a new filter mechanism for file selection based on glob patterns.
  * Added integration tests and documentation to verify the correct handling of includes and excludes.

* **Bug Fixes**
  * Improved handling of missing directories to prevent errors during file traversal.

* **Tests**
  * Added comprehensive tests for the new glob pattern filter functionality.
  * Updated tests to verify behavior when expected directories do not exist.

* **Documentation**
  * Provided detailed documentation for the new integration test and usage instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->