### PR TITLE
feat(#1222): Add logging for includes/excludes file matching

### DIFF
--- a/src/it/excludes-includes/verify.groovy
+++ b/src/it/excludes-includes/verify.groovy
@@ -15,4 +15,6 @@ assert log.contains("included class successfully invoked!")
 assert log.contains("not included class successfully invoked!")
 assert log.contains("ignored class successfully invoked!")
 assert log.contains("deeply ignored class successfully invoked!")
+
+assert log.contains("using 1 inclusions (**/Included.class) and 1 exclusions (ignored/**/*.class)")
 true

--- a/src/main/java/org/eolang/jeo/Assembler.java
+++ b/src/main/java/org/eolang/jeo/Assembler.java
@@ -50,7 +50,7 @@ public final class Assembler {
         final Stream<Path> all = new Summary(
             assembling,
             assembled,
-            this.input,
+            this.input.toString(),
             this.output,
             new ParallelTranslator(this::assemble)
         ).apply(new XmirFiles(this.input).all());

--- a/src/main/java/org/eolang/jeo/BytecodeClasses.java
+++ b/src/main/java/org/eolang/jeo/BytecodeClasses.java
@@ -8,12 +8,10 @@ import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.objectweb.asm.ClassReader;
@@ -35,7 +33,7 @@ import org.objectweb.asm.util.CheckClassAdapter;
  * for details on how all generated classes are loaded.</p>
  * @since 0.6.0
  */
-final class BytecodeClasses {
+final class BytecodeClasses implements Classes {
 
     /**
      * Input directory where all the generated class files are placed.
@@ -43,35 +41,20 @@ final class BytecodeClasses {
     private final Path input;
 
     /**
-     * Several filters to apply on class files.
-     */
-    private final List<? extends Predicate<Path>> filters;
-
-    /**
-     * Constructor.
-     * @param input Input directory where all the generated class files are placed.
-     * @param filters List of filters to apply on class files
-     */
-    @SafeVarargs
-    BytecodeClasses(final Path input, final Predicate<Path>... filters) {
-        this(input, Arrays.asList(filters));
-    }
-
-    /**
      * Constructor with filters.
      * @param input Input directory where all the generated class files are placed.
-     * @param filters List of filters to apply on class files
      */
-    private BytecodeClasses(final Path input, final List<Predicate<Path>> filters) {
+    BytecodeClasses(final Path input) {
         this.input = input;
-        this.filters = filters;
     }
 
-    /**
-     * All the class files.
-     * @return Stream of paths to class files
-     */
-    Stream<Path> all() {
+    @Override
+    public String toString() {
+        return this.input.toString();
+    }
+
+    @Override
+    public Stream<Path> all() {
         try {
             return this.classes().stream();
         } catch (final IOException exception) {
@@ -115,7 +98,6 @@ final class BytecodeClasses {
             return walk
                 .filter(Files::isRegularFile)
                 .filter(path -> path.toString().endsWith(".class"))
-                .filter(path -> this.filters.stream().allMatch(filter -> filter.test(path)))
                 .collect(Collectors.toList());
         }
     }

--- a/src/main/java/org/eolang/jeo/Classes.java
+++ b/src/main/java/org/eolang/jeo/Classes.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo;
+
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+/**
+ * Representation of all class files.
+ * @since 0.14.0
+ */
+interface Classes {
+
+    /**
+     * All the class files.
+     * @return Stream of paths to class files
+     */
+    Stream<Path> all();
+}

--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -223,7 +223,10 @@ public final class DisassembleMojo extends AbstractMojo {
                     comments
                 );
                 new Disassembler(
-                    this.sourcesDir.toPath(),
+                    new FilteredClasses(
+                        new BytecodeClasses(this.sourcesDir.toPath()),
+                        new GlobFilter(this.includes, this.excludes)
+                    ),
                     this.outputDir.toPath(),
                     new DisassembleParams(
                         DisassembleMode.fromString(this.mode),
@@ -231,7 +234,7 @@ public final class DisassembleMojo extends AbstractMojo {
                         this.prettyXmir,
                         comments
                     )
-                ).disassemble(new GlobFilter(this.includes, this.excludes));
+                ).disassemble();
                 if (this.xmirVerification) {
                     Logger.info(this, "Verifying all the XMIR files after disassembling");
                     new XmirFiles(this.outputDir.toPath()).verify();

--- a/src/main/java/org/eolang/jeo/Disassembler.java
+++ b/src/main/java/org/eolang/jeo/Disassembler.java
@@ -8,7 +8,6 @@ import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.asm.DisassembleParams;
 
@@ -26,7 +25,7 @@ public final class Disassembler {
     /**
      * Project compiled classes.
      */
-    private final Path classes;
+    private final Classes classes;
 
     /**
      * Where to save decompiled classes.
@@ -61,6 +60,14 @@ public final class Disassembler {
         final Path target,
         final DisassembleParams params
     ) {
+        this(new BytecodeClasses(classes), target, params);
+    }
+
+    public Disassembler(
+        final Classes classes,
+        final Path target,
+        final DisassembleParams params
+    ) {
         this.classes = classes;
         this.target = target;
         this.params = params;
@@ -68,19 +75,17 @@ public final class Disassembler {
 
     /**
      * Disassemble all bytecode files.
-     * @param filters Optional filters to apply on class files
      */
-    @SafeVarargs
-    public final void disassemble(final Predicate<Path>... filters) {
+    public void disassemble() {
         final String process = "Disassembling";
         final String disassembled = "disassembled";
         final Stream<Path> stream = new Summary(
             process,
             disassembled,
-            this.classes,
+            this.classes.toString(),
             this.target,
             new ParallelTranslator(this::disassemble)
-        ).apply(new BytecodeClasses(this.classes, filters).all());
+        ).apply(this.classes.all());
         stream.forEach(this::log);
         stream.close();
     }

--- a/src/main/java/org/eolang/jeo/FilteredClasses.java
+++ b/src/main/java/org/eolang/jeo/FilteredClasses.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo;
+
+import com.jcabi.log.Logger;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Filtered classes.
+ * @since 0.14.0
+ */
+final class FilteredClasses implements Classes {
+
+    /**
+     * Original classes.
+     */
+    private final Classes original;
+
+    /**
+     * Glob filter to apply.
+     */
+    private final GlobFilter filter;
+
+    /**
+     * Logger to use for logging messages.
+     */
+    private final Consumer<String> logger;
+
+    /**
+     * Constructor.
+     * @param original Original classes to filter
+     * @param filter Glob filter to apply
+     */
+    FilteredClasses(final Classes original, final GlobFilter filter) {
+        this(original, filter, s -> Logger.info(FilteredClasses.class, s));
+    }
+
+    /**
+     * Constructor with custom logger.
+     * @param original Original classes to filter
+     * @param filter Glob filter to apply
+     * @param logger Logger to use for logging messages
+     */
+    FilteredClasses(
+        final Classes original,
+        final GlobFilter filter,
+        final Consumer<String> logger
+    ) {
+        this.original = original;
+        this.filter = filter;
+        this.logger = logger;
+    }
+
+    @Override
+    public Stream<Path> all() {
+        final List<Path> res = this.original.all().filter(this.filter).collect(Collectors.toList());
+        final int size = res.size();
+        this.logger.accept(
+            String.format("Found %d files in %s using %s", size, this.original, this.filter)
+        );
+        return res.stream();
+    }
+}

--- a/src/main/java/org/eolang/jeo/GlobFilter.java
+++ b/src/main/java/org/eolang/jeo/GlobFilter.java
@@ -44,6 +44,17 @@ public final class GlobFilter implements Predicate<Path> {
     }
 
     @Override
+    public String toString() {
+        return String.format(
+            "%d inclusions (%s) and %d exclusions (%s)",
+            this.includes.size(),
+            String.join(", ", this.includes),
+            this.excludes.size(),
+            String.join(", ", this.excludes)
+        );
+    }
+
+    @Override
     public boolean test(final Path path) {
         final Set<PathMatcher> whitelist = this.includes.stream()
             .map(GlobFilter::matcher)

--- a/src/main/java/org/eolang/jeo/Summary.java
+++ b/src/main/java/org/eolang/jeo/Summary.java
@@ -34,7 +34,7 @@ public final class Summary implements Translator {
     /**
      * From where.
      */
-    private final Path input;
+    private final String input;
 
     /**
      * To where.
@@ -58,7 +58,7 @@ public final class Summary implements Translator {
     Summary(
         final String process,
         final String participle,
-        final Path input,
+        final String input,
         final Path output,
         final Translator original
     ) {

--- a/src/test/java/org/eolang/jeo/BytecodeClassesTest.java
+++ b/src/test/java/org/eolang/jeo/BytecodeClassesTest.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link BytecodeClasses}.
+ * @since 0.14.0
+ */
+final class BytecodeClassesTest {
+
+    @Test
+    void convertsToString() {
+        final Path path = Paths.get("src/test/resources/bytecode-classes");
+        MatcherAssert.assertThat(
+            "BytecodeClasses toString() should return the correct path",
+            new BytecodeClasses(path).toString(),
+            Matchers.equalTo(path.toString())
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/FilteredClassesTest.java
+++ b/src/test/java/org/eolang/jeo/FilteredClassesTest.java
@@ -1,0 +1,128 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link FilteredClasses}.
+ * @since 0.14.0
+ */
+final class FilteredClassesTest {
+
+    @Test
+    void returnsFilteredPathsWhenFilterMatchesSomeWithDefaultLogger() {
+        final Path first = Paths.get("A.class");
+        final Path second = Paths.get("B.class");
+        final List<Path> result = new FilteredClasses(
+            () -> Stream.of(first, second, Paths.get("C.txt")),
+            new GlobFilter(Collections.singleton("*.class"), Collections.emptySet())
+        ).all().collect(java.util.stream.Collectors.toList());
+        MatcherAssert.assertThat(
+            "Should return only paths that match the filter",
+            result,
+            Matchers.allOf(
+                Matchers.iterableWithSize(2),
+                Matchers.hasItem(first),
+                Matchers.hasItem(second)
+            )
+        );
+    }
+
+    @Test
+    void returnsEmptyWhenNoPathsMatchFilter() {
+        MatcherAssert.assertThat(
+            "No paths should match the filter",
+            new FilteredClasses(
+                () -> Stream.of(
+                    Paths.get("A.txt"),
+                    Paths.get("B.txt")
+                ),
+                new GlobFilter(Collections.singleton("*.class"), Collections.emptySet())
+            ).all().collect(java.util.stream.Collectors.toList()),
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    void logsMessageWithCorrectCount() {
+        final List<String> logs = new ArrayList<>(1);
+        final Path root = Paths.get("/dev/null");
+        new FilteredClasses(
+            new Project(
+                root,
+                Stream.of(
+                    Paths.get("FirstAdded.class"),
+                    Paths.get("SecondAdded.class"),
+                    Paths.get("Skipped.txt")
+                )
+            ),
+            new GlobFilter(Collections.emptySet(), Collections.singleton("*.txt")), logs::add
+        ).all();
+        MatcherAssert.assertThat(
+            "Should log the correct number of files found",
+            logs,
+            Matchers.allOf(
+                Matchers.iterableWithSize(1),
+                Matchers.hasItem(
+                    Matchers.containsString(
+                        String.format(
+                            "Found 2 files in %s using 0 inclusions () and 1 exclusions (*.txt)",
+                            root
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    /**
+     * Test project implementation of {@link Classes}.
+     * <p>
+     *     This class is used to simulate a project structure with
+     *     a root path and a stream of paths.
+     * </p>
+     * @since 0.14.0
+     */
+    private static final class Project implements Classes {
+        /**
+         * Project root path.
+         */
+        private final Path root;
+
+        /**
+         * Stream of paths representing project files.
+         */
+        private final Stream<Path> paths;
+
+        /**
+         * Constructor.
+         * @param root Project root path
+         * @param paths Stream of paths representing project files
+         */
+        private Project(final Path root, final Stream<Path> paths) {
+            this.root = root;
+            this.paths = paths;
+        }
+
+        @Override
+        public Stream<Path> all() {
+            return this.paths;
+        }
+
+        @Override
+        public String toString() {
+            return this.root.toString();
+        }
+    }
+}


### PR DESCRIPTION
Adds logging for file filtering operations to show inclusions/exclusions usage. Now displays messages like `Found X files in Y using Z inclusions and W exclusions` when processing class files.

Related to #1222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Filtering of class files is applied earlier and reported; logs show counts and inclusion/exclusion patterns.
  - When post-disassembly verification is disabled, an explicit info message is logged.

- Refactor
  - Class-file discovery unified behind a simpler abstraction, improving logging clarity and processing flow.

- Tests
  - Added tests and verification to cover filtering behavior, logging output, string summaries, and inclusion/exclusion reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->