### PR TITLE
feat(#1225): preserve bytecode line number information during disassemble

### DIFF
--- a/src/it/variable-names/pom.xml
+++ b/src/it/variable-names/pom.xml
@@ -19,6 +19,20 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <stack-size>256M</stack-size>
   </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>9.8</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-util</artifactId>
+      <version>9.8</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>

--- a/src/it/variable-names/src/main/java/org/eolang/jeo/lines/Dummy.java
+++ b/src/it/variable-names/src/main/java/org/eolang/jeo/lines/Dummy.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.lines;
+
+public class Dummy {
+    public int dummy(int z) {
+        int x = 4;
+        int y = 1 * 2;
+        return x * z + y * x * x;
+    }
+}

--- a/src/it/variable-names/src/main/java/org/eolang/jeo/lines/Lines.java
+++ b/src/it/variable-names/src/main/java/org/eolang/jeo/lines/Lines.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.lines;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class Lines {
+
+    public static void checkTransformationPreserveLines() throws IOException {
+        LineCountVisitor visitor = new LineCountVisitor();
+        try (InputStream in = Dummy.class.getResourceAsStream("Dummy.class")) {
+            if (in == null) {
+                throw new IOException("Dummy.class resource not found via Dummy.class loader");
+            }
+            System.out.println(
+                "Using Dummy.class loader to read the class bytes for transformation check."
+            );
+            new ClassReader(in).accept(visitor, 0);
+        }
+        int lines = visitor.total();
+        if (lines <= 0) {
+            throw new RuntimeException(
+                String.format(
+                    "We expect that line numbers are present in bytecode, but got %d instead.", lines
+                )
+            );
+        }
+    }
+
+    private static final class LineCountVisitor extends ClassVisitor {
+
+        /**
+         * Count.
+         */
+        private int count;
+
+        /**
+         * Ctor.
+         */
+        LineCountVisitor() {
+            super(Opcodes.ASM9);
+        }
+
+        @Override
+        public MethodVisitor visitMethod(
+            final int access,
+            final String name,
+            final String descriptor,
+            final String signature,
+            final String[] exceptions
+        ) {
+            return new MethodVisitor(Opcodes.ASM9) {
+                @Override
+                public void visitLineNumber(final int line, final Label start) {
+                    LineCountVisitor.this.count += 1;
+                }
+            };
+        }
+
+        /**
+         * Total found.
+         * @return Lines count
+         */
+        public int total() {
+            return this.count;
+        }
+    }
+}

--- a/src/it/variable-names/src/main/java/org/eolang/jeo/variables/Application.java
+++ b/src/it/variable-names/src/main/java/org/eolang/jeo/variables/Application.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.Set;
 import java.util.HashSet;
+import org.eolang.jeo.lines.Lines;
 
 /**
  *  Application Entry Point.
@@ -36,6 +37,7 @@ public class Application {
                 "Expected parameter 'secondParam' not found. All found methods: " + names);
         }
         someMethod("firstParam", "secondParam");
+        Lines.checkTransformationPreserveLines();
     }
 
     public static void someMethod(final String firstParam, final String secondParam) {

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmInstruction.java
@@ -21,6 +21,7 @@ import org.objectweb.asm.tree.InvokeDynamicInsnNode;
 import org.objectweb.asm.tree.JumpInsnNode;
 import org.objectweb.asm.tree.LabelNode;
 import org.objectweb.asm.tree.LdcInsnNode;
+import org.objectweb.asm.tree.LineNumberNode;
 import org.objectweb.asm.tree.LookupSwitchInsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MultiANewArrayInsnNode;
@@ -52,6 +53,7 @@ final class AsmInstruction {
      * @return Domain instruction.
      * @checkstyle CyclomaticComplexityCheck (100 lines)
      * @checkstyle JavaNCSSCheck (100 lines)
+     * @checkstyle MethodLengthCheck (200 lines)
      */
     @SuppressWarnings({"PMD.NcssCount", "PMD.ExcessiveMethodLength"})
     BytecodeEntry bytecode() {
@@ -192,7 +194,11 @@ final class AsmInstruction {
                 );
                 break;
             case AbstractInsnNode.LINE:
-                result = new BytecodeLine();
+                final LineNumberNode line = LineNumberNode.class.cast(this.node);
+                result = new BytecodeLine(
+                    line.line,
+                    new BytecodeLabel(LabelNode.class.cast(line.start).getLabel().toString())
+                );
                 break;
             default:
                 throw new IllegalStateException(

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLine.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeLine.java
@@ -9,27 +9,47 @@ import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.asm.AsmLabels;
+import org.eolang.jeo.representation.directives.DirectivesLine;
 import org.objectweb.asm.MethodVisitor;
 import org.xembly.Directive;
 
 /**
  * Bytecode line.
  * This class represents the reference to a source line from a bytecode instruction.
- * Since the purpose of this class is rather informative, we just ignore it.
  * @since 0.6
  */
 @EqualsAndHashCode
 @ToString
 public final class BytecodeLine implements BytecodeEntry {
 
+    /**
+     * Line number in the source code.
+     */
+    private final int number;
+
+    /**
+     * Bytecode label that this line refers to.
+     */
+    private final BytecodeLabel label;
+
+    /**
+     * Constructor.
+     * @param number Line number in the source code
+     * @param label Bytecode label that this line refers to
+     */
+    public BytecodeLine(final int number, final BytecodeLabel label) {
+        this.number = number;
+        this.label = label;
+    }
+
     @Override
     public void writeTo(final MethodVisitor visitor, final AsmLabels labels) {
-        // nothing to write
+        visitor.visitLineNumber(this.number, labels.label(this.label));
     }
 
     @Override
     public Iterable<Directive> directives() {
-        return Collections.emptyList();
+        return new DirectivesLine(this.number, this.label.uid());
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesLine.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesLine.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.Iterator;
+import org.xembly.Directive;
+
+/**
+ * Line number directives.
+ * @since 0.14.0
+ */
+public final class DirectivesLine implements Iterable<Directive> {
+
+    /**
+     * Line number in the source code.
+     */
+    private final int number;
+
+    /**
+     * Simple label identifier.
+     */
+    private final String identifier;
+
+    /**
+     * Constructor.
+     * @param number Line number in the source code
+     * @param identifier Identifier for the line
+     */
+    public DirectivesLine(final int number, final String identifier) {
+        this.number = number;
+        this.identifier = identifier;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        return new DirectivesJeoObject(
+            "line-number",
+            new RandName("ln").toString(),
+            new DirectivesValue("number", this.number),
+            new DirectivesLabel(this.identifier)
+        ).iterator();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlLine.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlLine.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import org.eolang.jeo.representation.bytecode.BytecodeLine;
+
+/**
+ * This class represents a line in the XML representation of bytecode.
+ * <p>
+ *     Mirrors {@link org.eolang.jeo.representation.directives.DirectivesLine}.
+ * </p>
+ * @since 0.14.0
+ */
+final class XmlLine implements XmlBytecodeEntry {
+
+    /**
+     * XML representation of a line.
+     */
+    private final XmlJeoObject object;
+
+    /**
+     * XML representation of a line.
+     * @param node XML node representing the line.
+     */
+    XmlLine(final XmlNode node) {
+        this(new XmlJeoObject(node));
+    }
+
+    /**
+     * XML representation of a line.
+     * @param object XML object representing the line.
+     */
+    XmlLine(final XmlJeoObject object) {
+        this.object = object;
+    }
+
+    @Override
+    public BytecodeLine bytecode() {
+        return new BytecodeLine(
+            (int) new XmlValue(
+                this.object.child(0)
+                    .orElseThrow(
+                        () -> new IllegalStateException(
+                            "Line node must have the first child with a number"
+                        )
+                    )
+            ).object(),
+            this.object.child(1)
+                .map(XmlLabel::new)
+                .orElseThrow(
+                    () -> new IllegalStateException(
+                        "Line node must have a label as the second child"
+                    )
+                ).bytecode()
+        );
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -235,6 +235,8 @@ public final class XmlMethod {
             result = new XmlLabel(node);
         } else if (base.isPresent() && new JeoFqn("frame").fqn().equals(base.get())) {
             result = new XmlFrame(node);
+        } else if (base.isPresent() && new JeoFqn("line-number").fqn().equals(base.get())) {
+            result = new XmlLine(node);
         } else {
             result = new XmlInstruction(node);
         }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesLineTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesLineTest.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link DirectivesLine}.
+ * @since 0.14.0
+ */
+final class DirectivesLineTest {
+
+    @Test
+    void generatesValidXmirForLineNumber() throws ImpossibleModificationException {
+        final DirectivesLine directives = new DirectivesLine(42, "test");
+        final String root = "./o[contains(@name,'ln')]";
+        MatcherAssert.assertThat(
+            "We expect to generate a valid XMIR for the line number directive",
+            new Xembler(directives).xml(),
+            XhtmlMatchers.hasXPaths(
+                root,
+                new JeoBaseXpath(root, "line-number").toXpath()
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlLineTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlLineTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import org.eolang.jeo.representation.bytecode.BytecodeLabel;
+import org.eolang.jeo.representation.bytecode.BytecodeLine;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link XmlLine}.
+ * @since 0.14.0
+ */
+final class XmlLineTest {
+
+    @Test
+    void parsesXmlLine() throws ImpossibleModificationException {
+        final BytecodeLine expected = new BytecodeLine(10, new BytecodeLabel("test"));
+        MatcherAssert.assertThat(
+            "We expect to parse the XML line correctly",
+            new XmlLine(
+                new XmlJeoObject(
+                    new JcabiXmlNode(
+                        new Xembler(expected.directives()).xml()
+                    )
+                )
+            ).bytecode(),
+            Matchers.equalTo(expected)
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
@@ -6,6 +6,8 @@ package org.eolang.jeo.representation.xmir;
 
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
+import org.eolang.jeo.representation.bytecode.BytecodeLabel;
+import org.eolang.jeo.representation.bytecode.BytecodeLine;
 import org.eolang.jeo.representation.bytecode.BytecodeMaxs;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodProperties;
@@ -131,6 +133,23 @@ final class XmlMethodTest {
                         new BytecodeAnnotation(descriptor, visible)
                     )
                 )
+            )
+        );
+    }
+
+    @Test
+    void parsesLineNumbers() throws ImpossibleModificationException {
+        final BytecodeLine expected = new BytecodeLine(42, new BytecodeLabel("label"));
+        MatcherAssert.assertThat(
+            "We expect that line numbers will be parsed correctly",
+            new XmlMethod(
+                new NativeXmlNode(
+                    new Xembler(new BytecodeMethod().entry(expected).directives(1)).xml()
+                )
+            ).bytecode().instructions(),
+            Matchers.allOf(
+                Matchers.iterableWithSize(1),
+                Matchers.hasItem(expected)
             )
         );
     }


### PR DESCRIPTION
This PR adds support for preserving bytecode line metadata during disassembly and assembly processes, ensuring that the line count information is maintained.

Related to #1225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for line-number metadata in bytecode and XML representations, enabling accurate round-trips and improving traceability.
  - Ensures line numbers are preserved after transformations.

- Tests
  - Added unit tests validating line-number directives, XML parsing, and method-level parsing to ensure correct round-trip behavior.

- Chores
  - Updated build configuration with bytecode tooling dependencies to enable line-number processing in integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->