### PR TITLE
fix(#1227): improve string representation in GlobFilter for clarity

### DIFF
--- a/src/main/java/org/eolang/jeo/GlobFilter.java
+++ b/src/main/java/org/eolang/jeo/GlobFilter.java
@@ -45,13 +45,31 @@ public final class GlobFilter implements Predicate<Path> {
 
     @Override
     public String toString() {
-        return String.format(
-            "%d inclusions (%s) and %d exclusions (%s)",
-            this.includes.size(),
-            String.join(", ", this.includes),
-            this.excludes.size(),
-            String.join(", ", this.excludes)
-        );
+        final String inclusions;
+        if (this.includes.isEmpty()) {
+            inclusions = "no inclusions";
+        } else {
+            inclusions = this.includes.stream().collect(
+                Collectors.joining(
+                    ", ",
+                    String.format("%d inclusions (", this.includes.size()),
+                    ")"
+                )
+            );
+        }
+        final String exclusions;
+        if (this.excludes.isEmpty()) {
+            exclusions = "no exclusions";
+        } else {
+            exclusions = this.excludes.stream().collect(
+                Collectors.joining(
+                    ", ",
+                    String.format("%d exclusions (", this.excludes.size()),
+                    ")"
+                )
+            );
+        }
+        return String.format("%s and %s", inclusions, exclusions);
     }
 
     @Override

--- a/src/test/java/org/eolang/jeo/FilteredClassesTest.java
+++ b/src/test/java/org/eolang/jeo/FilteredClassesTest.java
@@ -77,7 +77,7 @@ final class FilteredClassesTest {
                 Matchers.hasItem(
                     Matchers.containsString(
                         String.format(
-                            "Found 2 files in %s using 0 inclusions () and 1 exclusions (*.txt)",
+                            "Found 2 files in %s using no inclusions and 1 exclusions (*.txt)",
                             root
                         )
                     )

--- a/src/test/java/org/eolang/jeo/GlobFilterTest.java
+++ b/src/test/java/org/eolang/jeo/GlobFilterTest.java
@@ -48,6 +48,27 @@ final class GlobFilterTest {
     }
 
     /**
+     * Tests the string representation of the GlobFilter.
+     * @param description Description of the test case
+     * @param filter The GlobFilter to test
+     * @param expected Expected string representation of the filter
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("stringCases")
+    @DisplayName("Test GlobFilter string representation")
+    void convertsGlobFilterToString(
+        final String description,
+        final GlobFilter filter,
+        final String expected
+    ) {
+        MatcherAssert.assertThat(
+            "We expect the filter's string representation to match",
+            filter.toString(),
+            Matchers.is(expected)
+        );
+    }
+
+    /**
      * Test cases for GlobFilter.
      * @return Stream of test cases
      */
@@ -108,6 +129,38 @@ final class GlobFilterTest {
                 GlobFilterTest.setOf(),
                 Paths.get("any/path/file.txt"),
                 true
+            )
+        );
+    }
+
+    /**
+     * Test cases for {@link GlobFilter#toString()}.
+     * @return Stream of test cases
+     */
+    static Stream<Arguments> stringCases() {
+        return Stream.of(
+            Arguments.of(
+                "No inclusions and no exclusions",
+                new GlobFilter(GlobFilterTest.setOf(), GlobFilterTest.setOf()),
+                "no inclusions and no exclusions"
+            ),
+            Arguments.of(
+                "With inclusions only",
+                new GlobFilter(GlobFilterTest.setOf("**/*.java"), GlobFilterTest.setOf()),
+                "1 inclusions (**/*.java) and no exclusions"
+            ),
+            Arguments.of(
+                "With exclusions only",
+                new GlobFilter(GlobFilterTest.setOf(), GlobFilterTest.setOf("**/*.tmp")),
+                "no inclusions and 1 exclusions (**/*.tmp)"
+            ),
+            Arguments.of(
+                "With both inclusions and exclusions",
+                new GlobFilter(
+                    GlobFilterTest.setOf("src/**/*.java"),
+                    GlobFilterTest.setOf("**/test/**")
+                ),
+                "1 inclusions (src/**/*.java) and 1 exclusions (**/test/**)"
             )
         );
     }


### PR DESCRIPTION
This PR improves the string representation of `GlobFilter` to enhance logging clarity, addressing issue #1222.

Related to #1227