### PR TITLE
feat(#1233): add informative error handling to Assembler and Disassembler

### DIFF
--- a/src/main/java/org/eolang/jeo/Assembler.java
+++ b/src/main/java/org/eolang/jeo/Assembler.java
@@ -67,7 +67,7 @@ public final class Assembler {
         final Transformation trans = new Logging(
             "Assembling",
             "assembled",
-            new Caching(new Assembling(this.output, path))
+            new Caching(new Informative(new Assembling(this.output, path)))
         );
         trans.transform();
         return trans.target();

--- a/src/main/java/org/eolang/jeo/Disassembler.java
+++ b/src/main/java/org/eolang/jeo/Disassembler.java
@@ -99,9 +99,7 @@ public final class Disassembler {
         final Transformation trans = new Logging(
             "Disassembling",
             "disassembled",
-            new Caching(
-                new Disassembling(this.target, path, this.params)
-            )
+            new Caching(new Informative(new Disassembling(this.target, path, this.params)))
         );
         trans.transform();
         return trans.target();

--- a/src/main/java/org/eolang/jeo/Informative.java
+++ b/src/main/java/org/eolang/jeo/Informative.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo;
+
+import java.nio.file.Path;
+
+/**
+ * Convenient transformation wrapper that provides informative error messages in case of failure.
+ * @since 0.14.0
+ * @checkstyle IllegalCatchCheck (100 lines)
+ */
+final class Informative implements Transformation {
+
+    /**
+     * Original transformation to delegate to.
+     */
+    private final Transformation original;
+
+    /**
+     * Constructor.
+     * @param original Delegate transformation.
+     */
+    Informative(final Transformation original) {
+        this.original = original;
+    }
+
+    @Override
+    public Path source() {
+        return this.original.source();
+    }
+
+    @Override
+    public Path target() {
+        return this.original.target();
+    }
+
+    @Override
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    public byte[] transform() {
+        try {
+            return this.original.transform();
+        } catch (final RuntimeException exception) {
+            throw new IllegalStateException(
+                String.format(
+                    "Failed to transform %s to %s: %s",
+                    this.original.source(),
+                    this.original.target(),
+                    exception.getMessage()
+                ),
+                exception
+            );
+        }
+    }
+}

--- a/src/test/java/org/eolang/jeo/InformativeTest.java
+++ b/src/test/java/org/eolang/jeo/InformativeTest.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Informative}.
+ * @since 0.14.0
+ */
+final class InformativeTest {
+
+    @Test
+    void transformsSuccessfullyWhenOriginalTransformationSucceeds() {
+        final byte[] expected = "transformed".getBytes();
+        final Transformation original = new Transformation() {
+            @Override
+            public Path source() {
+                return Paths.get("source.txt");
+            }
+
+            @Override
+            public Path target() {
+                return Paths.get("target.txt");
+            }
+
+            @Override
+            public byte[] transform() {
+                return expected;
+            }
+        };
+        MatcherAssert.assertThat(
+            "We expect the transformation to delegate successfully",
+            new Informative(original).transform(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    @SuppressWarnings("PMD.AvoidThrowingNullPointerException")
+    void throwsInformativeExceptionWhenOriginalTransformationFails() {
+        final Transformation original = new Transformation() {
+            @Override
+            public Path source() {
+                return Paths.get("source.txt");
+            }
+
+            @Override
+            public Path target() {
+                return Paths.get("target.txt");
+            }
+
+            @Override
+            public byte[] transform() {
+                throw new NullPointerException("Original failure");
+            }
+        };
+        MatcherAssert.assertThat(
+            "Exception message should contain informative details",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                new Informative(original)::transform
+            ).getMessage(),
+            Matchers.containsString(
+                "Failed to transform source.txt to target.txt: Original failure"
+            )
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces the `Informative` transformation wrapper to enhance error handling in `Assembler` and `Disassembler`, providing clearer error messages.

Related to #1233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved error messages during assembly and disassembly, providing clear context about the source and target when failures occur.

- Tests
  - Added tests to verify successful transformation behavior.
  - Added tests to ensure failures produce informative exceptions with detailed context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->