### PR TITLE
fix(#1235): add toString() method to FilteredClasses for better logging

### DIFF
--- a/src/it/excludes-includes/verify.groovy
+++ b/src/it/excludes-includes/verify.groovy
@@ -2,6 +2,8 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
  * SPDX-License-Identifier: MIT
  */
+import java.nio.file.Paths
+
 String log = new File(basedir, 'build.log').text;
 assert log.contains("BUILD SUCCESS")
 
@@ -17,4 +19,8 @@ assert log.contains("ignored class successfully invoked!")
 assert log.contains("deeply ignored class successfully invoked!")
 
 assert log.contains("using 1 inclusions (**/Included.class) and 1 exclusions (ignored/**/*.class)")
+
+from = Paths.get("target").resolve("classes").toString()
+to = Paths.get("target").resolve("generated-sources").resolve("jeo-xmir").toString()
+assert log.contains("Disassembling files from ${from} to ${to}")
 true

--- a/src/main/java/org/eolang/jeo/FilteredClasses.java
+++ b/src/main/java/org/eolang/jeo/FilteredClasses.java
@@ -66,4 +66,9 @@ final class FilteredClasses implements Classes {
         );
         return res.stream();
     }
+
+    @Override
+    public String toString() {
+        return this.original.toString();
+    }
 }


### PR DESCRIPTION
This PR fixes the logging issue in `disassemble` by adding a `toString()` method to `FilteredClasses`.

Related to #1235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved string representation for filtered classes to provide clearer, more informative logging and diagnostics.

* **Tests**
  * Enhanced build verification by asserting the log includes disassembly source and destination paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->