### PR TITLE
feat(#1236): make class signature a mandatory attribute in directives

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/NamedDescriptor.java
+++ b/src/main/java/org/eolang/jeo/representation/NamedDescriptor.java
@@ -13,7 +13,7 @@ package org.eolang.jeo.representation;
  * unique identifier.</p>
  * @since 0.5.0
  */
-public final class Signature {
+public final class NamedDescriptor {
 
     /**
      * Human-readable method name in source code.
@@ -29,8 +29,8 @@ public final class Signature {
      * Constructor.
      * @param encoded The encoded method name and descriptor
      */
-    public Signature(final String encoded) {
-        this(Signature.prefix(encoded), Signature.suffix(encoded));
+    public NamedDescriptor(final String encoded) {
+        this(NamedDescriptor.prefix(encoded), NamedDescriptor.suffix(encoded));
     }
 
     /**
@@ -38,7 +38,7 @@ public final class Signature {
      * @param name The method name
      * @param descriptor The method descriptor
      */
-    public Signature(final String name, final String descriptor) {
+    public NamedDescriptor(final String name, final String descriptor) {
         this.original = name;
         this.descr = descriptor;
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.eolang.jeo.representation.Signature;
+import org.eolang.jeo.representation.NamedDescriptor;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -87,7 +87,7 @@ public final class DirectivesAnnotation implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "annotation",
-            new Signature(
+            new NamedDescriptor(
                 String.format("annotation-%d", new Random().nextInt(Integer.MAX_VALUE)),
                 this.descriptor
             ).encoded(),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
@@ -109,10 +109,8 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         final Directives directives = new Directives()
             .append(new DirectivesValue("version", this.version))
-            .append(new DirectivesValue("access", this.access));
-        if (this.signature != null) {
-            directives.append(new DirectivesValue("signature", this.signature));
-        }
+            .append(new DirectivesValue("access", this.access))
+            .append(new DirectivesValue("signature", this.signature));
         if (this.supername != null) {
             directives.append(new DirectivesValue("supername", this.supername));
         }

--- a/src/test/java/org/eolang/jeo/representation/NamedDescriptorTest.java
+++ b/src/test/java/org/eolang/jeo/representation/NamedDescriptorTest.java
@@ -12,17 +12,17 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /**
- * Test for {@link Signature}.
+ * Test for {@link NamedDescriptor}.
  * @since 0.5
  */
-final class SignatureTest {
+final class NamedDescriptorTest {
 
     @ParameterizedTest(name = "Encodes \"{0}\" name with \"{1}\" descriptor, should be \"{2}\"")
     @MethodSource("namesDescriptorsAndEncoded")
     void encodesNamesWithDescriptors(final String name, final String descr, final String encoded) {
         MatcherAssert.assertThat(
             "Encoded method name and descriptor should be correct",
-            new Signature(name, descr).encoded(),
+            new NamedDescriptor(name, descr).encoded(),
             Matchers.equalTo(encoded)
         );
     }
@@ -32,7 +32,7 @@ final class SignatureTest {
     void decodesNames(final String name, final String descr, final String encoded) {
         MatcherAssert.assertThat(
             "Decoded method name should be correct",
-            new Signature(encoded).name(),
+            new NamedDescriptor(encoded).name(),
             Matchers.equalTo(name)
         );
     }
@@ -42,7 +42,7 @@ final class SignatureTest {
     void decodesDescriptors(final String name, final String descr, final String encoded) {
         MatcherAssert.assertThat(
             "Decoded method descriptor should be correct",
-            new Signature(encoded).descriptor(),
+            new NamedDescriptor(encoded).descriptor(),
             Matchers.equalTo(descr)
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassPropertiesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassPropertiesTest.java
@@ -43,4 +43,26 @@ final class DirectivesClassPropertiesTest {
             )
         );
     }
+
+    @Test
+    void createsDirectivesWithMandatorySignature() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "Can't create proper xml with mandatory signature",
+            new Xembler(
+                new Directives()
+                    .add("o")
+                    .append(
+                        new DirectivesClassProperties(
+                            1,
+                            null,
+                            "java/lang/Object",
+                            "org/eolang/SomeInterface"
+                        )
+                    ).up()
+            ).xml(),
+            XhtmlMatchers.hasXPaths(
+                "//o[contains(@name,'signature')]"
+            )
+        );
+    }
 }


### PR DESCRIPTION
This PR makes the `signature` attribute mandatory for classes in the `DirectivesClassProperties` implementation, ensuring consistent attribute ordering.

Related to #1236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Class metadata now always includes a signature attribute for consistent output, even when not explicitly provided.
  - Improved handling of implemented interfaces in emitted metadata.

- Refactor
  - Renamed the internal descriptor abstraction with no functional impact.

- Tests
  - Added coverage to verify mandatory signature emission and updated descriptor-related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->