### PR TITLE
feat(#1239): add support for Java 23 in jeo-maven-plugin disassemble/assemble

### DIFF
--- a/.github/workflows/maven.test.yml
+++ b/.github/workflows/maven.test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-24.04, macos-15, windows-2022 ]
-        java: [ 11, 21 ]
+        java: [ 11, 21, 23 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5

--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,15 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>1.18.38</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
         <executions>
           <execution>
             <id>default-compile</id>

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlockTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeTryCatchBlockTest.java
@@ -40,4 +40,22 @@ final class BytecodeTryCatchBlockTest {
             )
         );
     }
+
+    @Test
+    void comparesEquality() {
+        final String start = UUID.randomUUID().toString();
+        final String end = UUID.randomUUID().toString();
+        final String handler = UUID.randomUUID().toString();
+        MatcherAssert.assertThat(
+            "We expected two try-catch blocks with the same parameters to be equal.",
+            new BytecodeTryCatchBlock(
+                start, end, handler, "java/lang/Exception"
+            ),
+            Matchers.equalTo(
+                new BytecodeTryCatchBlock(
+                    start, end, handler, "java/lang/Exception"
+                )
+            )
+        );
+    }
 }


### PR DESCRIPTION
This PR adds support for `Java 23` in the `jeo-maven-plugin`, ensuring compatibility for disassemble/assemble operations.

Closes #1239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded CI Java version matrix to include Java 23, increasing confidence across supported JDKs.
  * Enabled annotation processing in the build to streamline compilation.

* **Tests**
  * Added unit test to verify equality logic for bytecode-related structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->