### PR TITLE
fix(#1246): convert null signature to empty string in XML output

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
@@ -5,6 +5,7 @@
 package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
+import java.util.Optional;
 import org.eolang.jeo.representation.DefaultVersion;
 import org.xembly.Directive;
 import org.xembly.Directives;
@@ -110,7 +111,9 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
         final Directives directives = new Directives()
             .append(new DirectivesValue("version", this.version))
             .append(new DirectivesValue("access", this.access))
-            .append(new DirectivesValue("signature", this.signature));
+            .append(
+                new DirectivesValue("signature", Optional.ofNullable(this.signature).orElse(""))
+            );
         if (this.supername != null) {
             directives.append(new DirectivesValue("supername", this.supername));
         }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassPropertiesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassPropertiesTest.java
@@ -65,4 +65,31 @@ final class DirectivesClassPropertiesTest {
             )
         );
     }
+
+    /**
+     * This test was added to ensure that when a null signature is passed,
+     * it is converted to an empty string in the XML output.
+     * See more details in
+     * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/1246">#1246</a>
+     * @throws ImpossibleModificationException in case of XML modification failure.
+     */
+    @Test
+    void convertsNullSignatureToEmptyString() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "Signature should be empty string when null is passed",
+            new Xembler(
+                new Directives().add("o").append(
+                    new DirectivesClassProperties(
+                        1,
+                        null,
+                        "java/lang/Object",
+                        "org/eolang/SomeInterface"
+                    )
+                ).up()
+            ).xml(),
+            XhtmlMatchers.hasXPath(
+                "//o[@name='signature']/o[contains(@base,'bytes')]/o[text()='--']"
+            )
+        );
+    }
 }


### PR DESCRIPTION
This PR ensures that when a `null` signature is passed to `DirectivesClassProperties`, it is converted to an empty string in the XML output, addressing issue #1246.

Related to #1246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented null values for class signature in generated output by defaulting missing signatures to an empty string, improving stability and consistency.

* **Tests**
  * Added a unit test to verify that a missing (null) class signature is represented as an empty string in the output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->