### PR TITLE
fix(#1251): make local-variable-table mandatory in methods

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
@@ -57,6 +57,6 @@ public final class DirectivesAttributes implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        return new DirectivesOptionalSeq(this.name, this.attributes).iterator();
+        return new DirectivesSeq(this.name, this.attributes).iterator();
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -245,6 +245,27 @@ final class BytecodeMethodTest {
         );
     }
 
+    /**
+     * This test was added to mitigate the following issue:
+     * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/1251">issue #1251</a>.
+     * @throws ImpossibleModificationException if modification is impossible, programmer mistake.
+     */
+    @Test
+    void addsLocalVariableTableEvenIfItIsEmpty() throws ImpossibleModificationException {
+        final String name = "emptyLocalVariableTable";
+        final DirectivesMethod directives = new BytecodeMethod(name).directives();
+        MatcherAssert.assertThat(
+            "We expect that the local variable table will be added even if it is empty",
+            new Xembler(directives).xml(),
+            XhtmlMatchers.hasXPaths(
+                String.format(
+                    "./o[contains(@name,'%s')]/o[@name='local-variable-table']",
+                    name
+                )
+            )
+        );
+    }
+
     @ParameterizedTest(name = "Computing maxs for method {1}, expected  {2}")
     @MethodSource("implementedMethods")
     void computesMaxsCorrectlyForImplementedMethods(


### PR DESCRIPTION
This PR ensures that the `local-variable-table` is included as a mandatory field for class methods, addressing issue #1251.

Related to #1251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Ensures a local variable table is included in generated output even when empty, improving consistency and tooling compatibility.
- Bug Fixes
  - Improved stability and predictability in attribute handling during directive processing, reducing edge-case discrepancies.
- Tests
  - Added tests to verify emission of an empty local variable table and to strengthen coverage around method metadata generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->