### PR TITLE
ci(#1253): use stable version of `jmh-benchmark-action` instead of `@main`

### DIFF
--- a/.github/workflows/jmh-benchmark-action.yml
+++ b/.github/workflows/jmh-benchmark-action.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Run JMH Benchmark Action
-        uses: volodya-lombrozo/jmh-benchmark-action@main
+        uses: volodya-lombrozo/jmh-benchmark-action@v1.0.3
         with:
           java-version: "11"
           base-ref: "master"


### PR DESCRIPTION
This PR updates the `jmh-benchmark-action` to use the stable version `@v1.0.3` instead of `@main`.

Closes #1253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the JMH benchmark workflow to a specific action version, improving determinism, reproducibility, and stability of CI benchmark runs. No changes to benchmark configuration or behavior, but users can expect more consistent performance reports in PRs and main branch checks thanks to fixed action versioning across builds and clearer auditability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->