### PR TITLE
fix(#1258): convert null signature to empty string in local variable directives

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttribute.java
@@ -5,9 +5,9 @@
 package org.eolang.jeo.representation.bytecode;
 
 import org.eolang.jeo.representation.asm.AsmLabels;
-import org.eolang.jeo.representation.directives.DirectivesAttribute;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
+import org.xembly.Directive;
 
 /**
  * Bytecode attribute.
@@ -32,6 +32,6 @@ public interface BytecodeAttribute {
      * Converts to directives.
      * @return Directives.
      */
-    DirectivesAttribute directives();
+    Iterable<Directive> directives();
 
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/LocalVariable.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/LocalVariable.java
@@ -7,11 +7,11 @@ package org.eolang.jeo.representation.bytecode;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.asm.AsmLabels;
-import org.eolang.jeo.representation.directives.DirectivesAttribute;
-import org.eolang.jeo.representation.directives.DirectivesValue;
+import org.eolang.jeo.representation.directives.DirectivesLocalVariables;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.tree.LocalVariableNode;
+import org.xembly.Directive;
 
 /**
  * Local variable attribute.
@@ -116,13 +116,12 @@ public final class LocalVariable implements BytecodeAttribute {
     }
 
     @Override
-    public DirectivesAttribute directives() {
-        return new DirectivesAttribute(
-            "local-variable",
-            new DirectivesValue("index", this.index),
-            new DirectivesValue("name", this.name),
-            new DirectivesValue("descr", this.descriptor),
-            new DirectivesValue("signature", this.signature),
+    public Iterable<Directive> directives() {
+        return new DirectivesLocalVariables(
+            this.index,
+            this.name,
+            this.descriptor,
+            this.signature,
             this.start.directives(),
             this.end.directives()
         );

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAttributes.java
@@ -24,9 +24,9 @@ public final class DirectivesAttributes implements Iterable<Directive> {
     /**
      * Attributes.
      */
-    private final List<DirectivesAttribute> attributes;
+    private final List<Iterable<Directive>> attributes;
 
-    public DirectivesAttributes(final String name, final List<DirectivesAttribute> attributes) {
+    public DirectivesAttributes(final String name, final List<Iterable<Directive>> attributes) {
         this.name = name;
         this.attributes = attributes;
     }
@@ -43,7 +43,7 @@ public final class DirectivesAttributes implements Iterable<Directive> {
      * @param attributes Attributes.
      */
     @SafeVarargs
-    DirectivesAttributes(final DirectivesAttribute... attributes) {
+    DirectivesAttributes(final Iterable<Directive>... attributes) {
         this(Arrays.asList(attributes));
     }
 
@@ -51,7 +51,7 @@ public final class DirectivesAttributes implements Iterable<Directive> {
      * Constructor.
      * @param attributes Separate attributes.
      */
-    private DirectivesAttributes(final List<DirectivesAttribute> attributes) {
+    private DirectivesAttributes(final List<Iterable<Directive>> attributes) {
         this("attributes", attributes);
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesLocalVariables.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesLocalVariables.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.Iterator;
+import java.util.Optional;
+import org.xembly.Directive;
+
+/**
+ * Directives for local variables in a method.
+ * @since 0.14.0
+ */
+public final class DirectivesLocalVariables implements Iterable<Directive> {
+
+    /**
+     * Index of the local variable in the local variable array.
+     */
+    private final int index;
+
+    /**
+     * Name of the local variable.
+     */
+    private final String name;
+
+    /**
+     * Descriptor of the local variable.
+     */
+    private final String descriptor;
+
+    /**
+     * Signature of the local variable.
+     */
+    private final String signature;
+
+    /**
+     * Start label.
+     */
+    private final Iterable<Directive> start;
+
+    /**
+     * Start label.
+     */
+    private final Iterable<Directive> end;
+
+    /**
+     * Constructor.
+     * @param index Index of the local variable in the local variable array.
+     * @param name Name of the local variable.
+     * @param descriptor Descriptor of the local variable.
+     * @param signature Signature of the local variable.
+     * @param start Start directives for the local variable, e.g. labels.
+     * @param end End directives for the local variable, e.g. labels.
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    public DirectivesLocalVariables(
+        final int index,
+        final String name,
+        final String descriptor,
+        final String signature,
+        final Iterable<Directive> start,
+        final Iterable<Directive> end
+    ) {
+        this.index = index;
+        this.name = name;
+        this.descriptor = descriptor;
+        this.signature = signature;
+        this.start = start;
+        this.end = end;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        return new DirectivesAttribute(
+            "local-variable",
+            new DirectivesValue("index", this.index),
+            new DirectivesValue("name", this.name),
+            new DirectivesValue("descr", this.descriptor),
+            new DirectivesValue("signature",  Optional.ofNullable(this.signature).orElse("")),
+            this.start,
+            this.end
+        ).iterator();
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesLocalVariablesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesLocalVariablesTest.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.Directives;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link DirectivesLocalVariables}.
+ * @since 0.14.0
+ */
+final class DirectivesLocalVariablesTest {
+
+    @Test
+    void convertsNullableSignatureToEmptyString() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We should convert null signature to empty string",
+            new Xembler(
+                new DirectivesLocalVariables(
+                    0,
+                    "name",
+                    "descriptor",
+                    null,
+                    new Directives(),
+                    new Directives()
+                )
+            ).xml(),
+            XhtmlMatchers.hasXPath(
+                "//o[contains(@base, 'string') and contains(@name, 'signature')]/o/o[text()='--']"
+            )
+        );
+    }
+
+}


### PR DESCRIPTION
This PR refines the `signature` representation in the `local-variable-table`, ensuring it displays as an empty string instead of a complex structure.

Related to #1258