### PR TITLE
feat(#1263): add method modifiers field to XMIR output for clarity

### DIFF
--- a/src/it/custom-transformations/pom.xml
+++ b/src/it/custom-transformations/pom.xml
@@ -28,6 +28,7 @@
         <artifactId>jeo-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>
+          <modifiers>true</modifiers>
           <xmirVerification>true</xmirVerification>
         </configuration>
         <executions>

--- a/src/it/custom-transformations/verify.groovy
+++ b/src/it/custom-transformations/verify.groovy
@@ -17,4 +17,6 @@ assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/Appli
 //Check that class file was changed
 assert log.contains("Application.class disassembled to")
 assert log.contains("Application.xmir assembled to")
+//Check that the output contains method modifiers: https://github.com/objectionary/jeo-maven-plugin/issues/1263
+assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/Application.xmir').text.contains("modifiers")
 true

--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -17,6 +17,7 @@ import org.apache.maven.project.MavenProject;
 import org.cactoos.set.SetOf;
 import org.eolang.jeo.representation.asm.DisassembleMode;
 import org.eolang.jeo.representation.asm.DisassembleParams;
+import org.eolang.jeo.representation.directives.Format;
 
 /**
  * Disassembles Java bytecode into XMIR representation.
@@ -185,6 +186,22 @@ public final class DisassembleMojo extends AbstractMojo {
     private boolean xmirVerification;
 
     /**
+     * Should method modifiers be included in the output.
+     * <p>
+     * When true, method modifiers (e.g., public, private, static) will be
+     * included in the disassembled output.
+     * </p>
+     *
+     * @since 0.14.0
+     * @checkstyle MemberNameCheck (6 lines)
+     */
+    @Parameter(
+        property = "jeo.disassemble.xmir.modifiers",
+        defaultValue = "false"
+    )
+    private boolean modifiers;
+
+    /**
      * Set of inclusion GLOB filters for finding .class files
      * in the {@link #sourcesDir} directory.
      *
@@ -217,10 +234,12 @@ public final class DisassembleMojo extends AbstractMojo {
                 final boolean comments = !this.omitComments;
                 Logger.info(
                     this,
-                    "Disassembling is started with mode '%s' (with listings = '%b', comments = '%b')",
+                    "Disassembling is started with mode '%s' (with listings = '%b', comments = '%b', modifiers = '%b', pretty = '%b')",
                     this.mode,
                     listings,
-                    comments
+                    comments,
+                    this.modifiers,
+                    this.prettyXmir
                 );
                 new Disassembler(
                     new FilteredClasses(
@@ -232,7 +251,8 @@ public final class DisassembleMojo extends AbstractMojo {
                         DisassembleMode.fromString(this.mode),
                         listings,
                         this.prettyXmir,
-                        comments
+                        comments,
+                        new Format(Format.MODIFIERS, this.modifiers)
                     )
                 ).disassemble();
                 if (this.xmirVerification) {

--- a/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/BytecodeRepresentation.java
@@ -104,7 +104,7 @@ public final class BytecodeRepresentation {
         }
         Iterable<Directive> directives = new AsmProgram(this.input.value())
             .bytecode(params.asmMode())
-            .directives(listing);
+            .directives(listing, params.format());
         if (!params.includeComments()) {
             directives = new DirectivesWithoutComments(directives);
         }

--- a/src/main/java/org/eolang/jeo/representation/asm/DisassembleParams.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/DisassembleParams.java
@@ -4,6 +4,8 @@
  */
 package org.eolang.jeo.representation.asm;
 
+import org.eolang.jeo.representation.directives.Format;
+
 /**
  * Parameters for disassembling bytecode.
  * @since 0.11.0
@@ -33,11 +35,16 @@ public final class DisassembleParams {
     private final boolean comments;
 
     /**
+     * Format for disassembling.
+     */
+    private final Format fmt;
+
+    /**
      * Constructor with default parameters.
      * <p>Uses DEBUG mode, listings disabled, and pretty-printing enabled.</p>
      */
     public DisassembleParams() {
-        this(DisassembleMode.SHORT, false, true, false);
+        this(DisassembleMode.SHORT, false, true, false, new Format());
     }
 
     /**
@@ -47,18 +54,21 @@ public final class DisassembleParams {
      * @param listings Whether to include listings in the output
      * @param pretty Whether to pretty-print the output
      * @param comments Whether to include comments in the output
+     * @param format Format for disassembling
      * @checkstyle ParameterNumberCheck (10 lines)
      */
     public DisassembleParams(
         final DisassembleMode mode,
         final boolean listings,
         final boolean pretty,
-        final boolean comments
+        final boolean comments,
+        final Format format
     ) {
         this.mode = mode;
         this.listings = listings;
         this.pretty = pretty;
         this.comments = comments;
+        this.fmt = format;
     }
 
     /**
@@ -91,5 +101,13 @@ public final class DisassembleParams {
      */
     public boolean includeComments() {
         return this.comments;
+    }
+
+    /**
+     * Returns the format for disassembling.
+     * @return Format object with the properties set for disassembly.
+     */
+    public Format format() {
+        return this.fmt;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -12,6 +12,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.directives.DirectivesClass;
+import org.eolang.jeo.representation.directives.Format;
 import org.objectweb.asm.Opcodes;
 
 /**
@@ -279,12 +280,21 @@ public final class BytecodeClass {
      * @return Directives.
      */
     public DirectivesClass directives() {
+        return this.directives(new Format());
+    }
+
+    /**
+     * Convert to directives.
+     * @param format Format of the directives.
+     * @return Directives.
+     */
+    public DirectivesClass directives(final Format format) {
         return new DirectivesClass(
             this.name,
             this.props.directives(),
             this.fields.stream().map(BytecodeField::directives).collect(Collectors.toList()),
             this.cmethods.stream()
-                .map(method -> method.directives(this.mnumber(method)))
+                .map(method -> method.directives(this.mnumber(method), format))
                 .collect(Collectors.toList()),
             this.annotations.directives(),
             this.attributes.directives("attributes")
@@ -294,9 +304,8 @@ public final class BytecodeClass {
     /**
      * Constructor.
      * @param visitor Writer.
-     * @param pckg Package.
      */
-    void writeTo(final CustomClassWriter visitor, final String pckg) {
+    void writeTo(final CustomClassWriter visitor) {
         try {
             visitor.visit(
                 this.props.version(),

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -15,6 +15,7 @@ import org.eolang.jeo.representation.MethodName;
 import org.eolang.jeo.representation.NumberedName;
 import org.eolang.jeo.representation.asm.AsmLabels;
 import org.eolang.jeo.representation.directives.DirectivesMethod;
+import org.eolang.jeo.representation.directives.Format;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
@@ -271,12 +272,28 @@ public final class BytecodeMethod {
      * @return Directives.
      */
     public DirectivesMethod directives(final int number) {
+        return this.directives(number, new Format());
+    }
+
+    /**
+     * Generate directives.
+     * Since EO can't have overloaded methods, we need to add suffix to their names.
+     * This suffix is a number of the method.
+     * For example, if we have two methods with the same name, say 'foo',
+     * then we add suffixes to their names:
+     * foo and foo-2.
+     * That is why we need to pass method number to this method.
+     * @param number Method number.
+     * @param format Format of directives.
+     * @return Directives.
+     */
+    public DirectivesMethod directives(final int number, final Format format) {
         return new DirectivesMethod(
             new NumberedName(
                 number,
                 new MethodName(this.properties.name()).xmir()
             ),
-            this.properties.directives(this.maxs),
+            this.properties.directives(this.maxs, format),
             this.entries.stream().map(BytecodeEntry::directives)
                 .collect(Collectors.toList()),
             this.tryblocks.stream().map(BytecodeEntry::directives)

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
@@ -10,6 +10,7 @@ import java.util.stream.IntStream;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.directives.DirectivesMethodProperties;
+import org.eolang.jeo.representation.directives.Format;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
@@ -172,16 +173,18 @@ public final class BytecodeMethodProperties {
     /**
      * Convert to directives.
      * @param maxs Maxs.
+     * @param format Format of the directives.
      * @return Directives.
      */
-    public DirectivesMethodProperties directives(final BytecodeMaxs maxs) {
+    public DirectivesMethodProperties directives(final BytecodeMaxs maxs, final Format format) {
         return new DirectivesMethodProperties(
             this.access,
             this.descr,
             this.signature,
             this.exceptions,
             maxs.directives(),
-            this.parameters.directives()
+            this.parameters.directives(),
+            format
         );
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeObject.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeObject.java
@@ -16,6 +16,7 @@ import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.directives.DirectivesClass;
 import org.eolang.jeo.representation.directives.DirectivesMetas;
 import org.eolang.jeo.representation.directives.DirectivesObject;
+import org.eolang.jeo.representation.directives.Format;
 
 /**
  * Bytecode program.
@@ -85,7 +86,7 @@ public final class BytecodeObject {
      */
     public Bytecode bytecode() {
         final CustomClassWriter writer = new CustomClassWriter();
-        this.top().writeTo(writer, this.pckg);
+        this.top().writeTo(writer);
         return writer.bytecode();
     }
 
@@ -116,9 +117,19 @@ public final class BytecodeObject {
      * @return Directives program.
      */
     public DirectivesObject directives(final String listing) {
+        return this.directives(listing, new Format());
+    }
+
+    /**
+     * Convert to directives.
+     * @param listing Program listing.
+     * @param format Format of the directives.
+     * @return Directives program.
+     */
+    public DirectivesObject directives(final String listing, final Format format) {
         final BytecodeClass top = this.top();
         final ClassName classname = top.name();
-        final DirectivesClass clazz = top.directives();
+        final DirectivesClass clazz = top.directives(format);
         return new DirectivesObject(
             listing,
             clazz,

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
@@ -48,6 +48,11 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
     private final DirectivesMethodParams params;
 
     /**
+     * Format of the directives.
+     */
+    private final Format format;
+
+    /**
      * Constructor.
      */
     public DirectivesMethodProperties() {
@@ -96,31 +101,50 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
         final DirectivesMaxs max,
         final DirectivesMethodParams params
     ) {
+        this(access, descriptor, signature, exceptions, max, params, new Format());
+    }
+
+    /**
+     * Constructor.
+     * @param access Access modifiers.
+     * @param descriptor Method descriptor.
+     * @param signature Method signature.
+     * @param exceptions Method exceptions.
+     * @param max Max stack and locals.
+     * @param params Method parameters.
+     * @param format Format of the directives.
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    public DirectivesMethodProperties(
+        final int access,
+        final String descriptor,
+        final String signature,
+        final String[] exceptions,
+        final DirectivesMaxs max,
+        final DirectivesMethodParams params,
+        final Format format
+    ) {
         this.access = access;
         this.descriptor = Optional.ofNullable(descriptor).orElse("");
         this.signature = Optional.ofNullable(signature).orElse("");
         this.exceptions = Optional.ofNullable(exceptions).orElse(new String[0]).clone();
         this.max = new AtomicReference<>(max);
         this.params = params;
+        this.format = format;
     }
 
     @Override
     public Iterator<Directive> iterator() {
-        return new Directives()
+        final Directives dirs = new Directives()
             .append(new DirectivesValue("access", this.access))
             .append(new DirectivesValue("descriptor", this.descriptor))
             .append(new DirectivesValue("signature", this.signature))
             .append(new DirectivesOptionalValues("exceptions", (Object[]) this.exceptions))
             .append(this.max.get())
-            .append(this.params)
-            .iterator();
-    }
-
-    /**
-     * Method descriptor.
-     * @return Descriptor.
-     */
-    String descr() {
-        return this.descriptor;
+            .append(this.params);
+        if (this.format.modifiers()) {
+            dirs.append(new DirectivesModifiers(this.access));
+        }
+        return dirs.iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesModifiers.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesModifiers.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.Iterator;
+import org.objectweb.asm.Opcodes;
+import org.xembly.Directive;
+
+/**
+ * Method modifiers.
+ * @since 0.14.0
+ */
+public final class DirectivesModifiers implements Iterable<Directive> {
+
+    /**
+     * Access modifiers.
+     */
+    private final int modifiers;
+
+    /**
+     * Constructor.
+     * @param modifiers Access modifiers.
+     */
+    DirectivesModifiers(final int modifiers) {
+        this.modifiers = modifiers;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        return new DirectivesJeoObject(
+            "modifiers",
+            "modifiers",
+            new DirectivesValue("public", this.is(Opcodes.ACC_PUBLIC)),
+            new DirectivesValue("private", this.is(Opcodes.ACC_PRIVATE)),
+            new DirectivesValue("protected", this.is(Opcodes.ACC_PROTECTED)),
+            new DirectivesValue("static", this.is(Opcodes.ACC_STATIC)),
+            new DirectivesValue("final", this.is(Opcodes.ACC_FINAL)),
+            new DirectivesValue("synchronized", this.is(Opcodes.ACC_SYNCHRONIZED)),
+            new DirectivesValue("bridge", this.is(Opcodes.ACC_BRIDGE)),
+            new DirectivesValue("varargs", this.is(Opcodes.ACC_VARARGS)),
+            new DirectivesValue("native", this.is(Opcodes.ACC_NATIVE)),
+            new DirectivesValue("abstract", this.is(Opcodes.ACC_ABSTRACT)),
+            new DirectivesValue("strict", this.is(Opcodes.ACC_STRICT)),
+            new DirectivesValue("synthetic", this.is(Opcodes.ACC_SYNTHETIC)),
+            new DirectivesValue("mandated", this.is(Opcodes.ACC_MANDATED))
+        ).iterator();
+    }
+
+    /**
+     * Checks if the given flag is set.
+     * @param flag Flag to check.
+     * @return True if the flag is set, false otherwise.
+     * @checkstyle MethodNameCheck (3 lines)
+     */
+    @SuppressWarnings("PMD.ShortMethodName")
+    private boolean is(final int flag) {
+        return (this.modifiers & flag) != 0;
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/Format.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/Format.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Output format of the XMIR representation.
+ * @since 0.14.0
+ * @todo #1263:90min Use Format class instead of DisassembleParams.
+ *  DisassembleParams is rather rigid and cannot be extended with new properties.
+ *  Moreover, some of the properties in DisassembleParams are related to disassembling
+ *  in general and not to formatting specifically. We should move all formatting-related
+ *  properties to Format class and use it in all places where formatting is needed.
+ *  {@link org.eolang.jeo.representation.asm.DisassembleParams}
+ */
+public final class Format {
+
+    /**
+     * Should method modifiers be included in the output.
+     */
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
+    public static final String MODIFIERS = "modifiers";
+
+    /**
+     * All properties of the format.
+     */
+    private final Map<String, Object> properties;
+
+    /**
+     * Prepare pairs of properties.
+     * @param pairs Pairs of properties, each pair consists of a name and a value.
+     */
+    public Format(final Object... pairs) {
+        this(Format.pairs(pairs));
+    }
+
+    /**
+     * Constructor.
+     * @param properties Properties of the format.
+     */
+    private Format(final Map<String, Object> properties) {
+        this.properties = new ConcurrentHashMap<>(properties);
+    }
+
+    /**
+     * Should method modifiers be included in the output.
+     * @return True if modifiers are included, false otherwise.
+     */
+    public boolean modifiers() {
+        return this.bool(Format.MODIFIERS);
+    }
+
+    /**
+     * Get the boolean property.
+     * @param name Name of the property.
+     * @return Boolean value of the property.
+     */
+    private boolean bool(final String name) {
+        final boolean result;
+        if (this.properties.containsKey(name)) {
+            final Object value = this.properties.get(name);
+            if (value instanceof Boolean) {
+                result = (Boolean) value;
+            } else {
+                throw new IllegalArgumentException(
+                    String.format("Property '%s' is not a boolean", name)
+                );
+            }
+        } else {
+            result = false;
+        }
+        return result;
+    }
+
+    /**
+     * Parse pairs of properties into a map.
+     * @param properties Pairs of properties, each pair consists of a name and a value.
+     * @return Map of properties.
+     */
+    private static Map<String, Object> pairs(final Object... properties) {
+        if (properties.length % 2 != 0) {
+            throw new IllegalArgumentException(
+                "Properties must be in pairs: name and value"
+            );
+        }
+        final Map<String, Object> map = new java.util.HashMap<>();
+        for (int index = 0; index < properties.length; index += 2) {
+            if (!(properties[index] instanceof String)) {
+                throw new IllegalArgumentException(
+                    String.format("Property name '%s' is not a string", properties[index])
+                );
+            }
+            map.put((String) properties[index], properties[index + 1]);
+        }
+        return Collections.unmodifiableMap(map);
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/DisassemblerTest.java
+++ b/src/test/java/org/eolang/jeo/representation/DisassemblerTest.java
@@ -18,6 +18,7 @@ import org.cactoos.io.ResourceOf;
 import org.eolang.jeo.Disassembler;
 import org.eolang.jeo.representation.asm.DisassembleMode;
 import org.eolang.jeo.representation.asm.DisassembleParams;
+import org.eolang.jeo.representation.directives.Format;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,9 @@ final class DisassemblerTest {
     void transpilesSuccessfullyWithoutComments(@TempDir final Path temp) throws IOException {
         Files.write(temp.resolve(DisassemblerTest.CLASS_NAME), DisassemblerTest.BYTECODE);
         new Disassembler(
-            temp, temp, new DisassembleParams(DisassembleMode.SHORT, false, true, false)
+            temp,
+            temp,
+            new DisassembleParams(DisassembleMode.SHORT, false, true, false, new Format())
         ).disassemble();
         final Path disassembled = temp.resolve("org")
             .resolve("eolang")
@@ -82,7 +85,7 @@ final class DisassemblerTest {
     void transpilesWithComments(@TempDir final Path temp) throws IOException {
         Files.write(temp.resolve(DisassemblerTest.CLASS_NAME), DisassemblerTest.BYTECODE);
         new Disassembler(
-            temp, temp, new DisassembleParams(DisassembleMode.SHORT, true, true, true)
+            temp, temp, new DisassembleParams(DisassembleMode.SHORT, true, true, true, new Format())
         ).disassemble();
         final List<String> lines = Files.readAllLines(
             temp.resolve("org")

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodPropertiesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodPropertiesTest.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.xembly.Directives;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link DirectivesMethodProperties}.
+ * @since 0.14.0
+ */
+final class DirectivesMethodPropertiesTest {
+
+    @Test
+    void convertsToXmirWithoutAccessModifiers() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect no access modifiers in the directives",
+            new Xembler(
+                new Directives().add("o").append(
+                    new DirectivesMethodProperties(
+                        Opcodes.ACC_PUBLIC,
+                        "()V",
+                        "",
+                        new String[]{},
+                        new DirectivesMaxs(1, 1),
+                        new DirectivesMethodParams(),
+                        new Format(Format.MODIFIERS, false)
+                    )
+                ).up()
+            ).xml(),
+            Matchers.not(
+                XhtmlMatchers.hasXPath(
+                    "/o/o[contains(@name, 'modifiers')]"
+                )
+            )
+        );
+    }
+
+    @Test
+    void convertsToXmirWithAccessModifiers() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect access modifiers in the directives",
+            new Xembler(
+                new Directives().add("o").append(
+                    new DirectivesMethodProperties(
+                        Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL,
+                        "()V",
+                        "",
+                        new String[]{},
+                        new DirectivesMaxs(1, 1),
+                        new DirectivesMethodParams(),
+                        new Format(Format.MODIFIERS, true)
+                    )
+                ).up()
+            ).xml(),
+            XhtmlMatchers.hasXPath(
+                "/o/o[contains(@name, 'modifiers')]"
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesModifiersTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesModifiersTest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link DirectivesModifiers}.
+ * @since 0.14.0
+ */
+final class DirectivesModifiersTest {
+
+    @Test
+    void convertsToXmir() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect access modifiers in the directives with correct values",
+            new Xembler(
+                new DirectivesModifiers(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC)
+            ).xml(),
+            XhtmlMatchers.hasXPaths(
+                "/o[contains(@name, 'modifiers')]/o[contains(@name, 'public') and contains(@base, 'true')]",
+                "/o[contains(@name, 'modifiers')]/o[contains(@name, 'private') and contains(@base, 'false')]",
+                "/o[contains(@name, 'modifiers')]/o[contains(@name, 'protected') and contains(@base, 'false')]",
+                "/o[contains(@name, 'modifiers')]/o[contains(@name, 'static') and contains(@base, 'true')]",
+                "/o[contains(@name, 'modifiers')]/o[contains(@name, 'final') and contains(@base, 'false')]",
+                "/o[contains(@name, 'modifiers')]/o[contains(@name, 'synchronized') and contains(@base, 'false')]",
+                "/o[contains(@name, 'modifiers')]/o[contains(@name, 'bridge') and contains(@base, 'false')]",
+                "/o[contains(@name, 'modifiers')]/o[contains(@name, 'varargs') and contains(@base, 'false')]",
+                "/o[contains(@name, 'modifiers')]/o[contains(@name, 'native') and contains(@base, 'false')]",
+                "/o[contains(@name, 'modifiers')]/o[contains(@name, 'abstract') and contains(@base, 'false')]",
+                "/o[contains(@name, 'modifiers')]/o[contains(@name, 'strict') and contains(@base, 'false')]",
+                "/o[contains(@name, 'modifiers')]/o[contains(@name, 'synthetic') and contains(@base, 'false')]",
+                "/o[contains(@name, 'modifiers')]/o[contains(@name, 'mandated') and contains(@base, 'false')]"
+            )
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a `modifiers` field to the JEO method representation, enhancing access modifier visibility in the generated XMIR structure.

To use this feature you need to add the following configuration:

```xml
<modifiers>true</modifiers>
```

Related to #1263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an option to include method modifiers in generated XMIR. Configurable via the Maven plugin parameter or by enabling a new flag in project configuration. Disabled by default for backward compatibility. Logging now reflects the active formatting options.
- Tests
  - Added unit and integration tests to verify modifiers are correctly included or excluded in XMIR based on configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->