### PR TITLE
fix(#1279): Set the 'debug' mode by default and fix method parameters representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,20 +89,20 @@ configuration to your `pom.xml` file:
 </build>
 ```
 
-### Include debug information
+### Exclude debug information
 
-In order to include debug information in the generated EO files, you can set
-the `debug` option.
+In order to exclude debug information in the generated EO files, you can set
+the `short` option.
 
 ```xml
 
 <configuration>
-  <mode>debug</mode>
+  <mode>short</mode>
 </configuration>
 ```
 
-This option will add line numbers and local variable names to the EO files,
-together with their corresponding labels.
+This option will exclude line numbers and local variable names,
+together with their corresponding labels. The default mode is `debug`.
 
 ### Disable bytecode verification
 

--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -98,9 +98,9 @@ public final class DisassembleMojo extends AbstractMojo {
      * <p>
      * Supported modes:
      * <ul>
-     *   <li>{@code short} - Minimal output with bytecode instructions only (default)</li>
+     *   <li>{@code short} - Minimal output with bytecode instructions only</li>
      *   <li>{@code debug} - Include debug information such as line numbers, local variables,
-     *       and source file references</li>
+     *       and source file references (default)</li>
      * </ul>
      * </p>
      *
@@ -109,7 +109,7 @@ public final class DisassembleMojo extends AbstractMojo {
      */
     @Parameter(
         property = "jeo.disassemble.mode",
-        defaultValue = "short"
+        defaultValue = "debug"
     )
     private String mode;
 

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmAnnotations.java
@@ -72,6 +72,15 @@ public final class AsmAnnotations {
     }
 
     /**
+     * Check if there are no annotations.
+     * @return True if there are no annotations, false otherwise
+     */
+    public boolean isEmpty() {
+        return Optional.ofNullable(this.invisible).map(List::isEmpty).orElse(true)
+            && Optional.ofNullable(this.visible).map(List::isEmpty).orElse(true);
+    }
+
+    /**
      * Convert asm annotations to domain annotations.
      * @return Domain annotations.
      */

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmMethodParameters.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmMethodParameters.java
@@ -5,10 +5,13 @@
 package org.eolang.jeo.representation.asm;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodParameter;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodParameters;
+import org.eolang.jeo.representation.bytecode.BytecodeParamAnnotations;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.MethodNode;
@@ -38,27 +41,64 @@ final class AsmMethodParameters {
      * @return Domain method parameters.
      */
     BytecodeMethodParameters bytecode() {
-        final Type[] types = Type.getArgumentTypes(this.node.desc);
-        final List<BytecodeMethodParameter> params = new ArrayList<>(types.length);
-        for (int index = 0; index < types.length; ++index) {
-            params.add(
+        final List<ParameterNode> params = Optional.ofNullable(this.node.parameters)
+            .orElse(Collections.emptyList());
+        final Type[] types = this.types();
+        final List<BytecodeMethodParameter> res = new ArrayList<>(types.length);
+        for (int index = 0; index < params.size(); ++index) {
+            res.add(
                 new BytecodeMethodParameter(
                     index,
                     AsmMethodParameters.name(this.node, index),
                     AsmMethodParameters.access(this.node, index),
-                    types[index],
-                    new AsmAnnotations(
-                        AsmMethodParameters.annotations(
-                            this.node.visibleParameterAnnotations, index
-                        ),
-                        AsmMethodParameters.annotations(
-                            this.node.invisibleParameterAnnotations, index
-                        )
-                    ).bytecode()
+                    types[index]
                 )
             );
         }
-        return new BytecodeMethodParameters(params);
+        return new BytecodeMethodParameters(res, this.paramAnnotations());
+    }
+
+    /**
+     * Method parameter types.
+     * @return Method parameter types.
+     */
+    private Type[] types() {
+        final Type[] result;
+        if (this.node.desc != null) {
+            result = Type.getArgumentTypes(this.node.desc);
+        } else {
+            result = new Type[0];
+        }
+        return result;
+    }
+
+    /**
+     * Parameter annotations.
+     * @return Parameter annotations.
+     */
+    private List<BytecodeParamAnnotations> paramAnnotations() {
+        final List<AnnotationNode>[] visible = this.node.visibleParameterAnnotations;
+        final List<AnnotationNode>[] invisible = this.node.invisibleParameterAnnotations;
+        final int max = Math.max(
+            Optional.ofNullable(visible).map(a -> a.length).orElse(0),
+            Optional.ofNullable(invisible).map(a -> a.length).orElse(0)
+        );
+        final List<BytecodeParamAnnotations> annotations = new ArrayList<>(0);
+        for (int index = 0; index < max; ++index) {
+            final AsmAnnotations all = new AsmAnnotations(
+                AsmMethodParameters.annotations(visible, index),
+                AsmMethodParameters.annotations(invisible, index)
+            );
+            if (!all.isEmpty()) {
+                annotations.add(
+                    new BytecodeParamAnnotations(
+                        index,
+                        all.bytecode()
+                    )
+                );
+            }
+        }
+        return annotations;
     }
 
     /**
@@ -102,7 +142,7 @@ final class AsmMethodParameters {
      * @return Parameter name.
      */
     private static String name(final MethodNode node, final int index) {
-        String result = String.format("arg%d", index);
+        String result = null;
         if (node.parameters != null && node.parameters.size() > index) {
             final ParameterNode pnode = node.parameters.get(index);
             if (pnode.name != null) {

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameter.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameter.java
@@ -41,31 +41,15 @@ public final class BytecodeMethodParameter {
     private final Type type;
 
     /**
-     * Annotations of the parameter.
-     */
-    private final BytecodeAnnotations annotations;
-
-    /**
      * Constructor.
      * @param index Index of the parameter.
      * @param type Type of the parameter.
-     */
-    public BytecodeMethodParameter(final int index, final Type type) {
-        this(index, type, new BytecodeAnnotations());
-    }
-
-    /**
-     * Constructor.
-     * @param index Index of the parameter.
-     * @param type Type of the parameter.
-     * @param annotations Annotations of the parameter.
      */
     public BytecodeMethodParameter(
         final int index,
-        final Type type,
-        final BytecodeAnnotations annotations
+        final Type type
     ) {
-        this(index, String.format("arg%d", index), type, annotations);
+        this(index, null, type);
     }
 
     /**
@@ -73,16 +57,14 @@ public final class BytecodeMethodParameter {
      * @param index Index of the parameter.
      * @param name Name of the parameter.
      * @param type Type of the parameter.
-     * @param annotations Annotations of the parameter.
      * @checkstyle ParameterNumberCheck (5 lines)
      */
     public BytecodeMethodParameter(
         final int index,
         final String name,
-        final Type type,
-        final BytecodeAnnotations annotations
+        final Type type
     ) {
-        this(index, name, 0, type, annotations);
+        this(index, name, 0, type);
     }
 
     /**
@@ -91,21 +73,18 @@ public final class BytecodeMethodParameter {
      * @param name Name of the parameter.
      * @param access Method parameter access.
      * @param type Type of the parameter.
-     * @param annotations Annotations of the parameter.
      * @checkstyle ParameterNumberCheck (5 lines)
      */
     public BytecodeMethodParameter(
         final int index,
         final String name,
         final int access,
-        final Type type,
-        final BytecodeAnnotations annotations
+        final Type type
     ) {
         this.index = index;
         this.name = name;
         this.access = access;
         this.type = type;
-        this.annotations = annotations;
     }
 
     /**
@@ -114,7 +93,6 @@ public final class BytecodeMethodParameter {
      */
     public void write(final MethodVisitor visitor) {
         visitor.visitParameter(this.name, this.access);
-        this.annotations.write(this.index, visitor);
     }
 
     /**
@@ -128,8 +106,7 @@ public final class BytecodeMethodParameter {
             this.index,
             this.name,
             this.access,
-            this.type,
-            this.annotations.directives(format, String.format("param-annotations-%d", this.index))
+            this.type
         );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameters.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameters.java
@@ -24,9 +24,14 @@ import org.objectweb.asm.Type;
 public final class BytecodeMethodParameters {
 
     /**
-     * Annotations with a parameter position (as a key).
+     * Method parameter names.
      */
     private final List<BytecodeMethodParameter> params;
+
+    /**
+     * Method parameter annotations.
+     */
+    private final List<BytecodeParamAnnotations> annotations;
 
     /**
      * Default constructor.
@@ -56,7 +61,20 @@ public final class BytecodeMethodParameters {
      * @param params Parameters.
      */
     public BytecodeMethodParameters(final List<BytecodeMethodParameter> params) {
+        this(params, new ArrayList<>(0));
+    }
+
+    /**
+     * Constructor.
+     * @param params Parameters.
+     * @param annotations Parameter annotations.
+     */
+    public BytecodeMethodParameters(
+        final List<BytecodeMethodParameter> params,
+        final List<BytecodeParamAnnotations> annotations
+    ) {
         this.params = params;
+        this.annotations = annotations;
     }
 
     /**
@@ -65,6 +83,7 @@ public final class BytecodeMethodParameters {
      */
     public void write(final MethodVisitor visitor) {
         this.params.forEach(param -> param.write(visitor));
+        this.annotations.forEach(ann -> ann.write(visitor));
     }
 
     /**
@@ -76,7 +95,10 @@ public final class BytecodeMethodParameters {
         return new DirectivesMethodParams(
             this.params.stream()
                 .map(p -> p.directives(format))
-                .collect(Collectors.toList())
+                .collect(Collectors.toList()),
+            this.annotations.stream().map(
+                a -> a.directives(format)
+            ).collect(Collectors.toList())
         );
     }
 

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeObject.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeObject.java
@@ -76,7 +76,7 @@ public final class BytecodeObject {
      * @return XML representation of bytecode.
      */
     public XML xml() {
-        return new BytecodeRepresentation(this.bytecode()).toXmir();
+        return new BytecodeRepresentation(this.bytecode()).toXmir(new Format(Format.MODE, "debug"));
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeParamAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeParamAnnotations.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.bytecode;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.eolang.jeo.representation.directives.Format;
+import org.objectweb.asm.MethodVisitor;
+import org.xembly.Directive;
+
+/**
+ * Bytecode parameter annotations.
+ * @since 0.15.0
+ */
+@ToString
+@EqualsAndHashCode
+public final class BytecodeParamAnnotations {
+
+    /**
+     * Parameter index.
+     */
+    private final int index;
+
+    /**
+     * Parameter annotations.
+     */
+    private final BytecodeAnnotations annotations;
+
+    /**
+     * Constructor.
+     * @param index Parameter index.
+     * @param annotations Parameter annotations.
+     */
+    public BytecodeParamAnnotations(final int index, final BytecodeAnnotations annotations) {
+        this.index = index;
+        this.annotations = annotations;
+    }
+
+    /**
+     * Write all parameter annotations to bytecode.
+     * @param visitor Method to write in.
+     */
+    public void write(final MethodVisitor visitor) {
+        this.annotations.write(this.index, visitor);
+    }
+
+    /**
+     * Convert to directives.
+     * @param format Directive format.
+     * @return Xmir Directives.
+     */
+    Iterable<Directive> directives(final Format format) {
+        return this.annotations.directives(
+            format, String.format("param-annotations-%d", this.index)
+        );
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotations.java
@@ -56,6 +56,22 @@ public final class DirectivesAnnotations implements Iterable<Directive> {
 
     /**
      * Constructor.
+     * @param annotations Annotations.
+     */
+    public DirectivesAnnotations(final List<Iterable<Directive>> annotations) {
+        this(
+            annotations,
+            String.format(
+                String.format(
+                    "annotations-%d",
+                    Math.abs(DirectivesAnnotations.RANDOM.nextInt())
+                )
+            )
+        );
+    }
+
+    /**
+     * Constructor.
      * @param name Name.
      */
     DirectivesAnnotations(final String name) {
@@ -69,22 +85,6 @@ public final class DirectivesAnnotations implements Iterable<Directive> {
      */
     DirectivesAnnotations(final String name, final DirectivesAnnotation... annotations) {
         this(Arrays.asList(annotations), name);
-    }
-
-    /**
-     * Constructor.
-     * @param annotations Annotations.
-     */
-    private DirectivesAnnotations(final List<Iterable<Directive>> annotations) {
-        this(
-            annotations,
-            String.format(
-                String.format(
-                    "annotations-%d",
-                    Math.abs(DirectivesAnnotations.RANDOM.nextInt())
-                )
-            )
-        );
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParam.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParam.java
@@ -5,6 +5,7 @@
 package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
+import java.util.Optional;
 import org.objectweb.asm.Type;
 import org.xembly.Directive;
 
@@ -40,18 +41,12 @@ public final class DirectivesMethodParam implements Iterable<Directive> {
     private final Type type;
 
     /**
-     * Annotations of the parameter.
-     */
-    private final DirectivesAnnotations annotations;
-
-    /**
      * Constructor.
      * @param format Directives format.
      * @param index Index of the parameter.
      * @param name Name of the parameter.
      * @param access Access modifier of the parameter.
      * @param type Type of the parameter.
-     * @param annotations Annotations of the parameter.
      * @checkstyle ParameterNumberCheck (5 lines)
      */
     public DirectivesMethodParam(
@@ -59,26 +54,24 @@ public final class DirectivesMethodParam implements Iterable<Directive> {
         final int index,
         final String name,
         final int access,
-        final Type type,
-        final DirectivesAnnotations annotations
+        final Type type
     ) {
         this.format = format;
         this.index = index;
         this.name = name;
         this.access = access;
         this.type = type;
-        this.annotations = annotations;
     }
 
     @Override
     public Iterator<Directive> iterator() {
         return new DirectivesJeoObject(
             "param",
-            this.name,
+            Optional.ofNullable(this.name).orElse(String.format("arg%d", this.index)),
+            new DirectivesValue(this.format, "name", this.name),
             new DirectivesValue(this.format, "index", this.index),
             new DirectivesValue(this.format, "access", this.access),
-            new DirectivesValue(this.format, "type", this.type.toString()),
-            this.annotations
+            new DirectivesValue(this.format, "type", this.type.toString())
         ).iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodParams.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -22,6 +23,11 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
      * Parameters.
      */
     private final List<Iterable<Directive>> params;
+
+    /**
+     * Parameter annotations.
+     */
+    private final List<Iterable<Directive>> annotations;
 
     /**
      * Constructor.
@@ -44,7 +50,20 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
      * @param params Parameters.
      */
     public DirectivesMethodParams(final List<Iterable<Directive>> params) {
+        this(params, new ArrayList<>(0));
+    }
+
+    /**
+     * Constructor.
+     * @param params Parameters.
+     * @param annotations Parameter annotations.
+     */
+    public DirectivesMethodParams(
+        final List<Iterable<Directive>> params,
+        final List<Iterable<Directive>> annotations
+    ) {
         this.params = params;
+        this.annotations = annotations;
     }
 
     @Override
@@ -52,7 +71,10 @@ public final class DirectivesMethodParams implements Iterable<Directive> {
         return new DirectivesJeoObject(
             "params",
             "params",
-            this.params.stream().map(Directives::new).collect(Collectors.toList())
+            Stream.concat(
+                this.params.stream().map(Directives::new),
+                this.annotations.stream().map(Directives::new)
+            ).collect(Collectors.toList())
         ).iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -382,10 +382,10 @@ public final class XmlMethod {
      */
     private BytecodeMethodParameters params() {
         return this.node.children()
-            .map(XmlParams::new)
-            .filter(XmlParams::isParams)
+            .map(XmlMethodParams::new)
+            .filter(XmlMethodParams::isParams)
             .findFirst()
-            .map(XmlParams::params)
+            .map(XmlMethodParams::params)
             .orElse(new BytecodeMethodParameters());
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethodParam.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethodParam.java
@@ -5,15 +5,15 @@
 package org.eolang.jeo.representation.xmir;
 
 import org.eolang.jeo.representation.EncodedString;
-import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodParameter;
+import org.eolang.jeo.representation.directives.JeoFqn;
 import org.objectweb.asm.Type;
 
 /**
  * Xmir representation of a method parameter.
  * @since 0.4
  */
-public final class XmlParam {
+public final class XmlMethodParam {
 
     /**
      * Root node from which we will get all required data.
@@ -24,7 +24,7 @@ public final class XmlParam {
      * Constructor.
      * @param root Parameter xml node.
      */
-    XmlParam(final XmlNode root) {
+    XmlMethodParam(final XmlNode root) {
         this(new XmlJeoObject(root));
     }
 
@@ -32,7 +32,7 @@ public final class XmlParam {
      * Constructor.
      * @param root Parameter xml node.
      */
-    private XmlParam(final XmlJeoObject root) {
+    private XmlMethodParam(final XmlJeoObject root) {
         this.root = root;
     }
 
@@ -45,9 +45,16 @@ public final class XmlParam {
             this.index(),
             this.name(),
             this.access(),
-            this.type(),
-            this.annotations()
+            this.type()
         );
+    }
+
+    /**
+     * Check if the object is actually a method param.
+     * @return True if the method param, false otherwise.
+     */
+    public boolean isParam() {
+        return this.root.base().map(new JeoFqn("param").fqn()::equals).orElse(false);
     }
 
     /**
@@ -63,7 +70,7 @@ public final class XmlParam {
      * @return Name.
      */
     private String name() {
-        return this.root.name();
+        return this.child("name").string();
     }
 
     /**
@@ -83,21 +90,6 @@ public final class XmlParam {
     }
 
     /**
-     * Annotations of the parameter.
-     * @return Annotations.
-     */
-    private BytecodeAnnotations annotations() {
-        return this.root.children()
-            .map(XmlJeoObject::new)
-            .filter(XmlJeoObject::named)
-            .filter(node -> node.name().startsWith("param-annotations-"))
-            .findFirst()
-            .map(XmlAnnotations::new)
-            .map(XmlAnnotations::bytecode)
-            .orElse(new BytecodeAnnotations());
-    }
-
-    /**
      * Child node with the given name.
      * @param name Name of the child node.
      * @return Child node.
@@ -105,7 +97,7 @@ public final class XmlParam {
     private XmlValue child(final String name) {
         return new XmlValue(
             this.root.children()
-                .filter(node -> XmlParam.hasName(node, name))
+                .filter(node -> XmlMethodParam.hasName(node, name))
                 .findFirst()
                 .orElseThrow(
                     () -> new IllegalStateException(

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethodParams.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethodParams.java
@@ -4,15 +4,18 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import java.util.List;
 import java.util.stream.Collectors;
+import org.eolang.jeo.representation.bytecode.BytecodeMethodParameter;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodParameters;
+import org.eolang.jeo.representation.bytecode.BytecodeParamAnnotations;
 import org.eolang.jeo.representation.directives.JeoFqn;
 
 /**
  * XML method params.
  * @since 0.6
  */
-final class XmlParams {
+final class XmlMethodParams {
 
     /**
      * Params fully qualified name.
@@ -28,7 +31,7 @@ final class XmlParams {
      * Constructor.
      * @param node Xml representation of a method params.
      */
-    XmlParams(final XmlNode node) {
+    XmlMethodParams(final XmlNode node) {
         this(new XmlJeoObject(node));
     }
 
@@ -36,7 +39,7 @@ final class XmlParams {
      * Constructor.
      * @param node XML Jeo object node representing the method params.
      */
-    private XmlParams(final XmlJeoObject node) {
+    private XmlMethodParams(final XmlJeoObject node) {
         this.node = node;
     }
 
@@ -46,7 +49,7 @@ final class XmlParams {
      */
     boolean isParams() {
         return this.node.base()
-            .map(XmlParams.PARAMS_BASE::equals)
+            .map(XmlMethodParams.PARAMS_BASE::equals)
             .orElse(false);
     }
 
@@ -56,10 +59,33 @@ final class XmlParams {
      */
     BytecodeMethodParameters params() {
         return new BytecodeMethodParameters(
-            this.node.children()
-                .map(XmlParam::new)
-                .map(XmlParam::bytecode)
-                .collect(Collectors.toList())
+            this.parameters(),
+            this.annotations()
         );
+    }
+
+    /**
+     * Method parameters.
+     * @return List of bytecode method parameters.
+     */
+    private List<BytecodeMethodParameter> parameters() {
+        return this.node.children()
+            .map(XmlMethodParam::new)
+            .filter(XmlMethodParam::isParam)
+            .map(XmlMethodParam::bytecode)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Annotations of the parameter.
+     * @return Annotations.
+     */
+    private List<BytecodeParamAnnotations> annotations() {
+        return this.node.children()
+            .map(XmlJeoObject::new)
+            .map(XmlParamAnnotations::new)
+            .filter(XmlParamAnnotations::isParamAnnotations)
+            .map(XmlParamAnnotations::bytecode)
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlParamAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlParamAnnotations.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import org.eolang.jeo.representation.bytecode.BytecodeParamAnnotations;
+
+/**
+ * Mirrors {@link org.eolang.jeo.representation.bytecode.BytecodeParamAnnotations}.
+ * @since 0.15.0
+ */
+public final class XmlParamAnnotations {
+
+    /**
+     * Xmir node.
+     */
+    private final XmlJeoObject node;
+
+    /**
+     * Constructor.
+     * @param node Xmir node.
+     */
+    XmlParamAnnotations(final XmlJeoObject node) {
+        this.node = node;
+    }
+
+    /**
+     * Convert to bytecode.
+     * @return Bytecode parameter annotations.
+     */
+    public BytecodeParamAnnotations bytecode() {
+        return new BytecodeParamAnnotations(
+            Integer.parseInt(this.node.name().split("-")[2]),
+            new XmlAnnotations(this.node).bytecode()
+        );
+    }
+
+    /**
+     * Whether this node represents parameter annotations.
+     * @return True if it does.
+     */
+    boolean isParamAnnotations() {
+        return this.node.name().startsWith("param-annotations");
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
@@ -10,6 +10,7 @@ import org.cactoos.io.ResourceOf;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.bytecode.EoCodec;
 import org.eolang.jeo.representation.directives.DirectivesValue;
+import org.eolang.jeo.representation.directives.Format;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -126,14 +127,16 @@ final class BytecodeRepresentationTest {
     @Test
     void parsesBytecodeLoggerStackFrames() throws Exception {
         final ResourceOf input = new ResourceOf("LoggerFactory$DelegatingLogger.class");
+        final String actual = new Bytecode(
+            new XmirRepresentation(
+                new BytecodeRepresentation(input).toXmir(new Format(Format.MODE, "debug"))
+            ).toBytecode().bytes()
+        ).toString();
+        final String expected = new Bytecode(new BytesOf(input).asBytes()).toString();
         MatcherAssert.assertThat(
             "The disassembled/assembled bytecode representation should match the original bytecode",
-            new Bytecode(
-                new XmirRepresentation(
-                    new BytecodeRepresentation(input).toXmir()
-                ).toBytecode().bytes()
-            ).toString(),
-            Matchers.equalTo(new Bytecode(new BytesOf(input).asBytes()).toString())
+            actual,
+            Matchers.equalTo(expected)
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -17,6 +17,7 @@ import org.cactoos.io.ResourceOf;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.eolang.jeo.representation.bytecode.BytecodeObject;
+import org.eolang.jeo.representation.directives.Format;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -139,7 +140,7 @@ final class XmirRepresentationTest {
             new BytecodeClass("Application").helloWorldMethod()
         ).bytecode();
         final Bytecode actual = new XmirRepresentation(
-            new BytecodeRepresentation(expected).toXmir()
+            new BytecodeRepresentation(expected).toXmir(new Format(Format.MODE, "debug"))
         ).toBytecode();
         MatcherAssert.assertThat(
             String.format(XmirRepresentationTest.MESSAGE, expected, actual),
@@ -166,14 +167,13 @@ final class XmirRepresentationTest {
 
     @Test
     void generatesValidBytecodeWithNestMembersAttributeFromXmir() throws Exception {
+        final Bytecode original = new Bytecode(
+            new BytesOf(new ResourceOf("Check.class")).asBytes()
+        );
         MatcherAssert.assertThat(
             "We expect to parse the same bytecode with the 'NestMembers' attribute",
             new XmirRepresentation(
-                new BytecodeRepresentation(
-                    new Bytecode(
-                        new BytesOf(new ResourceOf("Check.class")).asBytes()
-                    )
-                ).toXmir()
+                new BytecodeRepresentation(original).toXmir()
             ).toBytecode().toString(),
             Matchers.containsString("NESTMEMBER")
         );

--- a/src/test/java/org/eolang/jeo/representation/asm/AsmMethodParametersTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/AsmMethodParametersTest.java
@@ -5,14 +5,19 @@
 package org.eolang.jeo.representation.asm;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodParameter;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodParameters;
+import org.eolang.jeo.representation.bytecode.BytecodeParamAnnotations;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.ParameterNode;
 
@@ -36,10 +41,42 @@ final class AsmMethodParametersTest {
                 new BytecodeMethodParameters(
                     new BytecodeMethodParameter(
                         0,
-                        "arg0",
+                        null,
                         access,
-                        Type.INT_TYPE,
-                        new BytecodeAnnotations()
+                        Type.INT_TYPE
+                    )
+                )
+            )
+        );
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void convertsMethodParamAnnotations() {
+        final MethodNode node = new MethodNode();
+        final String descriptor = "Ljava/lang/Deprecated()";
+        node.visibleParameterAnnotations = new List[1];
+        node.visibleParameterAnnotations[0] = Collections.singletonList(
+            new AnnotationNode(descriptor)
+        );
+        node.invisibleParameterAnnotations = new List[1];
+        node.invisibleParameterAnnotations[0] = Collections.singletonList(
+            new AnnotationNode(descriptor)
+        );
+        MatcherAssert.assertThat(
+            "We expect parameter annotations to be successfully parsed from bytecode",
+            new AsmMethodParameters(node).bytecode(),
+            Matchers.equalTo(
+                new BytecodeMethodParameters(
+                    new ArrayList<>(0),
+                    Collections.singletonList(
+                        new BytecodeParamAnnotations(
+                            0,
+                            new BytecodeAnnotations(
+                                new BytecodeAnnotation(descriptor, true),
+                                new BytecodeAnnotation(descriptor, false)
+                            )
+                        )
                     )
                 )
             )

--- a/src/test/java/org/eolang/jeo/representation/asm/AsmProgramTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/AsmProgramTest.java
@@ -33,8 +33,8 @@ final class AsmProgramTest {
             .bytecode();
         MatcherAssert.assertThat(
             "We expect to receive the same bytecode",
-            new AsmProgram(same.bytes()).bytecode().bytecode(),
-            Matchers.equalTo(same)
+            new AsmProgram(same.bytes()).bytecode(0).bytecode().toString(),
+            Matchers.equalTo(same.toString())
         );
     }
 
@@ -73,7 +73,7 @@ final class AsmProgramTest {
         MatcherAssert.assertThat(
             "We expect to receive the same bytecode with the 'NestMembers' attribute",
             actual.toString(),
-            Matchers.containsString("NESTMEMBER")
+            Matchers.equalTo(new Bytecode(original).toString())
         );
     }
 
@@ -82,20 +82,14 @@ final class AsmProgramTest {
      * Comes from the issue:
      * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/1274">#1274</a>
      * @throws Exception In case of error
-     * @todo #1274:30min Compare the bytecode before and after the conversion.
-     *  Instead of just checking for the presence of the 'NestHost' attribute, we should
-     *  compare the entire bytecode before and after the conversion to ensure that no other
-     *  attributes or instructions are lost or altered during the process.
-     *  We can't do it right now, because we have some strange 'arg0' attribute after
-     *  the conversion, which is not present in the original bytecode.
      */
     @Test
-    void persesNestHostBytecodeAttribute() throws Exception {
+    void parsesNestHostBytecodeAttribute() throws Exception {
         final byte[] original = new BytesOf(new ResourceOf("Check$1Local.class")).asBytes();
         MatcherAssert.assertThat(
             "We expect to receive the same bytecode with the 'NestHost' attribute",
             new AsmProgram(original).bytecode(0).bytecode().toString(),
-            Matchers.containsString("NESTHOST")
+            Matchers.equalTo(new Bytecode(original).toString())
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParameterTest.java
@@ -5,7 +5,6 @@
 package org.eolang.jeo.representation.bytecode;
 
 import java.util.stream.Stream;
-import org.eolang.jeo.representation.directives.DirectivesAnnotations;
 import org.eolang.jeo.representation.directives.DirectivesMethodParam;
 import org.eolang.jeo.representation.directives.Format;
 import org.hamcrest.MatcherAssert;
@@ -29,18 +28,24 @@ final class BytecodeMethodParameterTest {
         final int index, final Type type
     ) throws ImpossibleModificationException {
         final Format format = new Format();
+        final String name = String.format("arg%d", index);
         MatcherAssert.assertThat(
             "We can't convert bytecode method parameter to correct XML directives",
-            new Xembler(new BytecodeMethodParameter(index, type).directives(format)).xml(),
+            new Xembler(
+                new BytecodeMethodParameter(
+                    index,
+                    name,
+                    type
+                ).directives(format)
+            ).xml(),
             Matchers.equalTo(
                 new Xembler(
                     new DirectivesMethodParam(
                         format,
                         index,
-                        String.format("arg%d", index),
+                        name,
                         0,
-                        type,
-                        new DirectivesAnnotations()
+                        type
                     )
                 ).xml()
             )

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParametersTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodParametersTest.java
@@ -4,6 +4,9 @@
  */
 package org.eolang.jeo.representation.bytecode;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import org.eolang.jeo.representation.directives.DirectivesAnnotation;
 import org.eolang.jeo.representation.directives.DirectivesAnnotations;
 import org.eolang.jeo.representation.directives.DirectivesMethodParam;
 import org.eolang.jeo.representation.directives.DirectivesMethodParams;
@@ -36,10 +39,47 @@ final class BytecodeMethodParametersTest {
                 new Xembler(
                     new DirectivesMethodParams(
                         new DirectivesMethodParam(
-                            format, 0, "arg0", 0, Type.INT_TYPE, new DirectivesAnnotations()
+                            format, 0, null, 0, Type.INT_TYPE
                         ),
                         new DirectivesMethodParam(
-                            format, 1, "arg1", 0, Type.INT_TYPE, new DirectivesAnnotations()
+                            format, 1, null, 0, Type.INT_TYPE
+                        )
+                    )
+                ).xml()
+            )
+        );
+    }
+
+    @Test
+    void convertsMethodParamAnnotationsToDirectives() throws ImpossibleModificationException {
+        final String descriptor = "Ljava/lang/Deprecated()";
+        final boolean visible = true;
+        final Format format = new Format();
+        final int index = 0;
+        MatcherAssert.assertThat(
+            "We expect a visible annotation to be converted to xmir",
+            new Xembler(
+                new BytecodeMethodParameters(
+                    new ArrayList<>(index),
+                    Collections.singletonList(
+                        new BytecodeParamAnnotations(
+                            index,
+                            new BytecodeAnnotations(
+                                new BytecodeAnnotation(descriptor, visible)
+                            )
+                        )
+                    )
+                ).directives(format)
+            ).xml(),
+            Matchers.equalTo(
+                new Xembler(
+                    new DirectivesMethodParams(
+                        Collections.emptyList(),
+                        new DirectivesAnnotations(
+                            Collections.singletonList(
+                                new DirectivesAnnotation(index, format, descriptor, visible)
+                            ),
+                            "param-annotations-0"
                         )
                     )
                 ).xml()

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodParamTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodParamTest.java
@@ -5,6 +5,7 @@
 package org.eolang.jeo.representation.directives;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
@@ -31,8 +32,7 @@ final class DirectivesMethodParamTest {
                     1,
                     "foo",
                     Opcodes.ACC_PUBLIC,
-                    Type.INT_TYPE,
-                    new DirectivesAnnotations()
+                    Type.INT_TYPE
                 )
             ).xml(),
             XhtmlMatchers.hasXPath("./o[contains(@base, param) and contains(@name, 'foo')]")
@@ -49,8 +49,7 @@ final class DirectivesMethodParamTest {
                     2,
                     "bar",
                     Opcodes.ACC_PRIVATE,
-                    Type.DOUBLE_TYPE,
-                    new DirectivesAnnotations()
+                    Type.DOUBLE_TYPE
                 )
             ).xml(),
             XhtmlMatchers.hasXPath(
@@ -69,8 +68,7 @@ final class DirectivesMethodParamTest {
                     3,
                     "baz",
                     Opcodes.ACC_PROTECTED,
-                    Type.LONG_TYPE,
-                    new DirectivesAnnotations()
+                    Type.LONG_TYPE
                 )
             ).xml(),
             XhtmlMatchers.hasXPath(
@@ -89,8 +87,7 @@ final class DirectivesMethodParamTest {
                     4,
                     "qux",
                     Opcodes.ACC_STATIC,
-                    Type.getType("Lorg/eolang/jeo/representation/directives;"),
-                    new DirectivesAnnotations()
+                    Type.getType("Lorg/eolang/jeo/representation/directives;")
                 )
             ).xml(),
             XhtmlMatchers.hasXPath(
@@ -104,14 +101,20 @@ final class DirectivesMethodParamTest {
         MatcherAssert.assertThat(
             "We expect that the parameter directives will be generated with annotations",
             new Xembler(
-                new DirectivesMethodParam(
-                    new Format(),
-                    5,
-                    "quux",
-                    Opcodes.ACC_ABSTRACT,
-                    Type.FLOAT_TYPE,
-                    new DirectivesAnnotations(
-                        "annotations", new DirectivesAnnotation("Ljava/lang/Override;", true)
+                new DirectivesMethodParams(
+                    Collections.singletonList(
+                        new DirectivesMethodParam(
+                            new Format(),
+                            5,
+                            "quux",
+                            Opcodes.ACC_ABSTRACT,
+                            Type.FLOAT_TYPE
+                        )
+                    ),
+                    Collections.singletonList(
+                        new DirectivesAnnotations(
+                            "annotations", new DirectivesAnnotation("Ljava/lang/Override;", true)
+                        )
                     )
                 )
             ).xml(),

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodParamTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodParamTest.java
@@ -4,8 +4,6 @@
  */
 package org.eolang.jeo.representation.xmir;
 
-import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
-import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodParameter;
 import org.eolang.jeo.representation.directives.Format;
 import org.hamcrest.MatcherAssert;
@@ -17,10 +15,10 @@ import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
 /**
- * Test cases for {@link XmlParam}.
+ * Test cases for {@link XmlMethodParam}.
  * @since 0.6
  */
-final class XmlParamTest {
+final class XmlMethodParamTest {
 
     @Test
     void convertsToBytecode() throws ImpossibleModificationException {
@@ -28,12 +26,11 @@ final class XmlParamTest {
             1,
             "foo",
             Opcodes.ACC_STATIC,
-            Type.INT_TYPE,
-            new BytecodeAnnotations(new BytecodeAnnotation("Ljava/lang/Deprecated;", true))
+            Type.INT_TYPE
         );
         MatcherAssert.assertThat(
             "Can't convert XML param to bytecode",
-            new XmlParam(
+            new XmlMethodParam(
                 new NativeXmlNode(new Xembler(expected.directives(new Format())).xml())
             ).bytecode(),
             Matchers.equalTo(expected)

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodParamsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodParamsTest.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import java.util.Collections;
+import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
+import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
+import org.eolang.jeo.representation.bytecode.BytecodeMethodParameter;
+import org.eolang.jeo.representation.bytecode.BytecodeMethodParameters;
+import org.eolang.jeo.representation.bytecode.BytecodeParamAnnotations;
+import org.eolang.jeo.representation.directives.Format;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Type;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link XmlMethodParams}.
+ * @since 0.15.0
+ */
+final class XmlMethodParamsTest {
+
+    @Test
+    void parsesAnnotations() throws ImpossibleModificationException {
+        final int index = 0;
+        final BytecodeMethodParameters original = new BytecodeMethodParameters(
+            Collections.singletonList(new BytecodeMethodParameter(index, Type.INT_TYPE)),
+            Collections.singletonList(
+                new BytecodeParamAnnotations(
+                    index,
+                    new BytecodeAnnotations(
+                        new BytecodeAnnotation("Ljava/lang/Deprecated;", false),
+                        new BytecodeAnnotation("Lorg/jetbrains/annotations/Nullable;", true)
+                    )
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            "We expect to parse method parameter annotations correctly",
+            new XmlMethodParams(
+                new JcabiXmlNode(new Xembler(original.directives(new Format())).xml())
+            ).params(),
+            Matchers.equalTo(original)
+        );
+    }
+}


### PR DESCRIPTION
This PR resolves the puzzle `1274-798a41c0` by updating method parameter representation.

Fixes #1279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Here are the release notes based on the changes:

* **Documentation**
  * Updated README debug mode descriptions and configuration
  * Updated JavaDoc for various parameter and annotation handling classes

* **New Features**
  * Added method to check if annotations are empty
  * Added support for parameter annotations in bytecode representation

* **Bug Fixes**
  * Improved null-safety in parameter and annotation processing
  * Fixed default mode handling for disassembly and XML generation

* **Refactoring**
  * Renamed several classes related to method parameters and XML parsing
  * Simplified method parameter and annotation handling across multiple classes
  * Improved bytecode and XML representation generation

* **Tests**
  * Added new tests for parameter annotations parsing
  * Updated existing tests to match new method signatures and behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->