### PR TITLE
feat(#1278): add integration tests for Java records usage with jeo-maven-plugin

### DIFF
--- a/src/it/records/README.md
+++ b/src/it/records/README.md
@@ -1,0 +1,11 @@
+# Records Integration Test
+
+Integration test that attempts to transform a simple Java program with
+records usage.
+The integration test verifies that the program can run successfully, and the
+jeo-maven-plugin doesn't break anything.
+If you only need to run this test, use the following command:
+
+```shell
+mvn clean integration-test -Dinvoker.test=records -DskipTests
+```

--- a/src/it/records/invoker.properties
+++ b/src/it/records/invoker.properties
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+invoker.goals=clean process-classes -e
+invoker.mavenOpts=-Xss256m
+# We use records feature, which is available since Java 16
+# @todo #1278:90min Enable 'records' test.
+#  We disabled this test because parsing of records from Xmir to Bytecode doesn't work properly.
+#  We only convert records to Xmir, but don't convert them back.
+#  We need to fix this and enable the test again.
+#  To enable the test, change the version to 16+ or higher.
+#  Starting point is {@link BytecodeAttribute.RecordComponents}.
+invoker.java.version = 9999+

--- a/src/it/records/pom.xml
+++ b/src/it/records/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eolang</groupId>
+  <artifactId>jeo-it</artifactId>
+  <version>@project.version@</version>
+  <packaging>jar</packaging>
+  <description>
+    Integration test that attempts to transform a simple Java program with records usage.
+    The integration test verifies that the program can run successfully, and the jeo-maven-plugin doesn't break anything.
+    If you only need to run this test, use the following command:
+    "mvn clean integration-test invoker:run -Dinvoker.test=records -DskipTests"
+  </description>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>16</maven.compiler.release>
+    <stack-size>256M</stack-size>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>jeo-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <xmirVerification>true</xmirVerification>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bytecode-to-eo</id>
+            <goals>
+              <goal>disassemble</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>eo-to-bytecode</id>
+            <goals>
+              <goal>assemble</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <executions>
+          <execution>
+            <phase>
+              process-classes
+            </phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>org.eolang.jeo.records.App</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/records/src/main/java/org/eolang/jeo/records/App.java
+++ b/src/it/records/src/main/java/org/eolang/jeo/records/App.java
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.records;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Objects;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.RECORD_COMPONENT;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Retention(RUNTIME)
+@Target({RECORD_COMPONENT, FIELD, METHOD, PARAMETER})
+@interface Label {
+    String value();
+}
+
+@Documented
+@Retention(RUNTIME)
+@Target(RECORD_COMPONENT)
+@interface ComponentTag {
+    String value();
+}
+
+// Package-private record; single public top-level type per file.
+record User(
+    @Label("username") @ComponentTag("primary-id") String name,
+    @Label("age-years") int age
+) {}
+
+public class App {
+
+    public static void main(String[] args) throws Exception {
+        // --- Record components ---
+        var components = User.class.getRecordComponents();
+        check(components.length == 2, "Two record components expected");
+
+        var rcA = components[0];
+        var rcB = components[1];
+        var rcName = "name".equals(rcA.getName()) ? rcA : rcB;
+        var rcAge  = rcName == rcA ? rcB : rcA;
+
+        checkEquals("name", rcName.getName(), "Name component name");
+        check(rcName.getType() == String.class, "Name component type is String");
+        var nameLabel = rcName.getAnnotation(Label.class);
+        check(nameLabel != null && "username".equals(nameLabel.value()),
+            "@Label on name component");
+        var nameTag = rcName.getAnnotation(ComponentTag.class);
+        check(nameTag != null && "primary-id".equals(nameTag.value()),
+            "@ComponentTag on name component");
+
+        checkEquals("age", rcAge.getName(), "Age component name");
+        check(rcAge.getType() == int.class, "Age component type is int");
+        var ageLabel = rcAge.getAnnotation(Label.class);
+        check(ageLabel != null && "age-years".equals(ageLabel.value()),
+            "@Label on age component");
+        check(rcAge.getAnnotation(ComponentTag.class) == null,
+            "No @ComponentTag on age component");
+
+        // --- Backing fields (propagation when @Target includes FIELD) ---
+        Field fName = User.class.getDeclaredField("name");
+        Field fAge  = User.class.getDeclaredField("age");
+        var fNameLabel = fName.getAnnotation(Label.class);
+        var fAgeLabel  = fAge.getAnnotation(Label.class);
+        check(fNameLabel != null && "username".equals(fNameLabel.value()),
+            "@Label propagated to field 'name'");
+        check(fAgeLabel != null && "age-years".equals(fAgeLabel.value()),
+            "@Label propagated to field 'age'");
+        check(fName.getAnnotation(ComponentTag.class) == null,
+            "@ComponentTag should NOT be on fields");
+        check(fAge.getAnnotation(ComponentTag.class) == null,
+            "@ComponentTag should NOT be on fields");
+
+        // --- Accessor methods (propagation when @Target includes METHOD) ---
+        Method mName = User.class.getDeclaredMethod("name");
+        Method mAge  = User.class.getDeclaredMethod("age");
+        var mNameLabel = mName.getAnnotation(Label.class);
+        var mAgeLabel  = mAge.getAnnotation(Label.class);
+        check(mNameLabel != null && "username".equals(mNameLabel.value()),
+            "@Label propagated to accessor name()");
+        check(mAgeLabel != null && "age-years".equals(mAgeLabel.value()),
+            "@Label propagated to accessor age()");
+        check(mName.getAnnotation(ComponentTag.class) == null,
+            "@ComponentTag should NOT be on accessors");
+        check(mAge.getAnnotation(ComponentTag.class) == null,
+            "@ComponentTag should NOT be on accessors");
+
+        // --- Canonical constructor parameters (propagation when @Target includes PARAMETER) ---
+        Constructor<User> ctor = User.class.getDeclaredConstructor(String.class, int.class);
+        Parameter[] params = ctor.getParameters();
+        check(params.length == 2, "Two constructor parameters expected");
+        var p0Label = params[0].getAnnotation(Label.class);
+        var p1Label = params[1].getAnnotation(Label.class);
+        check(p0Label != null && "username".equals(p0Label.value()),
+            "@Label propagated to ctor param 0");
+        check(p1Label != null && "age-years".equals(p1Label.value()),
+            "@Label propagated to ctor param 1");
+
+        // --- Basic record behavior sanity checks ---
+        var u = new User("alice", 30);
+        checkEquals("alice", u.name(), "Accessor name()");
+        check(u.age() == 30, "Accessor age() == 30");
+        check(u.toString().contains("alice") && u.toString().contains("30"),
+            "toString contains component values");
+
+        // If we got here, everything matched.
+        System.out.println("All checks passed.");
+    }
+
+    // --- Minimal plain-Java "assertions" ---
+    private static void check(boolean condition, String message) {
+        if (!condition) throw new AssertionError(message);
+    }
+    private static void checkEquals(Object expected, Object actual, String message) {
+        if (!Objects.equals(expected, actual)) {
+            throw new AssertionError(message + " (expected=" + expected + ", actual=" + actual + ")");
+        }
+    }
+}

--- a/src/it/records/verify.groovy
+++ b/src/it/records/verify.groovy
@@ -1,0 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+//Check logs first.
+String log = new File(basedir, 'build.log').text;
+assert log.contains("BUILD SUCCESS")
+assert log.contains("All checks passed.")
+true

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmAnnotationValues.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmAnnotationValues.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.asm;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.eolang.jeo.representation.bytecode.BytecodeAnnotationValue;
+
+/**
+ * Annotation values in ASM representation.
+ * @since 0.15.0
+ */
+public final class AsmAnnotationValues {
+    /**
+     * Raw values list.
+     */
+    private final List<Object> values;
+
+    /**
+     * Constructor.
+     * @param values Raw values list.
+     */
+    AsmAnnotationValues(final List<Object> values) {
+        this.values = values;
+    }
+
+    /**
+     * Convert to bytecode representation.
+     * @return Bytecode representation.
+     */
+    public List<BytecodeAnnotationValue> bytecode() {
+        final List<BytecodeAnnotationValue> properties = new ArrayList<>(0);
+        final List<Object> all = Optional.ofNullable(this.values).orElse(new ArrayList<>(0));
+        for (int index = 0; index < all.size(); index += 2) {
+            properties.add(
+                new AsmAnnotationProperty(
+                    (String) all.get(index),
+                    all.get(index + 1)
+                ).bytecode()
+            );
+        }
+        return properties;
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmAnnotations.java
@@ -10,12 +10,12 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
-import org.eolang.jeo.representation.bytecode.BytecodeAnnotationValue;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.RecordComponentNode;
 
 /**
  * Asm annotations.
@@ -55,6 +55,14 @@ public final class AsmAnnotations {
      * @param node Field node.
      */
     AsmAnnotations(final FieldNode node) {
+        this(node.visibleAnnotations, node.invisibleAnnotations);
+    }
+
+    /**
+     * Constructor.
+     * @param node Record node.
+     */
+    AsmAnnotations(final RecordComponentNode node) {
         this(node.visibleAnnotations, node.invisibleAnnotations);
     }
 
@@ -115,16 +123,8 @@ public final class AsmAnnotations {
      * @return Domain annotation.
      */
     private static BytecodeAnnotation annotation(final AnnotationNode node, final boolean visible) {
-        final List<BytecodeAnnotationValue> properties = new ArrayList<>(0);
-        final List<Object> values = Optional.ofNullable(node.values).orElse(new ArrayList<>(0));
-        for (int index = 0; index < values.size(); index += 2) {
-            properties.add(
-                new AsmAnnotationProperty(
-                    (String) values.get(index),
-                    values.get(index + 1)
-                ).bytecode()
-            );
-        }
-        return new BytecodeAnnotation(node.desc, visible, properties);
+        return new BytecodeAnnotation(
+            node.desc, visible, new AsmAnnotationValues(node.values).bytecode()
+        );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmClass.java
@@ -16,7 +16,6 @@ import org.eolang.jeo.representation.bytecode.BytecodeClassProperties;
 import org.eolang.jeo.representation.bytecode.BytecodeField;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.eolang.jeo.representation.bytecode.BytecodeModule;
-import org.eolang.jeo.representation.bytecode.BytecodeRecordComponent;
 import org.eolang.jeo.representation.bytecode.InnerClass;
 import org.objectweb.asm.tree.ClassNode;
 
@@ -224,13 +223,7 @@ public final class AsmClass {
         } else {
             result = Optional.of(
                 new BytecodeAttribute.RecordComponents(
-                    this.node.recordComponents.stream().map(
-                        rc -> new BytecodeRecordComponent(
-                            rc.name,
-                            rc.descriptor,
-                            rc.signature
-                        )
-                    ).collect(Collectors.toList())
+                    new AsmRecordComponents(this.node.recordComponents).bytecode()
                 )
             );
         }

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmRecordComponents.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmRecordComponents.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.asm;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.eolang.jeo.representation.bytecode.BytecodeRecordComponent;
+import org.objectweb.asm.tree.RecordComponentNode;
+
+/**
+ * Asm record components.
+ * @since 0.15.0
+ */
+final class AsmRecordComponents {
+
+    /**
+     * Nodes of record components.
+     */
+    private final List<RecordComponentNode> nodes;
+
+    /**
+     * Constructor.
+     * @param components List of record component nodes
+     */
+    AsmRecordComponents(final List<RecordComponentNode> components) {
+        this.nodes = Optional.ofNullable(components).orElse(Collections.emptyList());
+    }
+
+    /**
+     * Bytecode record components.
+     * @return List of bytecode record components
+     */
+    public List<BytecodeRecordComponent> bytecode() {
+        return this.nodes.stream()
+            .map(
+                comp -> new BytecodeRecordComponent(
+                    comp.name,
+                    comp.descriptor,
+                    comp.signature,
+                    new AsmAnnotations(comp).bytecode(),
+                    new AsmTypeAnnotations(comp).bytecode()
+                )
+            ).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmTypeAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmTypeAnnotations.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.asm;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotation;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotations;
+import org.objectweb.asm.tree.RecordComponentNode;
+import org.objectweb.asm.tree.TypeAnnotationNode;
+
+/**
+ * Asm type annotations.
+ * @since 0.15.0
+ */
+final class AsmTypeAnnotations {
+
+    /**
+     * Visible type annotations.
+     */
+    private final List<TypeAnnotationNode> visible;
+
+    /**
+     * Invisible type annotations.
+     */
+    private final List<TypeAnnotationNode> invisible;
+
+    /**
+     * Constructor.
+     * @param comp Record component node.
+     */
+    AsmTypeAnnotations(final RecordComponentNode comp) {
+        this(comp.visibleTypeAnnotations, comp.invisibleTypeAnnotations);
+    }
+
+    /**
+     * Constructor.
+     * @param visible Visible type annotations.
+     * @param invisible Invisible type annotations.
+     */
+    private AsmTypeAnnotations(
+        final List<TypeAnnotationNode> visible, final List<TypeAnnotationNode> invisible
+    ) {
+        this.visible = visible;
+        this.invisible = invisible;
+    }
+
+    /**
+     * Convert to bytecode type annotations.
+     * @return Bytecode type annotations.
+     */
+    public BytecodeTypeAnnotations bytecode() {
+        final Stream.Builder<BytecodeTypeAnnotation> annotations = Stream.builder();
+        if (this.visible != null) {
+            this.visible.stream()
+                .map(ann -> AsmTypeAnnotations.parse(ann, true))
+                .forEach(annotations);
+        }
+        if (this.invisible != null) {
+            this.invisible.stream()
+                .map(ann -> AsmTypeAnnotations.parse(ann, false))
+                .forEach(annotations);
+        }
+        return new BytecodeTypeAnnotations(annotations.build().collect(Collectors.toList()));
+    }
+
+    /**
+     * Parse type annotation node.
+     * @param node Type annotation node.
+     * @param visible Visibility of the annotation.
+     * @return Bytecode type annotation.
+     */
+    private static BytecodeTypeAnnotation parse(
+        final TypeAnnotationNode node, final boolean visible
+    ) {
+        return new BytecodeTypeAnnotation(
+            node.typeRef,
+            node.typePath,
+            node.desc,
+            visible,
+            new AsmAnnotationValues(node.values).bytecode()
+        );
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotation.java
@@ -16,6 +16,7 @@ import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.RecordComponentVisitor;
 import org.xembly.Directive;
 
 /**
@@ -108,6 +109,17 @@ public final class BytecodeAnnotation implements BytecodeAnnotationValue {
      * @return This.
      */
     public BytecodeAnnotation write(final FieldVisitor visitor) {
+        final AnnotationVisitor avisitor = visitor.visitAnnotation(this.descr, this.visible);
+        this.values.forEach(property -> property.writeTo(avisitor));
+        return this;
+    }
+
+    /**
+     * Write record component annotation.
+     * @param visitor Visitor.
+     * @return This.
+     */
+    public BytecodeAnnotation write(final RecordComponentVisitor visitor) {
         final AnnotationVisitor avisitor = visitor.visitAnnotation(this.descr, this.visible);
         this.values.forEach(property -> property.writeTo(avisitor));
         return this;

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotationValue.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotationValue.java
@@ -24,5 +24,11 @@ public interface BytecodeAnnotationValue {
      */
     void writeTo(AnnotationVisitor visitor);
 
+    /**
+     * Convert to directives.
+     * @param index Index of the annotation in the list of annotations.
+     * @param format Format of the directives.
+     * @return Directives.
+     */
     Iterable<Directive> directives(int index, Format format);
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAnnotations.java
@@ -15,6 +15,7 @@ import lombok.ToString;
 import org.eolang.jeo.representation.directives.DirectivesAnnotations;
 import org.eolang.jeo.representation.directives.Format;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.RecordComponentVisitor;
 
 /**
  * Bytecode annotations.
@@ -108,5 +109,13 @@ public final class BytecodeAnnotations {
      */
     void write(final int index, final MethodVisitor writer) {
         this.all.forEach(annotation -> annotation.write(index, writer));
+    }
+
+    /**
+     * Write the record component.
+     * @param writer Record component visitor.
+     */
+    void write(final RecordComponentVisitor writer) {
+        this.all.forEach(annotation -> annotation.write(writer));
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttribute.java
@@ -6,6 +6,8 @@ package org.eolang.jeo.representation.bytecode;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.asm.AsmLabels;
@@ -13,12 +15,12 @@ import org.eolang.jeo.representation.directives.DirectivesEnclosingMethod;
 import org.eolang.jeo.representation.directives.DirectivesNestHost;
 import org.eolang.jeo.representation.directives.DirectivesNestMembers;
 import org.eolang.jeo.representation.directives.DirectivesPermittedSubclasses;
+import org.eolang.jeo.representation.directives.DirectivesRecordComponents;
 import org.eolang.jeo.representation.directives.DirectivesSourceFile;
 import org.eolang.jeo.representation.directives.Format;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.xembly.Directive;
-import org.xembly.Directives;
 
 /**
  * Bytecode attribute.
@@ -293,6 +295,14 @@ public interface BytecodeAttribute {
          * Constructor.
          * @param components Components.
          */
+        public RecordComponents(final BytecodeRecordComponent... components) {
+            this(Arrays.asList(components));
+        }
+
+        /**
+         * Constructor.
+         * @param components Components.
+         */
         public RecordComponents(final List<BytecodeRecordComponent> components) {
             this.components = components;
         }
@@ -311,7 +321,13 @@ public interface BytecodeAttribute {
 
         @Override
         public Iterable<Directive> directives(final int index, final Format format) {
-            return new Directives();
+            final AtomicInteger counter = new AtomicInteger(0);
+            return new DirectivesRecordComponents(
+                index,
+                this.components.stream()
+                    .map(component -> component.directives(counter.getAndIncrement(), format))
+                    .collect(Collectors.toList())
+            );
         }
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTypeAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTypeAnnotation.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.bytecode;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.eolang.jeo.representation.directives.DirectivesTypeAnnotation;
+import org.eolang.jeo.representation.directives.Format;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.RecordComponentVisitor;
+import org.objectweb.asm.TypePath;
+
+/**
+ * Bytecode type annotation.
+ * @since 0.15.0
+ */
+@ToString
+@EqualsAndHashCode
+public final class BytecodeTypeAnnotation {
+
+    /**
+     *A reference to the annotated type.
+     */
+    private final int ref;
+
+    /**
+     * The path to the annotated type argument, wildcard bound, array element type,
+     * or static outer type within the referenced type.
+     */
+    private final String path;
+
+    /**
+     * The class descriptor of the annotation class.
+     */
+    private final String desc;
+
+    /**
+     * Visibility of the annotation.
+     */
+    private final boolean visible;
+
+    /**
+     * Properties.
+     */
+    private final List<BytecodeAnnotationValue> values;
+
+    /**
+     * Constructor.
+     * @param ref A reference to the annotated type.
+     * @param path The path to the annotated type argument, wildcard bound, array element type,
+     * @param desc The class descriptor of the annotation class.
+     * @param visible Visibility of the annotation.
+     * @param values Properties.
+     * @checkstyle ParameterNumber (10 lines)
+     */
+    public BytecodeTypeAnnotation(
+        final int ref,
+        final TypePath path,
+        final String desc,
+        final boolean visible,
+        final List<BytecodeAnnotationValue> values
+    ) {
+        this.ref = ref;
+        this.path = path.toString();
+        this.desc = desc;
+        this.visible = visible;
+        this.values = values;
+    }
+
+    /**
+     * Write type annotation.
+     * @param visitor Visitor to write to.
+     */
+    public void write(final RecordComponentVisitor visitor) {
+        final AnnotationVisitor visited = visitor.visitTypeAnnotation(
+            this.ref, TypePath.fromString(this.path), this.desc, this.visible
+        );
+        this.values.forEach(v -> v.writeTo(visited));
+    }
+
+    /**
+     * Convert to directives.
+     * @param index Index of the annotation.
+     * @param format Directives format.
+     * @return Directives.
+     */
+    public DirectivesTypeAnnotation directives(final int index, final Format format) {
+        final AtomicInteger counter = new AtomicInteger(0);
+        return new DirectivesTypeAnnotation(
+            format, index,
+            this.ref,
+            this.path,
+            this.desc,
+            this.visible,
+            this.values.stream()
+                .map(v -> v.directives(counter.getAndIncrement(), format))
+                .collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTypeAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTypeAnnotations.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.bytecode;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.eolang.jeo.representation.directives.DirectivesTypeAnnotations;
+import org.eolang.jeo.representation.directives.Format;
+import org.objectweb.asm.RecordComponentVisitor;
+
+/**
+ * Bytecode type annotations.
+ * @since 0.15.0
+ */
+@ToString
+@EqualsAndHashCode
+public final class BytecodeTypeAnnotations {
+
+    /**
+     * All type annotations.
+     */
+    private final List<BytecodeTypeAnnotation> annotations;
+
+    /**
+     * Constructor.
+     */
+    public BytecodeTypeAnnotations() {
+        this(Collections.emptyList());
+    }
+
+    /**
+     * Constructor.
+     * @param annotations All type annotations.
+     */
+    public BytecodeTypeAnnotations(final BytecodeTypeAnnotation... annotations) {
+        this(Arrays.asList(annotations));
+    }
+
+    /**
+     * Constructor.
+     * @param annotations All type annotations.
+     */
+    public BytecodeTypeAnnotations(final List<BytecodeTypeAnnotation> annotations) {
+        this.annotations = Optional.ofNullable(annotations).orElse(Collections.emptyList());
+    }
+
+    /**
+     * Write to visitor.
+     * @param visitor Visitor to write to.
+     */
+    public void write(final RecordComponentVisitor visitor) {
+        this.annotations.forEach(annotation -> annotation.write(visitor));
+    }
+
+    /**
+     * Convert to directives.
+     * @param format Format of the directives.
+     * @return Directives with the name "annotations".
+     */
+    public DirectivesTypeAnnotations directives(final Format format) {
+        final AtomicInteger index = new AtomicInteger(0);
+        return new DirectivesTypeAnnotations(
+            this.annotations.stream()
+                .map(ann -> ann.directives(index.getAndIncrement(), format))
+                .collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotations.java
@@ -62,10 +62,8 @@ public final class DirectivesAnnotations implements Iterable<Directive> {
         this(
             annotations,
             String.format(
-                String.format(
-                    "annotations-%d",
-                    Math.abs(DirectivesAnnotations.RANDOM.nextInt())
-                )
+                "annotations-%d",
+                Math.abs(DirectivesAnnotations.RANDOM.nextInt())
             )
         );
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesRecordComponent.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesRecordComponent.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.Iterator;
+import org.xembly.Directive;
+
+/**
+ * Directives Record Component.
+ * @since 0.15.0
+ */
+public final class DirectivesRecordComponent implements Iterable<Directive> {
+
+    /**
+     * Directives format.
+     */
+    private final Format format;
+
+    /**
+     * Index.
+     */
+    private final int index;
+
+    /**
+     * Name.
+     */
+    private final String name;
+
+    /**
+     * Descriptor.
+     */
+    private final String descriptor;
+
+    /**
+     * Signature.
+     */
+    private final String signature;
+
+    /**
+     * Bytecode annotations.
+     */
+    private final DirectivesAnnotations annotations;
+
+    /**
+     * Type annotations.
+     */
+    private final DirectivesTypeAnnotations types;
+
+    /**
+     * Constructor.
+     * @param format Directives format.
+     * @param index Component index.
+     * @param name Component name.
+     * @param descriptor Descriptor.
+     * @param signature Signature.
+     * @param annotations Bytecode annotations.
+     * @param types Type annotations.
+     * @checkstyle ParameterNumber (10 lines)
+     */
+    public DirectivesRecordComponent(
+        final Format format,
+        final int index,
+        final String name,
+        final String descriptor,
+        final String signature,
+        final DirectivesAnnotations annotations,
+        final DirectivesTypeAnnotations types
+    ) {
+        this.format = format;
+        this.index = index;
+        this.name = name;
+        this.descriptor = descriptor;
+        this.signature = signature;
+        this.annotations = annotations;
+        this.types = types;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        return new DirectivesJeoObject(
+            "record-component",
+            String.format("rc%d", this.index),
+            new DirectivesValue(this.format, "name", this.name),
+            new DirectivesValue(this.format, "descriptor", this.descriptor),
+            new DirectivesValue(this.format, "signature", this.signature),
+            this.annotations,
+            this.types
+        ).iterator();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesRecordComponents.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesRecordComponents.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.Iterator;
+import java.util.List;
+import org.xembly.Directive;
+
+/**
+ * Record components directives.
+ * @since 0.15.0
+ */
+public final class DirectivesRecordComponents implements Iterable<Directive> {
+
+    /**
+     * Record component index.
+     */
+    private final int index;
+
+    /**
+     * All the record components.
+     */
+    private final List<Iterable<Directive>> components;
+
+    /**
+     * Constructor.
+     * @param index Index of the record component.
+     * @param components All the record components.
+     */
+    public DirectivesRecordComponents(
+        final int index,
+        final List<Iterable<Directive>> components
+    ) {
+        this.index = index;
+        this.components = components;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        return new DirectivesOptionalSeq(
+            String.format("record-components-%d", this.index),
+            this.components
+        ).iterator();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesTypeAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesTypeAnnotation.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+/**
+ * Directives of Type Annotation.
+ * @since 0.15.0
+ */
+public final class DirectivesTypeAnnotation implements Iterable<Directive> {
+
+    /**
+     * Index of the annotation among other annotations.
+     */
+    private final int index;
+
+    /**
+     *A reference to the annotated type.
+     */
+    private final int ref;
+
+    /**
+     * The path to the annotated type argument, wildcard bound, array element type,
+     * or static outer type within the referenced type.
+     */
+    private final String path;
+
+    /**
+     * The class descriptor of the annotation class.
+     */
+    private final String desc;
+
+    /**
+     * Visibility of the annotation.
+     */
+    private final boolean visible;
+
+    /**
+     * Annotation properties.
+     */
+    private final List<Iterable<Directive>> properties;
+
+    /**
+     * Annotation value.
+     */
+    private final Format format;
+
+    /**
+     * Constructor.
+     * @param format Format of the directives.
+     * @param index Index of the annotation among other annotations.
+     * @param ref A reference to the annotated type.
+     * @param path The path to the annotated type argument, wildcard bound, array element type,
+     * @param desc The class descriptor of the annotation class.
+     * @param visible Visibility of the annotation.
+     * @param properties Properties.
+     * @checkstyle ParameterNumber (10 lines)
+     */
+    public DirectivesTypeAnnotation(
+        final Format format,
+        final int index,
+        final int ref,
+        final String path,
+        final String desc,
+        final boolean visible,
+        final List<Iterable<Directive>> properties
+    ) {
+        this.format = format;
+        this.index = index;
+        this.ref = ref;
+        this.path = path;
+        this.desc = desc;
+        this.visible = visible;
+        this.properties = properties;
+    }
+
+    @Override
+    public java.util.Iterator<Directive> iterator() {
+        return new DirectivesSeq(
+            String.format("type-annotation-%d", this.index),
+            Stream.concat(
+                Stream.of(
+                    new DirectivesValue(0, this.format, this.ref),
+                    new DirectivesValue(1, this.format, this.path),
+                    new DirectivesValue(2, this.format, this.desc),
+                    new DirectivesValue(3, this.format, this.visible)
+                ),
+                this.properties.stream()
+            ).map(Directives::new).collect(Collectors.toList())
+        ).iterator();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesTypeAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesTypeAnnotations.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import org.xembly.Directive;
+
+/**
+ * Directives Type Annotations.
+ * @since 0.15.0
+ */
+public final class DirectivesTypeAnnotations implements Iterable<Directive> {
+
+    /**
+     * Random number generator.
+     */
+    private static final Random RANDOM = new SecureRandom();
+
+    /**
+     * Annotations name.
+     */
+    private final String name;
+
+    /**
+     * All the annotations.
+     */
+    private final List<Iterable<Directive>> annotations;
+
+    /**
+     * Constructor.
+     * @param annotations Annotations.
+     */
+    @SafeVarargs
+    public DirectivesTypeAnnotations(final Iterable<Directive>... annotations) {
+        this(Arrays.asList(annotations));
+    }
+
+    /**
+     * Constructor.
+     * @param annotations Annotations.
+     */
+    public DirectivesTypeAnnotations(final List<Iterable<Directive>> annotations) {
+        this(
+            String.format(
+                "type-annotations-%d",
+                Math.abs(DirectivesTypeAnnotations.RANDOM.nextInt())
+            ),
+            annotations
+        );
+    }
+
+    /**
+     * Constructor.
+     * @param name Name.
+     * @param annotations Annotations.
+     */
+    private DirectivesTypeAnnotations(
+        final String name, final List<Iterable<Directive>> annotations) {
+        this.name = name;
+        this.annotations = annotations;
+    }
+
+    @Override
+    public Iterator<Directive> iterator() {
+        return new DirectivesOptionalSeq(
+            this.name,
+            this.annotations
+        ).iterator();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -34,6 +34,10 @@ public final class JcabiXmlNode implements XmlNode {
 
     /**
      * Set of ignored defects.
+     * @todo #1278:30min Remove 'duplicate-names' check suppression.
+     *  We are ignoring 'duplicate-names' check because of records that usually have
+     *  the field names same as the method names which leads to false positives.
+     *  We should find a way to distinguish between fields and methods in XMIR.
      */
     private static final Collection<String> IGNORE = new HashSet<>(
         Arrays.asList(
@@ -41,7 +45,8 @@ public final class JcabiXmlNode implements XmlNode {
             "redundant-object",
             "duplicate-names-in-diff-context",
             "unit-test-missing",
-            "sparse-decoration"
+            "sparse-decoration",
+            "duplicate-names"
         )
     );
 

--- a/src/test/java/org/eolang/jeo/representation/asm/AsmRecordComponentsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/AsmRecordComponentsTest.java
@@ -1,0 +1,153 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.asm;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
+import org.eolang.jeo.representation.bytecode.BytecodeRecordComponent;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotation;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotations;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.TypePath;
+import org.objectweb.asm.TypeReference;
+import org.objectweb.asm.tree.AnnotationNode;
+import org.objectweb.asm.tree.RecordComponentNode;
+import org.objectweb.asm.tree.TypeAnnotationNode;
+
+/**
+ * Tests for {@link AsmRecordComponents}.
+ * @since 0.15.0
+ */
+final class AsmRecordComponentsTest {
+
+    @Test
+    void mapsNullToEmptyList() {
+        MatcherAssert.assertThat(
+            "We expect that when null is passed to the constructor, the bytecode method returns an empty list",
+            new AsmRecordComponents(null).bytecode(),
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    void mapsSingleRecordComponentToBytecodeComponent() {
+        final String name = "name";
+        final String descr = "descriptor";
+        final String sign = "signature";
+        final RecordComponentNode node = new RecordComponentNode(name, descr, sign);
+        MatcherAssert.assertThat(
+            "We expect a single record component node to map to a single bytecode component",
+            new AsmRecordComponents(
+                Collections.singletonList(node)
+            ).bytecode(),
+            Matchers.equalTo(
+                Collections.singletonList(new BytecodeRecordComponent(name, descr, sign))
+            )
+        );
+    }
+
+    @Test
+    void mapsMultipleRecordComponentsToBytecodeComponents() {
+        final String fname = "name1";
+        final String fdescr = "descriptor1";
+        final String fsign = "signature1";
+        final RecordComponentNode first = new RecordComponentNode(fname, fdescr, fsign);
+        final String sname = "name2";
+        final String sdescr = "descriptor2";
+        final String ssign = "signature2";
+        final RecordComponentNode second = new RecordComponentNode(sname, sdescr, ssign);
+        MatcherAssert.assertThat(
+            "We expect multiple record component nodes to map to corresponding bytecode components",
+            new AsmRecordComponents(
+                Arrays.asList(first, second)
+            ).bytecode(),
+            Matchers.equalTo(
+                Arrays.asList(
+                    new BytecodeRecordComponent(fname, fdescr, fsign),
+                    new BytecodeRecordComponent(sname, sdescr, ssign)
+                )
+            )
+        );
+    }
+
+    @Test
+    void mapsSingleRecordComponentWithAnnotationsToBytecodeComponent() {
+        final String name = "name";
+        final String descr = "descriptor";
+        final String sign = "signature";
+        final RecordComponentNode node = new RecordComponentNode(name, descr, sign);
+        node.visibleAnnotations = Collections.singletonList(
+            new AnnotationNode("Lvisible-annotation;")
+        );
+        node.invisibleAnnotations = Collections.singletonList(
+            new AnnotationNode("Linvisible-annotation;")
+        );
+        MatcherAssert.assertThat(
+            "We expect a single record component node with annotations to map to a bytecode component with corresponding annotations",
+            new AsmRecordComponents(
+                Collections.singletonList(node)
+            ).bytecode(),
+            Matchers.equalTo(
+                Collections.singletonList(
+                    new BytecodeRecordComponent(
+                        name,
+                        descr,
+                        sign,
+                        new AsmAnnotations(
+                            node.visibleAnnotations,
+                            node.invisibleAnnotations
+                        ).bytecode(),
+                        new BytecodeTypeAnnotations()
+                    )
+                )
+            )
+        );
+    }
+
+    @Test
+    void mapsRecordComponentWithTypeAnnotationsToBytecodeComponent() {
+        final String name = "name";
+        final String descr = "descriptor";
+        final String sign = "signature";
+        final RecordComponentNode node = new RecordComponentNode(name, descr, sign);
+        final int vref = TypeReference.FIELD;
+        final TypePath vpath = TypePath.fromString("*");
+        final String vdescr = "Lvisible-type-annotation;";
+        node.visibleTypeAnnotations = Collections.singletonList(
+            new TypeAnnotationNode(vref, vpath, vdescr)
+        );
+        final int iref = TypeReference.CLASS_TYPE_PARAMETER;
+        final TypePath itype = TypePath.fromString("0;1;");
+        final String idescr = "Linvisible-type-annotation;";
+        node.invisibleTypeAnnotations = Collections.singletonList(
+            new TypeAnnotationNode(iref, itype, idescr)
+        );
+        MatcherAssert.assertThat(
+            "We expect a single record component node with type annotations to map to a bytecode component",
+            new AsmRecordComponents(Collections.singletonList(node)).bytecode(),
+            Matchers.equalTo(
+                Collections.singletonList(
+                    new BytecodeRecordComponent(
+                        name,
+                        descr,
+                        sign,
+                        new BytecodeAnnotations(),
+                        new BytecodeTypeAnnotations(
+                            new BytecodeTypeAnnotation(
+                                vref, vpath, vdescr, true, Collections.emptyList()
+                            ),
+                            new BytecodeTypeAnnotation(
+                                iref, itype, idescr, false, Collections.emptyList()
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/asm/AsmTypeAnnotationsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/AsmTypeAnnotationsTest.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.asm;
+
+import java.util.Collections;
+import org.eolang.jeo.representation.bytecode.BytecodePlainAnnotationValue;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotation;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotations;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.TypePath;
+import org.objectweb.asm.TypeReference;
+import org.objectweb.asm.tree.RecordComponentNode;
+
+/**
+ * Test case for {@link AsmTypeAnnotations}.
+ * @since 0.15.0
+ */
+final class AsmTypeAnnotationsTest {
+
+    @Test
+    void mapsValuesOfTypeAnnotation() {
+        final RecordComponentNode node = new RecordComponentNode(
+            "name", "Ljava/lang/String;", null
+        );
+        final int ref = TypeReference.FIELD;
+        final TypePath path = TypePath.fromString("*");
+        final String desc = "Lorg/eolang/jeo/SomeAnnotation;";
+        final boolean visible = true;
+        final AnnotationVisitor visited = node.visitTypeAnnotation(
+            new TypeReference(ref).getValue(),
+            path,
+            desc,
+            visible
+        );
+        final String key = "key";
+        final String value = "value";
+        visited.visit(key, value);
+        visited.visitEnd();
+        MatcherAssert.assertThat(
+            "We expect the type annotations to be converted to bytecode type annotations",
+            new AsmTypeAnnotations(node).bytecode(),
+            Matchers.equalTo(
+                new BytecodeTypeAnnotations(
+                    new BytecodeTypeAnnotation(
+                        ref,
+                        path,
+                        desc,
+                        visible,
+                        Collections.singletonList(new BytecodePlainAnnotationValue(key, value))
+                    )
+                )
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeAttributeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeAttributeTest.java
@@ -5,12 +5,17 @@
 package org.eolang.jeo.representation.bytecode;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import org.eolang.jeo.representation.directives.DirectivesAnnotations;
 import org.eolang.jeo.representation.directives.DirectivesEnclosingMethod;
 import org.eolang.jeo.representation.directives.DirectivesNestHost;
 import org.eolang.jeo.representation.directives.DirectivesNestMembers;
 import org.eolang.jeo.representation.directives.DirectivesPermittedSubclasses;
+import org.eolang.jeo.representation.directives.DirectivesRecordComponent;
+import org.eolang.jeo.representation.directives.DirectivesRecordComponents;
 import org.eolang.jeo.representation.directives.DirectivesSourceFile;
+import org.eolang.jeo.representation.directives.DirectivesTypeAnnotations;
 import org.eolang.jeo.representation.directives.Format;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -119,4 +124,37 @@ final class BytecodeAttributeTest {
             )
         );
     }
+
+    @Test
+    void covertsRecordComponentsToDirectives() throws ImpossibleModificationException {
+        final Format format = new Format();
+        final int index = 0;
+        MatcherAssert.assertThat(
+            "We expect to have proper XML representation for RecordComponents",
+            new Xembler(
+                new BytecodeAttribute.RecordComponents(
+                    new BytecodeRecordComponent("n", "d", "s")
+                ).directives(index, format)
+            ).xml(),
+            Matchers.equalTo(
+                new Xembler(
+                    new DirectivesRecordComponents(
+                        index,
+                        Collections.singletonList(
+                            new DirectivesRecordComponent(
+                                format,
+                                0,
+                                "n",
+                                "d",
+                                "s",
+                                new DirectivesAnnotations(),
+                                new DirectivesTypeAnnotations()
+                            )
+                        )
+                    )
+                ).xml()
+            )
+        );
+    }
+
 }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeTypeAnnotationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeTypeAnnotationTest.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.bytecode;
+
+import java.util.Collections;
+import org.eolang.jeo.representation.directives.DirectivesTypeAnnotation;
+import org.eolang.jeo.representation.directives.Format;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.TypePath;
+import org.objectweb.asm.TypeReference;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Tests for {@link BytecodeTypeAnnotation}.
+ * @since 0.15.0
+ */
+final class BytecodeTypeAnnotationTest {
+
+    @Test
+    void convertsToDirectives() throws ImpossibleModificationException {
+        final int ref = TypeReference.FIELD;
+        final TypePath path = TypePath.fromString("*");
+        final String desc = "Lorg/eolang/jeo/Directives;";
+        final boolean visible = true;
+        final Format format = new Format();
+        final BytecodePlainAnnotationValue value = new BytecodePlainAnnotationValue(
+            "format", "json"
+        );
+        final int index = 42;
+        final DirectivesTypeAnnotation directives = new BytecodeTypeAnnotation(
+            ref,
+            path,
+            desc,
+            visible,
+            Collections.singletonList(
+                value
+            )
+        ).directives(index, format);
+        MatcherAssert.assertThat(
+            "We expect the bytecode type annotation to be converted to directives type annotation",
+            new Xembler(directives).xml(),
+            Matchers.equalTo(
+                new Xembler(
+                    new DirectivesTypeAnnotation(
+                        format,
+                        index,
+                        ref,
+                        path.toString(),
+                        desc,
+                        visible,
+                        Collections.singletonList(
+                            value.directives(0, format)
+                        )
+                    )
+                ).xml()
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesRecordComponentTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesRecordComponentTest.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link DirectivesRecordComponent}.
+ * @since 0.15.0
+ */
+final class DirectivesRecordComponentTest {
+
+    @Test
+    void convertsRecordComponentToDirectives() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect generated XML to contain record component",
+            new Xembler(
+                new DirectivesRecordComponent(
+                    new Format(),
+                    0,
+                    "name",
+                    "descr",
+                    null,
+                    new DirectivesAnnotations(),
+                    new DirectivesTypeAnnotations()
+                )
+            ).xml(),
+            XhtmlMatchers.hasXPaths(
+                "./o[@name='rc0']",
+                new JeoBaseXpath("./o[@name='rc0']", "record-component").toXpath()
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesRecordComponentsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesRecordComponentsTest.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Transformers;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link DirectivesRecordComponents}.
+ * @since 0.15.0
+ */
+final class DirectivesRecordComponentsTest {
+
+    @Test
+    void convertsRecordComponentsToDirectives() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect generated XML to contain record components",
+            new Xembler(
+                new DirectivesRecordComponents(
+                    9,
+                    Collections.singletonList(
+                        new DirectivesRecordComponent(
+                            new Format(),
+                            0,
+                            "name",
+                            "descr",
+                            null,
+                            new DirectivesAnnotations(),
+                            new DirectivesTypeAnnotations()
+                        )
+                    )
+                )
+            ).xml(),
+            XhtmlMatchers.hasXPaths(
+                "./o[@name='record-components-9']",
+                new JeoBaseXpath(
+                    "./o[@name='record-components-9']",
+                    "seq.of1"
+                ).toXpath(),
+                "./o/o[@name='rc0']"
+            )
+        );
+    }
+
+    @Test
+    void convertsEmptyRecordComponentsToDirectives() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "We expect generated XML to be empty",
+            new Xembler(
+                new DirectivesRecordComponents(
+                    0,
+                    Collections.emptyList()
+                ), new Transformers.Node()
+            ).xml(),
+            Matchers.is(Matchers.emptyString())
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesTypeAnnotationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesTypeAnnotationTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.TypeReference;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link DirectivesTypeAnnotationTest}.
+ * @since 0.15.0
+ */
+final class DirectivesTypeAnnotationTest {
+
+    @Test
+    void translatesToCorrectXmir() throws ImpossibleModificationException {
+        final Format format = new Format();
+        MatcherAssert.assertThat(
+            "We expect the directives type annotation to be converted to correct XMIR",
+            new Xembler(
+                new DirectivesTypeAnnotation(
+                    format,
+                    42,
+                    TypeReference.FIELD,
+                    "*",
+                    "LAnn;",
+                    true,
+                    Collections.singletonList(
+                        new DirectivesPlainAnnotationValue(
+                            0,
+                            format,
+                            "key",
+                            "value"
+                        )
+                    )
+                )
+            ).xml(),
+            XhtmlMatchers.hasXPaths(
+                "./o[@name='type-annotation-42']",
+                new JeoBaseXpath("./o[@name='type-annotation-42']", "seq.of5").toXpath(),
+                "./o/o[contains(@base,'number') and @name='v0']/o/o[ text()='40-33-00-00-00-00-00-00']",
+                "./o/o[contains(@base,'string') and @name='v1']/o/o[ text()='2A-']",
+                "./o/o[contains(@base,'string') and @name='v2']/o/o[ text()='4C-41-6E-6E-3B']",
+                "./o/o[contains(@base,'true') and @name='v3']",
+                "./o/o[contains(@name,'p0')]"
+            )
+        );
+    }
+}


### PR DESCRIPTION
This PR implements integration tests for Java `records` usage, addressing puzzle `1274-b26068ae`.

Related to #1278