### PR TITLE
feat(#1288): enable 'records' test by updating Java version in invoker.properties

### DIFF
--- a/src/it/records/invoker.properties
+++ b/src/it/records/invoker.properties
@@ -3,10 +3,4 @@
 invoker.goals=clean process-classes -e
 invoker.mavenOpts=-Xss256m
 # We use records feature, which is available since Java 16
-# @todo #1278:90min Enable 'records' test.
-#  We disabled this test because parsing of records from Xmir to Bytecode doesn't work properly.
-#  We only convert records to Xmir, but don't convert them back.
-#  We need to fix this and enable the test again.
-#  To enable the test, change the version to 16+ or higher.
-#  Starting point is {@link BytecodeAttribute.RecordComponents}.
-invoker.java.version = 9999+
+invoker.java.version = 16+

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeAttribute.java
@@ -284,6 +284,8 @@ public interface BytecodeAttribute {
      * Record components attribute.
      * @since 0.14.0
      */
+    @ToString
+    @EqualsAndHashCode
     final class RecordComponents implements BytecodeAttribute {
 
         /**

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesRecordComponents.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesRecordComponents.java
@@ -39,9 +39,12 @@ public final class DirectivesRecordComponents implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        return new DirectivesOptionalSeq(
+        return new DirectivesJeoObject(
+            "record-components",
             String.format("record-components-%d", this.index),
-            this.components
+            new DirectivesOptionalSeq(
+                "all", this.components
+            )
         ).iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesTypeAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesTypeAnnotations.java
@@ -4,11 +4,9 @@
  */
 package org.eolang.jeo.representation.directives;
 
-import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 import org.xembly.Directive;
 
 /**
@@ -16,11 +14,6 @@ import org.xembly.Directive;
  * @since 0.15.0
  */
 public final class DirectivesTypeAnnotations implements Iterable<Directive> {
-
-    /**
-     * Random number generator.
-     */
-    private static final Random RANDOM = new SecureRandom();
 
     /**
      * Annotations name.
@@ -46,13 +39,7 @@ public final class DirectivesTypeAnnotations implements Iterable<Directive> {
      * @param annotations Annotations.
      */
     public DirectivesTypeAnnotations(final List<Iterable<Directive>> annotations) {
-        this(
-            String.format(
-                "type-annotations-%d",
-                Math.abs(DirectivesTypeAnnotations.RANDOM.nextInt())
-            ),
-            annotations
-        );
+        this("type-annotations", annotations);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlAttribute.java
@@ -88,6 +88,8 @@ public final class XmlAttribute {
             result = new XmlNestMembers(this.node).attribute();
         } else if (new JeoFqn("permitted-subclasses").fqn().equals(base)) {
             result = new XmlPermittedSubclasses(this.node).attribute();
+        } else if (new JeoFqn("record-components").fqn().equals(base)) {
+            result = new XmlRecordComponents(this.node).bytecode();
         } else {
             throw new IllegalArgumentException(
                 String.format("Unknown attribute base '%s'", base)

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlRecordComponent.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlRecordComponent.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import java.util.Optional;
+import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
+import org.eolang.jeo.representation.bytecode.BytecodeRecordComponent;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotations;
+
+/**
+ * Xml representation of a record component.
+ * Maps to {@link BytecodeRecordComponent}.
+ * Mirror of {@link org.eolang.jeo.representation.directives.DirectivesRecordComponent}.
+ * @since 0.15.0
+ */
+final class XmlRecordComponent {
+
+    /**
+     * Xml node of record component to parse.
+     */
+    private final XmlJeoObject node;
+
+    /**
+     * Constructor.
+     * @param node Node to parse.
+     */
+    XmlRecordComponent(final XmlNode node) {
+        this(new XmlJeoObject(node));
+    }
+
+    /**
+     * Constructor.
+     * @param node Node to parse.
+     */
+    private XmlRecordComponent(final XmlJeoObject node) {
+        this.node = node;
+    }
+
+    /**
+     * Bytecode representation of the record component.
+     * @return Bytecode record component.
+     */
+    public BytecodeRecordComponent bytecode() {
+        return new BytecodeRecordComponent(
+            this.name(),
+            this.descriptor(),
+            this.signature(),
+            this.annotations(),
+            this.typeAnnotations()
+        );
+    }
+
+    /**
+     * Parses the name of the record component.
+     * @return Name or null if not present.
+     */
+    private String name() {
+        return new XmlValue(this.byName("name")).string();
+    }
+
+    /**
+     * Parses the descriptor of the record component.
+     * @return Descriptor or null if not present.
+     */
+    private String descriptor() {
+        return new XmlValue(this.byName("descriptor")).string();
+    }
+
+    /**
+     * Parses the signature of the record component.
+     * @return Signature or null if not present.
+     */
+    private String signature() {
+        return new XmlValue(this.byName("signature")).string();
+    }
+
+    /**
+     * Parses the annotations of the record component.
+     * @return Annotations.
+     */
+    private BytecodeAnnotations annotations() {
+        return this.byNameOpt("annotations")
+            .map(XmlAnnotations::new)
+            .map(XmlAnnotations::bytecode)
+            .orElseGet(BytecodeAnnotations::new);
+    }
+
+    /**
+     * Parses the type annotations of the record component.
+     * @return Type annotations.
+     */
+    private BytecodeTypeAnnotations typeAnnotations() {
+        return this.byNameOpt("type-annotations")
+            .map(XmlTypeAnnotations::new)
+            .map(XmlTypeAnnotations::bytecode)
+            .orElseGet(BytecodeTypeAnnotations::new);
+    }
+
+    /**
+     * Parses a child node by its name attribute.
+     * @param name Name of the child node.
+     * @return Child node.
+     */
+    private XmlNode byName(final String name) {
+        return this.byNameOpt(name).orElseThrow(
+            () ->
+                new IllegalStateException(
+                    String.format(
+                        "Record component '%s' is not defined in '%s'",
+                        name,
+                        this.node
+                    )
+                )
+        );
+    }
+
+    /**
+     * Parses a child node by its name attribute.
+     * @param name Name of the child node.
+     * @return Child node or empty if not found.
+     */
+    private Optional<XmlNode> byNameOpt(final String name) {
+        return this.node.children()
+            .filter(n -> n.attribute("name").orElse("").equals(name))
+            .findFirst();
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlRecordComponents.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlRecordComponents.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import java.util.stream.Collectors;
+import org.eolang.jeo.representation.bytecode.BytecodeAttribute;
+
+/**
+ * Xml representation of record components.
+ * Maps to {@link BytecodeAttribute.RecordComponents}.
+ * Mirror of {@link org.eolang.jeo.representation.directives.DirectivesRecordComponents}.
+ *
+ * @since 0.15.0
+ */
+final class XmlRecordComponents {
+
+    /**
+     * Xml node of record components to parse.
+     */
+    private final XmlJeoObject node;
+
+    /**
+     * Constructor.
+     * @param xmlnode XML node.
+     */
+    XmlRecordComponents(final XmlNode xmlnode) {
+        this(new XmlJeoObject(xmlnode));
+    }
+
+    /**
+     * Constructor.
+     * @param node Node to parse.
+     */
+    XmlRecordComponents(final XmlJeoObject node) {
+        this.node = node;
+    }
+
+    /**
+     * Convert to bytecode attribute.
+     * @return Bytecode attribute.
+     */
+    public BytecodeAttribute bytecode() {
+        final XmlNode seq = this.node.child(0).orElseThrow(
+            () -> new IllegalStateException(
+                "Record components must contain a sequence as the first child"
+            )
+        );
+        return new BytecodeAttribute.RecordComponents(
+            new XmlSeq(seq).children()
+                .map(XmlRecordComponent::new)
+                .map(XmlRecordComponent::bytecode)
+                .collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlTypeAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlTypeAnnotation.java
@@ -1,0 +1,138 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eolang.jeo.representation.bytecode.BytecodeAnnotationValue;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotation;
+import org.objectweb.asm.TypePath;
+
+/**
+ * Xml representation of a type annotation.
+ * Mirror of {@link org.eolang.jeo.representation.directives.DirectivesTypeAnnotation}.
+ * Maps to {@link BytecodeTypeAnnotation}.
+ * @since 0.15.0
+ */
+final class XmlTypeAnnotation {
+
+    /**
+     * Xml node of type annotation to parse.
+     */
+    private final XmlJeoObject node;
+
+    /**
+     * Constructor.
+     * @param node Node to parse.
+     */
+    XmlTypeAnnotation(final XmlNode node) {
+        this(new XmlJeoObject(node));
+    }
+
+    /**
+     * Constructor.
+     * @param node Node to parse.
+     */
+    private XmlTypeAnnotation(final XmlJeoObject node) {
+        this.node = node;
+    }
+
+    /**
+     * Parse to bytecode type annotation.
+     * @return Bytecode type annotation.
+     */
+    public BytecodeTypeAnnotation bytecode() {
+        return new BytecodeTypeAnnotation(
+            this.ref(),
+            this.path(),
+            this.descriptor(),
+            this.visible(),
+            this.values()
+        );
+    }
+
+    /**
+     * Parses a reference to the annotated type.
+     * @return Reference.
+     */
+    private int ref() {
+        return (int) new XmlValue(
+            this.node.child(0).orElseThrow(
+                () -> new IllegalStateException(
+                    String.format(
+                        "Expected 'ref' node for type annotation: %s",
+                        this.node
+                    )
+                )
+            )
+        ).object();
+    }
+
+    /**
+     * Parses the path to the annotated type argument.
+     * @return Path.
+     */
+    private TypePath path() {
+        return TypePath.fromString(
+            new XmlValue(
+                this.node.child(1).orElseThrow(
+                    () -> new IllegalStateException(
+                        String.format(
+                            "Expected 'path' node for type annotation: %s",
+                            this.node
+                        )
+                    )
+                )
+            ).string()
+        );
+    }
+
+    /**
+     * Parses the class descriptor of the annotation class.
+     * @return Descriptor.
+     */
+    private String descriptor() {
+        return new XmlValue(
+            this.node.child(2).orElseThrow(
+                () -> new IllegalStateException(
+                    String.format(
+                        "Expected 'descriptor' node for type annotation: %s",
+                        this.node
+                    )
+                )
+            )
+        ).string();
+    }
+
+    /**
+     * Parses the visibility of the annotation.
+     * @return Visibility.
+     */
+    private boolean visible() {
+        return (boolean) new XmlValue(
+            this.node.child(3).orElseThrow(
+                () -> new IllegalStateException(
+                    String.format(
+                        "Expected 'visible' node for type annotation: %s",
+                        this.node
+                    )
+                )
+            )
+        ).object();
+    }
+
+    /**
+     * Parses the properties of the annotation.
+     * @return Properties.
+     */
+    private List<BytecodeAnnotationValue> values() {
+        return this.node.children()
+            .map(XmlAnnotationValue::new)
+            .filter(XmlAnnotationValue::isValue)
+            .map(XmlAnnotationValue::bytecode)
+            .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlTypeAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlTypeAnnotations.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import java.util.stream.Collectors;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotations;
+
+/**
+ * Xml representation of type annotations.
+ * Maps to {@link BytecodeTypeAnnotations}.
+ * Mirror of {@link org.eolang.jeo.representation.directives.DirectivesTypeAnnotations}.
+ * @since 0.15.0
+ */
+final class XmlTypeAnnotations {
+    /**
+     * Node of type annotations to parse.
+     */
+    private final XmlJeoObject node;
+
+    /**
+     * Node of type annotations to parse.
+     * @param node Node to parse.
+     */
+    XmlTypeAnnotations(final XmlNode node) {
+        this(new XmlJeoObject(node));
+    }
+
+    /**
+     * Node of type annotations to parse.
+     * @param node Node to parse.
+     */
+    private XmlTypeAnnotations(final XmlJeoObject node) {
+        this.node = node;
+    }
+
+    /**
+     * Parse to bytecode type annotations.
+     * @return Bytecode type annotations.
+     */
+    public BytecodeTypeAnnotations bytecode() {
+        return new BytecodeTypeAnnotations(
+            new XmlSeq(this.node).children()
+                .map(XmlTypeAnnotation::new)
+                .map(XmlTypeAnnotation::bytecode)
+                .collect(Collectors.toList())
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesRecordComponentsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesRecordComponentsTest.java
@@ -7,7 +7,6 @@ package org.eolang.jeo.representation.directives;
 import com.jcabi.matchers.XhtmlMatchers;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Transformers;
@@ -43,9 +42,9 @@ final class DirectivesRecordComponentsTest {
                 "./o[@name='record-components-9']",
                 new JeoBaseXpath(
                     "./o[@name='record-components-9']",
-                    "seq.of1"
+                    "record-components"
                 ).toXpath(),
-                "./o/o[@name='rc0']"
+                "./o/o[@name='all']/o[@name='rc0']"
             )
         );
     }
@@ -60,7 +59,13 @@ final class DirectivesRecordComponentsTest {
                     Collections.emptyList()
                 ), new Transformers.Node()
             ).xml(),
-            Matchers.is(Matchers.emptyString())
+            XhtmlMatchers.hasXPaths(
+                "./o[@name='record-components-0']",
+                new JeoBaseXpath(
+                    "./o[@name='record-components-0']",
+                    "record-components"
+                ).toXpath()
+            )
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlAttributeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlAttributeTest.java
@@ -5,6 +5,7 @@
 package org.eolang.jeo.representation.xmir;
 
 import org.eolang.jeo.representation.bytecode.BytecodeAttribute;
+import org.eolang.jeo.representation.bytecode.BytecodeRecordComponent;
 import org.eolang.jeo.representation.bytecode.InnerClass;
 import org.eolang.jeo.representation.directives.DirectivesAttribute;
 import org.eolang.jeo.representation.directives.Format;
@@ -111,6 +112,20 @@ final class XmlAttributeTest {
         );
         MatcherAssert.assertThat(
             "We expect to parse PermittedSubclasses attribute",
+            new XmlAttribute(
+                new Xembler(attr.directives(0, new Format())).xmlQuietly()
+            ).attribute(),
+            Matchers.equalTo(attr)
+        );
+    }
+
+    @Test
+    void parsesRecordComponents() {
+        final BytecodeAttribute attr = new BytecodeAttribute.RecordComponents(
+            new BytecodeRecordComponent("name", "descr", null)
+        );
+        MatcherAssert.assertThat(
+            "We expect to parse RecordComponents attribute",
             new XmlAttribute(
                 new Xembler(attr.directives(0, new Format())).xmlQuietly()
             ).attribute(),

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlRecordComponentTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlRecordComponentTest.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import java.util.Collections;
+import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
+import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
+import org.eolang.jeo.representation.bytecode.BytecodePlainAnnotationValue;
+import org.eolang.jeo.representation.bytecode.BytecodeRecordComponent;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotation;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotations;
+import org.eolang.jeo.representation.directives.Format;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.TypePath;
+import org.objectweb.asm.TypeReference;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link XmlRecordComponent}.
+ * @since 0.15.0
+ */
+final class XmlRecordComponentTest {
+
+    @Test
+    void parsesRecordComponent() throws ImpossibleModificationException {
+        final BytecodeRecordComponent original = new BytecodeRecordComponent(
+            "name",
+            "descr",
+            null,
+            new BytecodeAnnotations(),
+            new BytecodeTypeAnnotations()
+        );
+        final String xml = new Xembler(original.directives(0, new Format())).xml();
+        MatcherAssert.assertThat(
+            "We expect the record component to be parsed correctly",
+            new XmlRecordComponent(new JcabiXmlNode(xml)).bytecode(),
+            Matchers.equalTo(original)
+        );
+    }
+
+    @Test
+    void parsesRecordComponentWithBytecodeAnnotations() throws ImpossibleModificationException {
+        final BytecodeRecordComponent original = new BytecodeRecordComponent(
+            "name",
+            "descr",
+            null,
+            new BytecodeAnnotations(
+                Collections.singletonList(
+                    new BytecodeAnnotation(
+                        "Lorg/eolang/jeo/Directives;",
+                        true,
+                        Collections.singletonList(
+                            new BytecodePlainAnnotationValue("key", "value")
+                        )
+                    )
+                )
+            ),
+            new BytecodeTypeAnnotations()
+        );
+        MatcherAssert.assertThat(
+            "We expect the record component with bytecode annotations to be parsed correctly",
+            new XmlRecordComponent(
+                new JcabiXmlNode(
+                    new Xembler(original.directives(0, new Format())).xml()
+                )
+            ).bytecode(),
+            Matchers.equalTo(original)
+        );
+    }
+
+    @Test
+    void parsesRecordComponentWithTypeAnnotations() throws ImpossibleModificationException {
+        final BytecodeRecordComponent original = new BytecodeRecordComponent(
+            "name",
+            "descr",
+            null,
+            new BytecodeAnnotations(),
+            new BytecodeTypeAnnotations(
+                Collections.singletonList(
+                    new BytecodeTypeAnnotation(
+                        TypeReference.FIELD,
+                        TypePath.fromString("*"),
+                        "Lorg/eolang/jeo/Directives;",
+                        true,
+                        Collections.singletonList(
+                            new BytecodePlainAnnotationValue("key", "value")
+                        )
+                    )
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            "We expect the record component with type annotations to be parsed correctly",
+            new XmlRecordComponent(
+                new JcabiXmlNode(
+                    new Xembler(original.directives(0, new Format())).xml()
+                )
+            ).bytecode(),
+            Matchers.equalTo(original)
+        );
+    }
+
+}

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlRecordComponentsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlRecordComponentsTest.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
+import org.eolang.jeo.representation.bytecode.BytecodeAttribute;
+import org.eolang.jeo.representation.bytecode.BytecodeRecordComponent;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotations;
+import org.eolang.jeo.representation.directives.Format;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test for {@link XmlRecordComponents}.
+ * @since 0.15.0
+ */
+final class XmlRecordComponentsTest {
+
+    @Test
+    void parsesRecordComponents() throws ImpossibleModificationException {
+        final BytecodeAttribute.RecordComponents original = new BytecodeAttribute.RecordComponents(
+            new BytecodeRecordComponent(
+                "name",
+                "Ljava/lang/String;",
+                null,
+                new BytecodeAnnotations(),
+                new BytecodeTypeAnnotations()
+            )
+        );
+        MatcherAssert.assertThat(
+            "We expect the record components to be parsed correctly",
+            new XmlRecordComponents(
+                new JcabiXmlNode(new Xembler(original.directives(0, new Format())).xml())
+            ).bytecode(),
+            Matchers.equalTo(original)
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlTypeAnnotationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlTypeAnnotationTest.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import java.util.Collections;
+import org.eolang.jeo.representation.bytecode.BytecodePlainAnnotationValue;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotation;
+import org.eolang.jeo.representation.directives.Format;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.TypePath;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link XmlTypeAnnotation}.
+ * @since 0.15.0
+ */
+final class XmlTypeAnnotationTest {
+
+    @Test
+    void parsesTypeAnnotation() throws ImpossibleModificationException {
+        final BytecodeTypeAnnotation annotation = new BytecodeTypeAnnotation(
+            0,
+            TypePath.fromString("*"),
+            "Lorg/eolang/jeo/SomeAnnotation;",
+            true,
+            Collections.singletonList(
+                new BytecodePlainAnnotationValue("key", "value")
+            )
+        );
+        MatcherAssert.assertThat(
+            "We expect the type annotation to be parsed correctly",
+            new XmlTypeAnnotation(
+                new JcabiXmlNode(
+                    new Xembler(annotation.directives(0, new Format())).xml()
+                )
+            ).bytecode(),
+            Matchers.equalTo(annotation)
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlTypeAnnotationsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlTypeAnnotationsTest.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import java.util.Collections;
+import org.eolang.jeo.representation.bytecode.BytecodePlainAnnotationValue;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotation;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotations;
+import org.eolang.jeo.representation.directives.Format;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.TypePath;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link XmlTypeAnnotations}.
+ * @since 0.15.0
+ */
+final class XmlTypeAnnotationsTest {
+
+    @Test
+    void convertsToBytecode() throws ImpossibleModificationException {
+        final BytecodeTypeAnnotations annotations =
+            new BytecodeTypeAnnotations(
+                new BytecodeTypeAnnotation(
+                    1,
+                    TypePath.fromString("*"),
+                    "Lorg/eolang/jeo/SomeAnnotation;",
+                    true,
+                    Collections.singletonList(new BytecodePlainAnnotationValue("key", "value"))
+                )
+            );
+        MatcherAssert.assertThat(
+            "We expect the type annotations to be converted to bytecode type annotations",
+            new XmlTypeAnnotations(
+                new JcabiXmlNode(new Xembler(annotations.directives(new Format())).xml())
+            ).bytecode(),
+            Matchers.equalTo(annotations)
+        );
+    }
+}


### PR DESCRIPTION
This PR enables the 'records' test in `invoker.properties` by updating the Java version to `16+`.
Also, I've added records parsing from XMIR.

Fixes #1288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added XML↔bytecode round-trip support for Java record components.
  - Added XML↔bytecode round-trip support for type annotations.

- Refactor
  - Standardized naming for type-annotations to a deterministic value, ensuring predictable XML output.
  - Restructured record components directives into a dedicated object with a nested “all” collection for clearer structure.

- Tests
  - Added comprehensive tests for record components, type annotations, and related attribute parsing/round-trips.

- Chores
  - Enabled records-related test path by updating the required Java version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->