### PR TITLE
feat(#1277): disassembling java modules

### DIFF
--- a/src/it/modules/README.md
+++ b/src/it/modules/README.md
@@ -1,0 +1,11 @@
+# Modules Integration Test
+
+Integration test that attempts to transform a simple Java program with
+modules usage.
+The integration test verifies that the program can run successfully, and the
+jeo-maven-plugin doesn't break anything.
+If you only need to run this test, use the following command:
+
+```shell
+mvn clean integration-test -Dinvoker.test=modules -DskipTests
+```

--- a/src/it/modules/invoker.properties
+++ b/src/it/modules/invoker.properties
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+invoker.goals=clean process-classes -e
+invoker.mavenOpts=-Xss256m
+# We use records feature, which is available since Java 9
+# @todo #1277:90min Finish modules disassmebly and assembly.
+#  Here, we set the Java version to 9999+ to avoid running this test
+#  in CI, because it uses modules feature, which is available since Java 9.
+#  After the disassembly and assembly of modules is finished,
+#  we should set it to 9+.
+invoker.java.version = 9999+

--- a/src/it/modules/pom.xml
+++ b/src/it/modules/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eolang</groupId>
+  <artifactId>jeo-it</artifactId>
+  <version>@project.version@</version>
+  <packaging>jar</packaging>
+  <description>
+    Integration test that attempts to transform a simple Java program with modules usage.
+    The integration test verifies that the program can run successfully, and the jeo-maven-plugin doesn't break anything.
+    If you only need to run this test, use the following command:
+    "mvn clean integration-test invoker:run -Dinvoker.test=modules -DskipTests"
+  </description>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>9</maven.compiler.release>
+    <stack-size>256M</stack-size>
+    <exec.mainClass>org.eolang.jeo.modules/org.eolang.jeo.modules.App</exec.mainClass>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>jeo-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <xmirVerification>true</xmirVerification>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bytecode-to-eo</id>
+            <goals>
+              <goal>disassemble</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>eo-to-bytecode</id>
+            <goals>
+              <goal>assemble</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <executions>
+          <execution>
+            <id>run-module</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <phase>process-classes</phase>
+            <configuration>
+              <executable>java</executable>
+              <arguments>
+                <argument>--module-path</argument>
+                <modulepath/>
+                <argument>--module</argument>
+                <argument>org.eolang.jeo.modules/org.eolang.jeo.modules.App</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/modules/src/main/java/module-info.java
+++ b/src/it/modules/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+module org.eolang.jeo.modules {
+}

--- a/src/it/modules/src/main/java/org/eolang/jeo/modules/App.java
+++ b/src/it/modules/src/main/java/org/eolang/jeo/modules/App.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.modules;
+
+import java.lang.module.ModuleDescriptor;
+
+public class App {
+    public static void main(String[] args) {
+        Module module = App.class.getModule();
+        System.out.println("Module: " + module);
+
+        // Ensure module has a name
+        if (module.getName() == null) {
+            throw new IllegalStateException("Module name is missing!");
+        }
+
+        // Ensure module has a descriptor
+        ModuleDescriptor descriptor = module.getDescriptor();
+        if (descriptor == null) {
+            throw new IllegalStateException("Module descriptor is missing!");
+        }
+
+        // Ensure this package is part of the module
+        String pkg = App.class.getPackageName();
+        if (!descriptor.packages().contains(pkg)) {
+            throw new IllegalStateException("Package " + pkg + " not in module descriptor!");
+        }
+
+        System.out.println("Module name: " + module.getName());
+        System.out.println("Packages: " + descriptor.packages());
+        System.out.println("Everything looks fine!");
+    }
+}

--- a/src/it/modules/verify.groovy
+++ b/src/it/modules/verify.groovy
@@ -4,5 +4,5 @@
  */
 String log = new File(basedir, 'build.log').text;
 assert log.contains("BUILD SUCCESS")
-assert log.contains("All checks passed.")
+assert log.contains("Everything looks fine!")
 true

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmClass.java
@@ -15,9 +15,9 @@ import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.eolang.jeo.representation.bytecode.BytecodeClassProperties;
 import org.eolang.jeo.representation.bytecode.BytecodeField;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
-import org.eolang.jeo.representation.bytecode.BytecodeModule;
 import org.eolang.jeo.representation.bytecode.InnerClass;
 import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.ModuleNode;
 
 /**
  * ASM-based bytecode parser for Java classes.
@@ -133,10 +133,11 @@ public final class AsmClass {
      */
     private Optional<BytecodeAttribute> module() {
         final Optional<BytecodeAttribute> result;
-        if (this.node.module == null) {
+        final ModuleNode module = this.node.module;
+        if (module == null) {
             result = Optional.empty();
         } else {
-            result = Optional.of(new BytecodeModule());
+            result = Optional.of(new AsmModule(module).bytecode());
         }
         return result;
     }

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmModule.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmModule.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.asm;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.eolang.jeo.representation.bytecode.BytecodeModule;
+import org.eolang.jeo.representation.bytecode.BytecodeModuleExported;
+import org.eolang.jeo.representation.bytecode.BytecodeModuleOpened;
+import org.eolang.jeo.representation.bytecode.BytecodeModuleProvided;
+import org.eolang.jeo.representation.bytecode.BytecodeModuleRequired;
+import org.objectweb.asm.tree.ModuleNode;
+
+/**
+ * ASM-based bytecode parser for Java modules.
+ * @since 0.15.0
+ */
+public final class AsmModule {
+
+    /**
+     * Module node.
+     */
+    private final ModuleNode module;
+
+    /**
+     * Constructor.
+     * @param node The ASM module node to parse.
+     */
+    public AsmModule(final ModuleNode node) {
+        this.module = node;
+    }
+
+    /**
+     * Convert ASM module to domain bytecode module.
+     * @return The domain bytecode module representation.
+     */
+    public BytecodeModule bytecode() {
+        return new BytecodeModule(
+            this.module.name,
+            this.module.access,
+            this.module.version,
+            this.module.mainClass,
+            this.module.packages,
+            AsmModule.requires(this.module),
+            AsmModule.exports(this.module),
+            AsmModule.opens(this.module),
+            AsmModule.provides(this.module),
+            this.module.uses
+        );
+    }
+
+    /**
+     * Module provides.
+     * @param module ASM module node.
+     * @return List of module provides.
+     */
+    private static List<BytecodeModuleProvided> provides(final ModuleNode module) {
+        return Optional.ofNullable(module.provides).orElse(Collections.emptyList())
+            .stream()
+            .map(prov -> new BytecodeModuleProvided(prov.service, prov.providers))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Module opens.
+     * @param module ASM module node.
+     * @return List of module opens.
+     */
+    private static List<BytecodeModuleOpened> opens(final ModuleNode module) {
+        return Optional.ofNullable(module.opens).orElse(Collections.emptyList())
+            .stream()
+            .map(opn -> new BytecodeModuleOpened(opn.packaze, opn.access, opn.modules))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Module exports.
+     * @param module ASM module node.
+     * @return List of module exports.
+     */
+    private static List<BytecodeModuleExported> exports(final ModuleNode module) {
+        return Optional.ofNullable(module.exports).orElse(Collections.emptyList())
+            .stream()
+            .map(exp -> new BytecodeModuleExported(exp.packaze, exp.access, exp.modules))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Module requires.
+     * @param module ASM module node.
+     * @return List of module requirements.
+     */
+    private static List<BytecodeModuleRequired> requires(final ModuleNode module) {
+        return Optional.ofNullable(module.requires).orElse(Collections.emptyList())
+            .stream()
+            .map(req -> new BytecodeModuleRequired(req.module, req.access, req.version))
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeModule.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeModule.java
@@ -4,25 +4,131 @@
  */
 package org.eolang.jeo.representation.bytecode;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.eolang.jeo.representation.asm.AsmLabels;
 import org.eolang.jeo.representation.directives.Format;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.ModuleVisitor;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
 /**
  * Bytecode module.
  * @since 0.14.0
- * @todo #1274:30min Implement disassembling module attribute.
- *  The module attribute is represented by ModuleNode in ASM.
- *  We need to implement the BytecodeModule class to handle this attribute.
  */
+@ToString
+@EqualsAndHashCode
 public final class BytecodeModule implements BytecodeAttribute {
 
+    /** The fully qualified name (using dots) of this module. */
+    private final String name;
+
+    /**
+     * The module's access flags.
+     * Among {@code ACC_OPEN}, {@code ACC_SYNTHETIC} and {@code ACC_MANDATED}.
+     */
+    private final int access;
+
+    /**
+     * The version of this module.
+     * */
+    private final String version;
+
+    /**
+     * The internal name of the main class of this module.
+     */
+    private final String main;
+
+    /**
+     * The internal name of the packages declared by this module.
+     */
+    private final List<String> packages;
+
+    /**
+     * The dependencies of this module.
+     */
+    private final List<BytecodeModuleRequired> requires;
+
+    /**
+     * The packages exported by this module. May be {@literal null}.
+     */
+    private final List<BytecodeModuleExported> exports;
+
+    /**
+     * The packages opened by this module. May be {@literal null}.
+     */
+    private final List<BytecodeModuleOpened> opens;
+
+    /**
+     *  The services provided by this module.
+     *  */
+    private final List<BytecodeModuleProvided> provides;
+
+    /**
+     * The internal names of the services used by this module.
+     */
+    private final List<String> uses;
+
+    /**
+     * Constructor.
+     * @param name Module name
+     * @param access Module access flags
+     * @param version Module version
+     * @param main Module main class
+     * @param packages Module packages
+     * @param requires Module dependencies
+     * @param exports Module exports
+     * @param opens Module opens
+     * @param provides Module provides
+     * @param uses Module uses
+     * @checkstyle ParameterNumber (10 lines)
+     */
+    @SuppressWarnings("PMD.ExcessiveParameterList")
+    public BytecodeModule(
+        final String name,
+        final int access,
+        final String version,
+        final String main,
+        final List<String> packages,
+        final List<BytecodeModuleRequired> requires,
+        final List<BytecodeModuleExported> exports,
+        final List<BytecodeModuleOpened> opens,
+        final List<BytecodeModuleProvided> provides,
+        final List<String> uses
+    ) {
+        this.name = name;
+        this.access = access;
+        this.version = version;
+        this.main = main;
+        this.packages = Optional.ofNullable(packages).orElse(Collections.emptyList());
+        this.requires = requires;
+        this.exports = exports;
+        this.opens = opens;
+        this.provides = provides;
+        this.uses = Optional.ofNullable(uses).orElse(Collections.emptyList());
+    }
+
     @Override
-    public void write(final ClassVisitor ignore) {
-        // Module attribute is not implemented yet.
+    public void write(final ClassVisitor visitor) {
+        final ModuleVisitor module = visitor.visitModule(
+            this.name,
+            this.access,
+            this.version
+        );
+        if (this.main != null) {
+            module.visitMainClass(this.main);
+        }
+        this.packages.forEach(module::visitPackage);
+        this.requires.forEach(req -> req.write(module));
+        this.exports.forEach(exp -> exp.write(module));
+        this.opens.forEach(opn -> opn.write(module));
+        this.provides.forEach(prov -> prov.write(module));
+        this.uses.forEach(module::visitUse);
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeModuleExported.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeModuleExported.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.bytecode;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.objectweb.asm.ModuleVisitor;
+
+/**
+ * A node that represents an exported package with its name and the module that can access to it.
+ * @since 0.15.0
+ */
+@ToString
+@EqualsAndHashCode
+public final class BytecodeModuleExported {
+
+    /**
+     * The internal name of the exported package.
+     */
+    private final String pckg;
+
+    /**
+     * The access flags.
+     * Valid values are {@code ACC_SYNTHETIC} and {@code ACC_MANDATED}.
+     */
+    private final int access;
+
+    /**
+     * The list of modules that can access this exported package.
+     * Specified with fully qualified names using dots.
+     */
+    private final List<String> modules;
+
+    /**
+     * Constructor.
+     * @param pckg The internal name of the exported package
+     * @param access The access flags
+     * @param modules The list of modules that can access this exported package
+     */
+    public BytecodeModuleExported(final String pckg, final int access, final List<String> modules) {
+        this.pckg = pckg;
+        this.access = access;
+        this.modules = Optional.ofNullable(modules).orElse(Collections.emptyList());
+    }
+
+    /**
+     * Writes this exported package to the given module visitor.
+     * @param module Uhe module visitor
+     */
+    public void write(final ModuleVisitor module) {
+        module.visitExport(this.pckg, this.access, this.modules.toArray(new String[0]));
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeModuleOpened.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeModuleOpened.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.bytecode;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.objectweb.asm.ModuleVisitor;
+
+/**
+ * A node that represents an opened package with its name and the module that can access it.
+ * @since 0.15.0
+ */
+@ToString
+@EqualsAndHashCode
+public final class BytecodeModuleOpened {
+
+    /**
+     * The internal name of the opened package.
+     */
+    private final String pckg;
+
+    /**
+     * The access flag of the opened package.
+     * Valid values are among {@code ACC_SYNTHETIC} and {@code ACC_MANDATED}.
+     */
+    private final int access;
+
+    /**
+     * The fully qualified names (using dots) of the modules.
+     */
+    private final List<String> modules;
+
+    /**
+     * Constructor.
+     * @param pckg The internal name of the opened package
+     * @param access The access flag of the opened package
+     * @param modules The fully qualified names (using dots) of the modules
+     */
+    public BytecodeModuleOpened(final String pckg, final int access, final List<String> modules) {
+        this.pckg = pckg;
+        this.access = access;
+        this.modules = Optional.ofNullable(modules).orElse(Collections.emptyList());
+    }
+
+    /**
+     * Writes this opened package to the given module visitor.
+     * @param module The module visitor
+     */
+    public void write(final ModuleVisitor module) {
+        module.visitOpen(this.pckg, this.access, this.modules.toArray(new String[0]));
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeModuleProvided.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeModuleProvided.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.bytecode;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.objectweb.asm.ModuleVisitor;
+
+/**
+ * A node that represents a service and its implementation provided by the current module.
+ * @since 0.15.0
+ */
+@ToString
+@EqualsAndHashCode
+public final class BytecodeModuleProvided {
+
+    /**
+     * The internal name of the service.
+     */
+    private final String service;
+
+    /**
+     * The internal names of the implementations of the service (there is at least one provider).
+     */
+    private final List<String> providers;
+
+    /**
+     * Constructor.
+     * @param service The internal name of the service
+     * @param providers The internal names of the implementations of the service
+     */
+    public BytecodeModuleProvided(final String service, final List<String> providers) {
+        this.service = service;
+        this.providers = Optional.ofNullable(providers).orElse(Collections.emptyList());
+    }
+
+    /**
+     * Writes this provided service to the given module visitor.
+     * @param module The module visitor
+     */
+    public void write(final ModuleVisitor module) {
+        module.visitProvide(this.service, this.providers.toArray(new String[0]));
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeModuleRequired.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeModuleRequired.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.bytecode;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.objectweb.asm.ModuleVisitor;
+
+/**
+ * A node that represents a required module with its name and access of a module descriptor.
+ * @since 0.15.0
+ */
+@ToString
+@EqualsAndHashCode
+public final class BytecodeModuleRequired {
+
+    /**
+     * The fully qualified name (using dots) of the dependence.
+     * */
+    private final String module;
+
+    /**
+     * The access flag of the dependence.
+     * Among {@code ACC_TRANSITIVE}, {@code ACC_STATIC_PHASE},
+     * {@code ACC_SYNTHETIC} and {@code ACC_MANDATED}.
+     */
+    private final int access;
+
+    /**
+     * The module version at compile time.
+     */
+    private final String version;
+
+    /**
+     * Constructor.
+     * @param module The fully qualified name (using dots) of the dependence
+     * @param access The access flag of the dependence
+     * @param version The module version at compile time
+     */
+    public BytecodeModuleRequired(final String module, final int access, final String version) {
+        this.module = module;
+        this.access = access;
+        this.version = version;
+    }
+
+    /**
+     * Writes this required module to the given module visitor.
+     * @param visitor The module visitor
+     */
+    public void write(final ModuleVisitor visitor) {
+        visitor.visitRequire(this.module, this.access, this.version);
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/asm/AsmModuleTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/AsmModuleTest.java
@@ -1,0 +1,156 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.asm;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.eolang.jeo.representation.bytecode.BytecodeModule;
+import org.eolang.jeo.representation.bytecode.BytecodeModuleExported;
+import org.eolang.jeo.representation.bytecode.BytecodeModuleOpened;
+import org.eolang.jeo.representation.bytecode.BytecodeModuleProvided;
+import org.eolang.jeo.representation.bytecode.BytecodeModuleRequired;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.tree.ModuleExportNode;
+import org.objectweb.asm.tree.ModuleNode;
+import org.objectweb.asm.tree.ModuleOpenNode;
+import org.objectweb.asm.tree.ModuleProvideNode;
+import org.objectweb.asm.tree.ModuleRequireNode;
+
+/**
+ * Test case for {@link AsmModule}.
+ * @since 0.15.0
+ */
+final class AsmModuleTest {
+
+    @Test
+    void convertsSimpleModuleToDomainBytecode() {
+        final String name = "name";
+        final int access = 0;
+        final String version = "0.1.0";
+        final ModuleNode node = new ModuleNode(name, access, version);
+        final String main = "main";
+        node.mainClass = main;
+        final BytecodeModule bytecode = new AsmModule(node).bytecode();
+        MatcherAssert.assertThat(
+            "We expect the module to be converted to domain bytecode correctly",
+            bytecode,
+            org.hamcrest.Matchers.equalTo(
+                new BytecodeModule(
+                    name,
+                    access,
+                    version,
+                    main,
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    Collections.emptyList()
+                )
+            )
+        );
+    }
+
+    @Test
+    void convertsModuleWithPackagesToDomainBytecode() {
+        final String name = "name";
+        final int access = 0;
+        final String version = "0.1.0";
+        final ModuleNode node = new ModuleNode(
+            name,
+            access,
+            version
+        );
+        final String main = "main";
+        node.mainClass = main;
+        node.packages = new ArrayList<>(2);
+        final String example = "com.example";
+        final String sample = "org.sample";
+        node.packages.add(example);
+        node.packages.add(sample);
+        final BytecodeModule bytecode = new AsmModule(node).bytecode();
+        MatcherAssert.assertThat(
+            "We expect the module with packages to be converted to domain bytecode correctly",
+            bytecode,
+            org.hamcrest.Matchers.equalTo(
+                new BytecodeModule(
+                    name,
+                    access,
+                    version,
+                    main,
+                    Arrays.asList(example, sample),
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    Collections.emptyList()
+                )
+            )
+        );
+    }
+
+    @Test
+    void convertsModuleWithEverythingToDomainBytecode() {
+        final String name = "name";
+        final int access = 0;
+        final String version = "0.1.0";
+        final ModuleNode node = new ModuleNode(
+            name,
+            access,
+            version
+        );
+        final String main = "main";
+        node.mainClass = main;
+        node.packages = new ArrayList<>(2);
+        final String example = "com.example";
+        final String sample = "org.sample";
+        node.packages.add(example);
+        node.packages.add(sample);
+        node.requires = new ArrayList<>(1);
+        node.requires.add(new ModuleRequireNode("required", 0, "0.1.1"));
+        node.exports = new ArrayList<>(1);
+        final List<String> emodules = Collections.singletonList("m1");
+        node.exports.add(new ModuleExportNode("exported", 0, emodules));
+        node.opens = new ArrayList<>(1);
+        final List<String> omodules = Collections.singletonList("m2");
+        node.opens.add(new ModuleOpenNode("opened", 0, omodules));
+        node.provides = new ArrayList<>(1);
+        final List<String> impls = new ArrayList<>(1);
+        impls.add("impl");
+        node.provides.add(new ModuleProvideNode("service", impls));
+        node.uses = new ArrayList<>(1);
+        node.uses.add("used");
+        final BytecodeModule bytecode = new AsmModule(node).bytecode();
+        MatcherAssert.assertThat(
+            "We expect the module with everything to be converted to domain bytecode correctly",
+            bytecode,
+            org.hamcrest.Matchers.equalTo(
+                new BytecodeModule(
+                    name,
+                    access,
+                    version,
+                    main,
+                    Arrays.asList(example, sample),
+                    Collections.singletonList(
+                        new BytecodeModuleRequired("required", 0, "0.1.1")
+                    ),
+                    Collections.singletonList(
+                        new BytecodeModuleExported("exported", 0, emodules)
+                    ),
+                    Collections.singletonList(
+                        new BytecodeModuleOpened("opened", 0, omodules)
+                    ),
+                    Collections.singletonList(
+                        new BytecodeModuleProvided("service", impls)
+                    ),
+                    Collections.singletonList("used")
+                )
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeModuleTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeModuleTest.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.bytecode;
+
+import java.util.Collections;
+import org.eolang.jeo.representation.asm.AsmModule;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.tree.ClassNode;
+
+/**
+ * Test case for {@link BytecodeModule}.
+ * @since 0.15.0
+ */
+final class BytecodeModuleTest {
+
+    @Test
+    void writesModuleToAsmClass() {
+        final BytecodeModule original = new BytecodeModule(
+            "name",
+            0,
+            "0.1.0",
+            "main",
+            Collections.singletonList("org.eolang.jeo"),
+            Collections.singletonList(new BytecodeModuleRequired("required", 0, "0.1.0")),
+            Collections.singletonList(
+                new BytecodeModuleExported("exported", 1, Collections.singletonList("m1"))
+            ),
+            Collections.singletonList(
+                new BytecodeModuleOpened("opened", 2, Collections.singletonList("m2"))
+            ),
+            Collections.singletonList(
+                new BytecodeModuleProvided("provided", Collections.singletonList("impl"))
+            ),
+            Collections.singletonList("used")
+        );
+        final ClassNode node = new ClassNode();
+        original.write(node);
+        MatcherAssert.assertThat(
+            "We expect the module to be written to ASM class and read back correctly",
+            new AsmModule(node.module).bytecode(),
+            Matchers.equalTo(original)
+        );
+    }
+}


### PR DESCRIPTION
In this PR I've implemented disassembling of `module` feature of bytecote. The next step is to implement bytecode -> XMIR -> bytecode transformation.

Fixes #1277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced support for Java modules: read, write, and preserve module metadata during build and execution.

- Tests
  - Added an integration test that runs a modular Java app to validate module handling (temporarily skipped in CI).
  - Added unit tests covering module conversion and round-trip serialization.

- Documentation
  - Added instructions for running the new modules integration test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->