### PR TITLE
fix(#1282): prevent empty signatures from being added to variable table

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/LocalVariable.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/LocalVariable.java
@@ -106,10 +106,16 @@ public final class LocalVariable implements BytecodeAttribute {
 
     @Override
     public void write(final MethodVisitor method, final AsmLabels labels) {
+        final String sig;
+        if (this.signature == null || this.signature.isEmpty()) {
+            sig = null;
+        } else {
+            sig = this.signature;
+        }
         method.visitLocalVariable(
             this.name,
             this.descriptor,
-            this.signature,
+            sig,
             labels.label(this.start),
             labels.label(this.end),
             this.index


### PR DESCRIPTION
This PR fixes a bug in the `LocalVariable` handling.

```java
 * The problem lies in the 'signature' field of the LocalVariableNode,
 * if it is null, we save an empty string in XMIR and then try to decode it back into bytecode,
 * which leads to saving an empty signature in the variable table of the method,
 * instead of (expected) null.
```

Related to #1282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved an issue where absent local variable signatures could be emitted as empty strings in bytecode. Such signatures are now correctly omitted, improving fidelity with original bytecode and compatibility with bytecode tooling.

- Tests
  - Added a regression test ensuring that round-tripping bytecode does not introduce empty local variable signatures, safeguarding against future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->