### PR TITLE
feat(#1326): handle non-existent input directory with warning and return empty collection

### DIFF
--- a/src/main/java/org/eolang/jeo/BytecodeClasses.java
+++ b/src/main/java/org/eolang/jeo/BytecodeClasses.java
@@ -4,10 +4,12 @@
  */
 package org.eolang.jeo;
 
+import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -79,20 +81,25 @@ final class BytecodeClasses implements Classes {
                 "The classes directory is not set, jeo-maven-plugin does not know where to look for classes."
             );
         }
-        if (!Files.exists(this.input)) {
-            throw new IllegalStateException(
+        final Collection<Path> result;
+        if (Files.exists(this.input)) {
+            try (Stream<Path> walk = Files.walk(this.input)) {
+                result = walk
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(".class"))
+                    .collect(Collectors.toList());
+            }
+        } else {
+            Logger.warn(
+                this,
                 String.format(
                     "The classes directory '%s' does not exist, jeo-maven-plugin does not know where to look for classes.",
                     this.input
                 )
             );
+            result = Collections.emptyList();
         }
-        try (Stream<Path> walk = Files.walk(this.input)) {
-            return walk
-                .filter(Files::isRegularFile)
-                .filter(path -> path.toString().endsWith(".class"))
-                .collect(Collectors.toList());
-        }
+        return result;
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/BytecodeClassesTest.java
+++ b/src/test/java/org/eolang/jeo/BytecodeClassesTest.java
@@ -25,4 +25,14 @@ final class BytecodeClassesTest {
             Matchers.equalTo(path.toString())
         );
     }
+
+    @Test
+    void doesNotThrowExceptionOnAbsentDirectory() {
+        final Path path = Paths.get("/dev/null/absent");
+        MatcherAssert.assertThat(
+            "BytecodeClasses should handle empty directories without throwing exceptions",
+            new BytecodeClasses(path).all().count(),
+            Matchers.equalTo(0L)
+        );
+    }
 }


### PR DESCRIPTION
This PR updates the `jeo-maven-plugin` to handle non-existent input directories by logging a warning and returning an empty collection of classes.

Fixes #1326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when the expected input directory is missing by returning an empty result instead of failing; added a warning log to inform when the directory is absent.

* **Tests**
  * Added a unit test to verify graceful handling of absent directories, asserting zero results are returned without throwing exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->