### PR TITLE
fix(#1333): handle missing child node in XmlMethodParam for bytecode generation

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethodParam.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethodParam.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import java.util.Optional;
 import org.eolang.jeo.representation.EncodedString;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodParameter;
 import org.eolang.jeo.representation.directives.JeoFqn;
@@ -70,7 +71,7 @@ public final class XmlMethodParam {
      * @return Name.
      */
     private String name() {
-        return this.child("name").string();
+        return this.ochild("name").map(XmlValue::string).orElse(null);
     }
 
     /**
@@ -95,19 +96,26 @@ public final class XmlMethodParam {
      * @return Child node.
      */
     private XmlValue child(final String name) {
-        return new XmlValue(
-            this.root.children()
-                .filter(node -> XmlMethodParam.hasName(node, name))
-                .findFirst()
-                .orElseThrow(
-                    () -> new IllegalStateException(
-                        String.format(
-                            "Child with attribute 'as'='%s' not found in node '%s'", name,
-                            this.root
-                        )
-                    )
+        return this.ochild(name).orElseThrow(
+            () -> new IllegalStateException(
+                String.format(
+                    "Child with attribute 'name'='%s' not found in node '%s'", name,
+                    this.root
                 )
+            )
         );
+    }
+
+    /**
+     * Child node with the given name.
+     * @param name Name of the child node.
+     * @return Child node.
+     */
+    private Optional<XmlValue> ochild(final String name) {
+        return this.root.children()
+            .filter(node -> XmlMethodParam.hasName(node, name))
+            .findFirst()
+            .map(XmlValue::new);
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodParamTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodParamTest.java
@@ -11,6 +11,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
+import org.xembly.Directives;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
@@ -32,6 +33,29 @@ final class XmlMethodParamTest {
             "Can't convert XML param to bytecode",
             new XmlMethodParam(
                 new NativeXmlNode(new Xembler(expected.directives(new Format())).xml())
+            ).bytecode(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    void parsesMethodParamWithoutName() throws ImpossibleModificationException {
+        final BytecodeMethodParameter expected = new BytecodeMethodParameter(
+            0,
+            null,
+            Opcodes.ACC_FINAL,
+            Type.getType("Ljava/lang/String;")
+        );
+        MatcherAssert.assertThat(
+            "Can't parse XML param without name",
+            new XmlMethodParam(
+                new JcabiXmlNode(
+                    new Xembler(
+                        new Directives(expected.directives(new Format()))
+                            .xpath(".//o[@name='name']")
+                            .remove()
+                    ).xml()
+                )
             ).bytecode(),
             Matchers.equalTo(expected)
         );


### PR DESCRIPTION
This PR enhances the `XmlMethodParam` class to handle optional child nodes, addressing the issue with the missing "name"  attribute in generated params.

Related to #1333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved XML parsing to gracefully handle method parameters without a name, preventing errors and allowing processing to continue.
  - Enhanced error messages when required child attributes are missing, making issues easier to diagnose.

- Tests
  - Added a unit test to verify correct handling of parameters with missing names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->