### PR TITLE
feat(#1348): add `XmlExceptions` representation for method exception parsing

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlExceptions.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlExceptions.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * XML representation of method exceptions.
+ * @since 0.15.0
+ */
+public final class XmlExceptions {
+
+    /**
+     * XML node representing the exceptions.
+     */
+    private final XmlSeq node;
+
+    /**
+     * Constructor.
+     * @param node XML node representing the exceptions.
+     */
+    XmlExceptions(final XmlNode node) {
+        this(new XmlSeq(node));
+    }
+
+    /**
+     * Constructor.
+     * @param node XML node representing the exceptions.
+     */
+    private XmlExceptions(final XmlSeq node) {
+        this.node = node;
+    }
+
+    /**
+     * Checks if the node represents exceptions.
+     * @return True if the node is named "exceptions", false otherwise.
+     */
+    public boolean isExceptions() {
+        final boolean res;
+        if (this.node.named()) {
+            final String name = this.node.name();
+            res = "exceptions".equals(name);
+        } else {
+            res = false;
+        }
+        return res;
+    }
+
+    /**
+     * Converts the XML exceptions to a list of exception class names.
+     * @return List of exception class names.
+     */
+    public List<String> bytecode() {
+        try {
+            return this.node.children()
+                .map(XmlValue::new)
+                .map(XmlValue::string)
+                .collect(Collectors.toList());
+        } catch (final IllegalArgumentException exception) {
+            throw new IllegalStateException(
+                String.format("Failed to parse exceptions in the node: %s", this.node),
+                exception
+            );
+        }
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -146,8 +146,9 @@ public final class XmlMethod {
         } catch (final IllegalArgumentException exception) {
             throw new ParsingException(
                 String.format(
-                    "Can't transform method '%s' to bytecode",
-                    this.name()
+                    "Can't transform method '%s' to bytecode, node: '%s",
+                    this.name(),
+                    this.node
                 ),
                 exception
             );
@@ -396,14 +397,11 @@ public final class XmlMethod {
      */
     private String[] exceptions() {
         return this.node.children()
-            .map(XmlSeq::new)
-            .filter(XmlSeq::named)
-            .filter(seq -> seq.name().contains("exceptions"))
+            .map(XmlExceptions::new)
+            .filter(XmlExceptions::isExceptions)
             .findFirst()
-            .map(XmlSeq::children)
+            .map(n -> n.bytecode().stream())
             .orElse(Stream.empty())
-            .map(XmlValue::new)
-            .map(XmlValue::string)
             .toArray(String[]::new);
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlSeq.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlSeq.java
@@ -5,6 +5,7 @@
 package org.eolang.jeo.representation.xmir;
 
 import java.util.stream.Stream;
+import lombok.ToString;
 
 /**
  * Xml representation of a sequence of XML nodes.
@@ -13,6 +14,7 @@ import java.util.stream.Stream;
  * </p>
  * @since 0.11.0
  */
+@ToString
 final class XmlSeq {
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
@@ -11,6 +11,7 @@ import org.eolang.jeo.representation.bytecode.BytecodeLine;
 import org.eolang.jeo.representation.bytecode.BytecodeMaxs;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodProperties;
+import org.eolang.jeo.representation.bytecode.BytecodeTryCatchBlock;
 import org.eolang.jeo.representation.directives.DirectivesAnnotation;
 import org.eolang.jeo.representation.directives.DirectivesMethod;
 import org.eolang.jeo.representation.directives.DirectivesMethodProperties;
@@ -154,4 +155,28 @@ final class XmlMethodTest {
         );
     }
 
+    /**
+     * Ensures that a method with try-catch blocks is correctly parsed from XML to bytecode.
+     * Pay attention that the name of the method contains 'exceptions' word.
+     * This name caused issues in parsing:
+     * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/1348">#1348</a>
+     * @throws ImpossibleModificationException if something goes wrong
+     */
+    @Test
+    void parsesWithExceptions() throws ImpossibleModificationException {
+        final BytecodeMethod original = new BytecodeMethod("exceptionsAndFailedTasks")
+            .trycatch(
+                new BytecodeTryCatchBlock(
+                    "start",
+                    "end",
+                    "handler",
+                    "java/io/IOException"
+                )
+            );
+        MatcherAssert.assertThat(
+            "We expect that method with try-catch blocks will be correctly parsed",
+            new XmlMethod(new JcabiXmlNode(new Xembler(original.directives(1)).xml())).bytecode(),
+            Matchers.equalTo(original)
+        );
+    }
 }


### PR DESCRIPTION
This PR introduces the `XmlExceptions` class to improve the readability of parsing error messages (this error happens during the 'assemble' goal). It also fixes the bug related to methods containing `exceptions` in the name together with several `exceptions` in the signature. See the tests for more info.

Related to #1348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for parsing method exceptions/try-catch blocks from XML into bytecode.
* Refactor
  * Streamlined exceptions extraction for methods and improved robustness of XML-to-bytecode transformation.
  * Enhanced error messages with richer context to aid troubleshooting.
  * Added readable string output for XML sequences to improve diagnostics.
* Tests
  * Introduced a test validating correct parsing of try-catch blocks from XML to bytecode, increasing coverage around exception handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->