### PR TITLE
feat(#1240): add debug logging option to reduce disassemble log noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,32 @@ To enable them, you need to set `xmirVerification` to `true`:
 </configuration>
 ```
 
+### Extend Logging Output
+
+You can extend the logging output of the plugin by setting the `debug` parameter
+to `true`:
+
+```xml
+<configuration>
+  <debug>true</debug>
+</configuration>
+```
+
+This will enable more detailed logging output, which can be useful for debugging
+purposes.
+
+Without the `debug` parameter:
+
+```txt
+1/3 WithoutPackage.xmir (9Kb) disassembled in 1s
+```
+
+With the `debug` parameter:
+
+```txt
+1/3 .../WithoutPackage.class disassembled to .../WithoutPackage.xmir (9Kb) in 1s
+```
+
 ## Run Without a POM File
 
 You can run the plugin in a project that does not contain a `pom.xml` file.  

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.5.18</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/src/it/bytecode-to-eo/pom.xml
+++ b/src/it/bytecode-to-eo/pom.xml
@@ -30,6 +30,7 @@
           <omitListings>false</omitListings>
           <omitComments>false</omitComments>
           <prettyXmir>false</prettyXmir>
+          <debug>true</debug>
         </configuration>
         <executions>
           <execution>

--- a/src/it/custom-transformations/pom.xml
+++ b/src/it/custom-transformations/pom.xml
@@ -30,6 +30,7 @@
         <configuration>
           <modifiers>true</modifiers>
           <xmirVerification>true</xmirVerification>
+          <debug>true</debug>
         </configuration>
         <executions>
           <execution>

--- a/src/it/excludes-includes/pom.xml
+++ b/src/it/excludes-includes/pom.xml
@@ -49,6 +49,7 @@
         <configuration>
           <xmirVerification>true</xmirVerification>
           <omitComments>false</omitComments>
+          <debug>true</debug>
           <excludes>
             <exclude>ignored/**/*.class</exclude>
           </excludes>

--- a/src/main/java/org/eolang/jeo/AssembleMojo.java
+++ b/src/main/java/org/eolang/jeo/AssembleMojo.java
@@ -122,6 +122,14 @@ public final class AssembleMojo extends AbstractMojo {
     )
     private boolean disabled;
 
+    /**
+     * Enable debug logging for the assembling process.
+     * @since 0.15.0
+     * @checkstyle MemberNameCheck (6 lines)
+     */
+    @Parameter(property = "jeo.assemble.debug", defaultValue = "false")
+    private boolean debug;
+
     @Override
     public void execute() throws MojoExecutionException {
         try {
@@ -136,7 +144,8 @@ public final class AssembleMojo extends AbstractMojo {
                 }
                 new Assembler(
                     this.sourcesDir.toPath(),
-                    this.outputDir.toPath()
+                    this.outputDir.toPath(),
+                    this.debug
                 ).assemble();
                 if (this.skipVerification) {
                     Logger.info(this, "Bytecode verification is disabled, skipping");

--- a/src/main/java/org/eolang/jeo/BytecodeClasses.java
+++ b/src/main/java/org/eolang/jeo/BytecodeClasses.java
@@ -44,6 +44,11 @@ final class BytecodeClasses implements Classes {
     }
 
     @Override
+    public long total() {
+        return this.all().count();
+    }
+
+    @Override
     public Path root() {
         return this.input;
     }

--- a/src/main/java/org/eolang/jeo/Classes.java
+++ b/src/main/java/org/eolang/jeo/Classes.java
@@ -14,6 +14,12 @@ import java.util.stream.Stream;
 interface Classes {
 
     /**
+     * Total number of class files.
+     * @return Total count of class files
+     */
+    long total();
+
+    /**
      * Root directory containing the class files.
      * @return Path to the root directory
      */

--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -221,6 +221,14 @@ public final class DisassembleMojo extends AbstractMojo {
     @SuppressWarnings("PMD.ImmutableField")
     private Set<String> excludes = new SetOf<>();
 
+    /**
+     * Enable debug logging for the disassembly process.
+     * @since 0.15.0
+     * @checkstyle MemberNameCheck (6 lines)
+     */
+    @Parameter(property = "jeo.disassemble.debug", defaultValue = "false")
+    private boolean debug;
+
     @Override
     public void execute() throws MojoExecutionException {
         try {
@@ -251,7 +259,8 @@ public final class DisassembleMojo extends AbstractMojo {
                         Format.WITH_LISTING, listings,
                         Format.PRETTY, this.prettyXmir,
                         Format.MODE, this.mode
-                    )
+                    ),
+                    this.debug
                 ).disassemble();
                 if (this.xmirVerification) {
                     Logger.info(this, "Verifying all the XMIR files after disassembling");

--- a/src/main/java/org/eolang/jeo/FilteredClasses.java
+++ b/src/main/java/org/eolang/jeo/FilteredClasses.java
@@ -58,6 +58,11 @@ final class FilteredClasses implements Classes {
     }
 
     @Override
+    public long total() {
+        return this.all().count();
+    }
+
+    @Override
     public Path root() {
         return this.original.root();
     }

--- a/src/main/java/org/eolang/jeo/XmirFiles.java
+++ b/src/main/java/org/eolang/jeo/XmirFiles.java
@@ -35,6 +35,14 @@ final class XmirFiles {
     }
 
     /**
+     * Count of all representations.
+     * @return Count of all XMIR files in the directory tree
+     */
+    public long total() {
+        return this.all().count();
+    }
+
+    /**
      * All representations.
      * @return Stream of paths to all XMIR files in the directory tree
      */

--- a/src/main/java/org/eolang/jeo/representation/Counter.java
+++ b/src/main/java/org/eolang/jeo/representation/Counter.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A simple counter class that wraps an AtomicInteger.
+ * This class is thread-safe.
+ * @since 0.15
+ */
+public final class Counter {
+
+    /**
+     * Total.
+     */
+    private final long all;
+
+    /**
+     * Current.
+     */
+    private final AtomicLong current;
+
+    /**
+     * Constructor.
+     * @param all Total number of items.
+     */
+    public Counter(final long all) {
+        this(Counter.safe(all), new AtomicLong(0));
+    }
+
+    /**
+     * Constructor.
+     * @param all Total number of items.
+     * @param current Current item number.
+     */
+    private Counter(final long all, final AtomicLong current) {
+        this.all = all;
+        this.current = current;
+    }
+
+    /**
+     * Get the current count and increment it.
+     * @return The current count in the format "current/total".
+     */
+    public String next() {
+        return String.format("%d/%d", this.current.incrementAndGet(), this.all);
+    }
+
+    /**
+     * Ensure the total number of items is non-negative.
+     * @param all Total number of items.
+     * @return The total number of items if valid.
+     * @throws IllegalArgumentException if the total number of items is negative.
+     */
+    private static long safe(final long all) {
+        if (all < 0) {
+            throw new IllegalArgumentException("Total number of items cannot be negative");
+        }
+        return all;
+    }
+}

--- a/src/test/java/benchmark/AssembleBenchmark.java
+++ b/src/test/java/benchmark/AssembleBenchmark.java
@@ -68,7 +68,7 @@ public class AssembleBenchmark {
         this.dir.toFile().deleteOnExit();
         Files.createDirectories(input);
         Files.write(input.resolve("test.xmir"), new Representation().disassemble());
-        this.assembler = new Assembler(input, this.dir);
+        this.assembler = new Assembler(input, this.dir, false);
     }
 
     @Benchmark

--- a/src/test/java/org/eolang/jeo/FilteredClassesTest.java
+++ b/src/test/java/org/eolang/jeo/FilteredClassesTest.java
@@ -121,6 +121,11 @@ final class FilteredClassesTest {
         }
 
         @Override
+        public long total() {
+            return this.all().count();
+        }
+
+        @Override
         public Path root() {
             return this.dir;
         }

--- a/src/test/java/org/eolang/jeo/representation/CounterTest.java
+++ b/src/test/java/org/eolang/jeo/representation/CounterTest.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Counter}.
+ * @since 0.15.0
+ */
+final class CounterTest {
+
+    @Test
+    void incrementsCurrentCountCorrectly() {
+        final Counter counter = new Counter(3);
+        MatcherAssert.assertThat(
+            "First call should return 1/3",
+            counter.next(),
+            Matchers.is("1/3")
+        );
+        MatcherAssert.assertThat(
+            "Second call should return 2/3",
+            counter.next(),
+            Matchers.is("2/3")
+        );
+        MatcherAssert.assertThat(
+            "Third call should return 3/3",
+            counter.next(),
+            Matchers.is("3/3")
+        );
+    }
+
+    @Test
+    void throwsExceptionForNegativeTotal() {
+        MatcherAssert.assertThat(
+            "We should get the correct exception message",
+            Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new Counter(-1)
+            ).getMessage(),
+            Matchers.is("Total number of items cannot be negative")
+        );
+    }
+
+    @Test
+    void handlesZeroTotalWithoutIncrementing() {
+        final Counter counter = new Counter(0);
+        MatcherAssert.assertThat(
+            "First call should return 1/0",
+            counter.next(),
+            Matchers.is("1/0")
+        );
+        MatcherAssert.assertThat(
+            "Second call should return 2/0",
+            counter.next(),
+            Matchers.is("2/0")
+        );
+    }
+
+    @Test
+    void handlesLargeCountsWithoutOverflow() {
+        final Counter counter = new Counter(Integer.MAX_VALUE);
+        MatcherAssert.assertThat(
+            "First call should return 1/MAX_VALUE",
+            counter.next(),
+            Matchers.is(String.format("1/%d", Integer.MAX_VALUE))
+        );
+        MatcherAssert.assertThat(
+            "Second call should return 2/MAX_VALUE",
+            counter.next(),
+            Matchers.is(String.format("2/%d", Integer.MAX_VALUE))
+        );
+    }
+}


### PR DESCRIPTION
This PR enhances logging output for the disassembly process by adding a `debug` parameter, allowing for more concise log messages when debug logging is disabled.

Related to #1240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional debug/verbose logging for assemble and disassemble runs, with per-item progress counters and richer end-of-task messages.
- Documentation
  - Added "Extend Logging Output" section showing how to enable verbose logging with configuration examples and before/after log samples.
- Tests
  - New unit tests for the progress counter; updated benchmarks and tests to account for the new logging options.
- Chores
  - Scoped logging dependency to tests and enabled debug mode in integration test configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->