### PR TITLE
chore(#1354): update version in README to 0.14.12 using GitHub action

### DIFF
--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -21,7 +21,8 @@ jobs:
       - run: |-
           git fetch --tags --force && \
           latest=$(git tag --sort=creatordate | tail -1) && \
-          sed -E -i "s/<version>[^<]+/<version>${latest}/g" README.md
+          prev=$(grep -oE '<version>[^<]+' README.md | sed 's/<version>//' | head -1) && \
+          sed -i "s/${prev}/${latest}/g" README.md
       - uses: peter-evans/create-pull-request@v7
         with:
           sign-commits: true

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ configuration to your `pom.xml` file:
     <plugin>
       <groupId>org.eolang</groupId>
       <artifactId>jeo-maven-plugin</artifactId>
-      <version>0.14.11</version>
+      <version>0.14.12</version>
       <executions>
         <execution>
           <id>bytecode-to-eo</id>
@@ -141,7 +141,7 @@ You can run the plugin in a project that does not contain a `pom.xml` file.
 For example, to disassemble compiled classes, use:
 
 ```bash
-mvn org.eolang:jeo-maven-plugin:${project.version}:disassemble \
+mvn org.eolang:jeo-maven-plugin:0.14.12:disassemble \
   -Djeo.disassemble.sourcesDir=input \
   -Djeo.disassemble.outputDir=xmir
 ```
@@ -152,7 +152,7 @@ in [DisassembleMojo.java](src/main/java/org/eolang/jeo/DisassembleMojo.java).
 Similarly, you can run the `assemble` goal:
 
 ```bash
-mvn org.eolang:jeo-maven-plugin:${project.version}:assemble \
+mvn org.eolang:jeo-maven-plugin:0.14.12:assemble \
     -Djeo.assemble.sourcesDir=xmir \
     -Djeo.assemble.outputDir=output
 ```


### PR DESCRIPTION
This PR updates the version number in `README.md` to `0.14.12` as part of the automated process.

Related to #1354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Documentation
  - Updated README to pin jeo-maven-plugin to version 0.14.12.
  - Adjusted example commands to reference the fixed plugin version.

- Chores
  - Refined CI workflow to extract the current version from README and apply a targeted update to the latest tag, replacing broad regex-based substitution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->