### PR TITLE
fix(#1375): replace `v1` with `α0` in DirectivesBytes, DirectivesNumber, and DirectivesValue

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesBytes.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesBytes.java
@@ -69,14 +69,14 @@ public final class DirectivesBytes implements Iterable<Directive> {
             directives = new DirectivesClosedObject(
                 "Φ.org.eolang.bytes",
                 this.as,
-                new Directives().add("o").attr("as", "v1").set(this.hex).up()
+                new Directives().add("o").attr("as", "α0").set(this.hex).up()
             );
         } else {
             directives = new DirectivesClosedObject(
                 "Φ.org.eolang.bytes",
                 this.as,
                 this.name,
-                new Directives().add("o").attr("as", "v1").set(this.hex).up()
+                new Directives().add("o").attr("as", "α0").set(this.hex).up()
             );
         }
         return directives.iterator();

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesNumber.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesNumber.java
@@ -67,7 +67,7 @@ final class DirectivesNumber implements Iterable<Directive> {
             new EoFqn("number").fqn(),
             this.as,
             this.name,
-            new DirectivesBytes(this.hex, "", "v1")
+            new DirectivesBytes(this.hex, "", "α0")
         ).iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -255,7 +255,7 @@ public final class DirectivesValue implements Iterable<Directive> {
             this.name,
             this.as,
             new DirectivesComment(this.format, this.comment()),
-            new DirectivesBytes(this.hex(codec), "", "v1")
+            new DirectivesBytes(this.hex(codec), "", "α0")
         );
     }
 


### PR DESCRIPTION
This PR updates the `as` attribute from `v1` to `α0` in multiple directives to align with the required XMIR format.

Related to #1375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized the emitted directive tag for byte-related values from “v1” to “α0” across outputs, ensuring consistent labeling in generated artifacts.

- **Chores**
  - Aligned number and value emissions to use the new “α0” tag for bytes for uniformity across components.

Note: Outputs that previously contained the “v1” tag for bytes will now show “α0”. Users parsing or relying on these tags may need to update their integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->