### PR TITLE
fix(#1379): resolve duplicated names of overloaded class methods and fields with prefixing

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/PrefixedName.java
+++ b/src/main/java/org/eolang/jeo/representation/PrefixedName.java
@@ -50,17 +50,66 @@ public final class PrefixedName {
     );
 
     /**
+     * Prefix to be used for encoding and decoding.
+     */
+    private final String prefix;
+
+    /**
      * Original name.
-     * Might be with 'j' prefix or without it, depending on the context.
+     * Might be with a prefix or without it, depending on the context.
      */
     private final String origin;
 
     /**
+     * Pattern to find positions for prefixing and existing prefixes for removal.
+     */
+    private final Pattern delimited;
+
+    /**
+     * Pattern to find existing prefixes for removal.
+     */
+    private final Pattern prefixed;
+
+    /**
      * Constructor.
-     * @param origin The original name (may or may not be prefixed)
+     * @param origin The original name.
      */
     public PrefixedName(final String origin) {
+        this(PrefixedName.PREFIX, origin, PrefixedName.DELIMITED, PrefixedName.PREFIXED);
+    }
+
+    /**
+     * Constructor.
+     * @param prefix Prefix to be used for encoding and decoding
+     * @param origin The original name.
+     */
+    public PrefixedName(final String prefix, final String origin) {
+        this(
+            prefix,
+            origin,
+            PrefixedName.DELIMITED,
+            Pattern.compile(String.format("(?<=^|[./])%s", Pattern.quote(prefix)))
+        );
+    }
+
+    /**
+     * Constructor.
+     * @param prefix Prefix to be used for encoding and decoding
+     * @param origin The original name
+     * @param delimited Pattern to find positions for prefixing
+     * @param prefixed Pattern to find existing prefixes for removal
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    public PrefixedName(
+        final String prefix,
+        final String origin,
+        final Pattern delimited,
+        final Pattern prefixed
+    ) {
+        this.prefix = prefix;
         this.origin = origin;
+        this.delimited = delimited;
+        this.prefixed = prefixed;
     }
 
     /**
@@ -71,9 +120,9 @@ public final class PrefixedName {
         if (PrefixedName.BLANKED.matcher(this.origin).matches()) {
             throw new IllegalArgumentException(PrefixedName.BLANK);
         }
-        return PrefixedName.DELIMITED
+        return this.delimited
             .matcher(this.origin)
-            .replaceAll(Matcher.quoteReplacement(PrefixedName.PREFIX));
+            .replaceAll(Matcher.quoteReplacement(this.prefix));
     }
 
     /**
@@ -84,6 +133,6 @@ public final class PrefixedName {
         if (PrefixedName.BLANKED.matcher(this.origin).matches()) {
             throw new IllegalArgumentException(PrefixedName.BLANK);
         }
-        return PrefixedName.PREFIXED.matcher(this.origin).replaceAll("");
+        return this.prefixed.matcher(this.origin).replaceAll("");
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -155,7 +155,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
         final String mname = this.name.toString();
         return new DirectivesJeoObject(
             "method",
-            new PrefixedName(mname).encode(),
+            new PrefixedName("jm$", mname).encode(),
             Stream.concat(
                 Stream.of(
                     this.properties,

--- a/src/test/java/org/eolang/jeo/representation/PrefixedNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/PrefixedNameTest.java
@@ -59,6 +59,45 @@ final class PrefixedNameTest {
         );
     }
 
+    @ParameterizedTest
+    @CsvSource({
+        "name, jm$name",
+        "ClassName, jm$ClassName",
+        "someLongName, jm$someLongName",
+        "jm$jm, jm$jm$jm",
+        "jeo/xmir/Fake, jm$jeo/jm$xmir/jm$Fake",
+        "EOorg.EOeolang, jm$EOorg.jm$EOeolang",
+        "org.eolang, jm$org.jm$eolang",
+        "org.eolang.Fake, jm$org.jm$eolang.jm$Fake"
+    })
+    void encodesNamesWithDifferentPrefix(final String origin, final String encoded) {
+        MatcherAssert.assertThat(
+            String.format("Can't encode '%s' to '%s' with prefix 'jm'", origin, encoded),
+            new PrefixedName("jm$", origin).encode(),
+            Matchers.equalTo(encoded)
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "jm$name, name",
+        "jm$ClassName, ClassName",
+        "jm$someLongName, someLongName",
+        "jm$jm$jm, jm$jm",
+        "someName, someName",
+        "jm$jeo/jm$xmir/jm$Fake, jeo/xmir/Fake",
+        "jm$EOorg.jm$EOeolang, EOorg.EOeolang",
+        "jm$org.jm$eolang, org.eolang",
+        "jm$org.jm$eolang.jm$Fake, org.eolang.Fake"
+    })
+    void decodesNamesWithDifferentPrefix(final String encoded, final String origin) {
+        MatcherAssert.assertThat(
+            String.format("Can't decode '%s' to '%s' with prefix 'jm'", encoded, origin),
+            new PrefixedName("jm$", encoded).decode(),
+            Matchers.equalTo(origin)
+        );
+    }
+
     @Test
     void throwsExceptionWhenEncodingInvalidName() {
         Assertions.assertThrows(

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeClassTest.java
@@ -4,11 +4,15 @@
  */
 package org.eolang.jeo.representation.bytecode;
 
+import com.jcabi.matchers.XhtmlMatchers;
+import org.eolang.jeo.representation.directives.Format;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
 
 /**
  * Test case for {@link org.eolang.jeo.representation.bytecode.BytecodeClass}.
@@ -179,6 +183,54 @@ final class BytecodeClassTest {
                     .up()
             ).bytecode(),
             "We expect no exception here because all instructions are valid"
+        );
+    }
+
+    @Test
+    void convertsToDirectivesOverloadedMethods() throws ImpossibleModificationException {
+        final String duplicated = "duplicated";
+        MatcherAssert.assertThat(
+            "We expect to have two methods with the names containing numbers to distinguish them",
+            new Xembler(
+                new BytecodeClass("OverloadedMethods")
+                    .withMethod(duplicated, "(I)I", Opcodes.ACC_PUBLIC)
+                    .opcode(Opcodes.ILOAD, 1)
+                    .opcode(Opcodes.IRETURN)
+                    .up()
+                    .withMethod(duplicated, "(II)I", Opcodes.ACC_PUBLIC)
+                    .opcode(Opcodes.ILOAD, 1)
+                    .opcode(Opcodes.ILOAD, 2)
+                    .opcode(Opcodes.IADD)
+                    .opcode(Opcodes.IRETURN)
+                    .up()
+                    .directives(new Format())
+            ).xml(),
+            XhtmlMatchers.hasXPaths(
+                "//o[@name='jm$duplicated']",
+                "//o[@name='jm$duplicated-2']"
+            )
+        );
+    }
+
+    @Test
+    void convertsToDirectivesWithMethodAndFieldHavingTheSameName()
+        throws ImpossibleModificationException {
+        final String same = "same";
+        MatcherAssert.assertThat(
+            "We expect to have a method and a field with the same name",
+            new Xembler(
+                new BytecodeClass("MethodAndFieldWithSameName")
+                    .withField(same)
+                    .withMethod(same, "()I", Opcodes.ACC_PUBLIC)
+                    .opcode(Opcodes.ICONST_0)
+                    .opcode(Opcodes.IRETURN)
+                    .up()
+                    .directives(new Format())
+            ).xml(),
+            XhtmlMatchers.hasXPaths(
+                "//o[@name='j$same']",
+                "//o[@name='jm$same']"
+            )
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -28,9 +28,9 @@ final class DirectivesMethodTest {
     @Test
     void addsPrefixToTheMethodName() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
-            "We expect that 'j$' prefix will be added to the method name",
+            "We expect that 'jm$' prefix will be added to the method name",
             new Xembler(new BytecodeMethod("φTerm").directives(1)).xml(),
-            XhtmlMatchers.hasXPaths("./o[contains(@name, 'j$φTerm')]")
+            XhtmlMatchers.hasXPaths("./o[contains(@name, 'jm$φTerm')]")
         );
     }
 


### PR DESCRIPTION
This PR resolves the issue of duplicated names for overloaded methods and fields in JEO by updating the prefixing mechanism to use `jm$` instead of `j$` for methods.

Related to #1379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configurable prefix for name encoding to support different naming schemes.
  - Method identifiers now use a dedicated prefix to clearly distinguish them in generated output.
  - Improved directive generation correctly represents overloaded methods and separates methods from fields with the same name.

- Bug Fixes
  - Eliminated naming collisions between methods and fields in generated directives.

- Tests
  - Added tests covering custom prefixes, encoding/decoding, overloaded methods, and method/field name disambiguation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->