### PR TITLE
fix(#1388): remove method name from trycatchblocks field in directives

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -161,10 +161,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
                     this.properties,
                     this.annotations,
                     new DirectivesSeq("body", this.instructions),
-                    new DirectivesSeq(
-                        String.format("trycatchblocks-%s", this.name.plain()),
-                        this.exceptions
-                    )
+                    new DirectivesSeq("trycatchblocks", this.exceptions)
                 ),
                 Stream.concat(
                     this.dvalue.stream(),

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -122,4 +122,15 @@ final class DirectivesMethodTest {
             )
         );
     }
+
+    @Test
+    void containsTryCatchBlocksIfThereAreNoExceptions() {
+        MatcherAssert.assertThat(
+            "We expect that empty trycatchblocks will be mentioned in the method directives",
+            new Xembler(new DirectivesMethod("foo")).xmlQuietly(),
+            XhtmlMatchers.hasXPath(
+                "./o[contains(@name,'foo')]/o[@name='trycatchblocks']"
+            )
+        );
+    }
 }


### PR DESCRIPTION
This PR modifies the `trycatchblocks` field in `DirectivesMethod` to remove the method name, simplifying pattern matching.

Related to #1388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage to verify that try-catch block directives are properly generated for edge cases involving methods with no explicit exception declarations, strengthening exception handling validation.

* **Refactor**
  * Standardized the internal naming convention for try-catch block representations within method directives to ensure consistent behavior and improved system reliability across all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->