### PR TITLE
refactor(#1370): remove 'compound-name' check suppression from JcabiXmlNode

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
@@ -121,7 +121,7 @@ public final class DirectivesField implements Iterable<Directive> {
             descriptor,
             signature,
             value,
-            new DirectivesAnnotations(String.format("annotations-%s", name))
+            new DirectivesAnnotations("annotations")
         );
     }
 
@@ -159,10 +159,10 @@ public final class DirectivesField implements Iterable<Directive> {
         return new DirectivesJeoObject(
             "field",
             new PrefixedName(this.name).encode(),
-            new DirectivesValue(this.format, this.title("access"), this.access),
-            new DirectivesValue(this.format, this.title("descriptor"), this.descriptor),
-            new DirectivesValue(this.format, this.title("signature"), this.signature),
-            new DirectivesValue(this.format, this.title("value"), this.value),
+            new DirectivesValue(this.format, DirectivesField.title("access"), this.access),
+            new DirectivesValue(this.format, DirectivesField.title("descriptor"), this.descriptor),
+            new DirectivesValue(this.format, DirectivesField.title("signature"), this.signature),
+            new DirectivesValue(this.format, DirectivesField.title("value"), this.value),
             this.annotations
         ).iterator();
     }
@@ -173,8 +173,7 @@ public final class DirectivesField implements Iterable<Directive> {
      * @param prefix Prefix
      * @return Title
      */
-    private String title(final String prefix) {
-        final String template = "%s-%s";
-        return String.format(template, prefix, this.name);
+    private static String title(final String prefix) {
+        return prefix;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesFrame.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesFrame.java
@@ -73,9 +73,9 @@ public final class DirectivesFrame implements Iterable<Directive> {
         return new DirectivesJeoObject(
             "frame",
             new NumName("f", this.index).toString(),
-            new DirectivesValue(this.format, this.name("type"), this.type),
-            new DirectivesFrameValues(this.format, this.name("locals"), this.locals),
-            new DirectivesFrameValues(this.format, this.name("stack"), this.stack)
+            new DirectivesValue(this.format, DirectivesFrame.name("type"), this.type),
+            new DirectivesFrameValues(this.format, DirectivesFrame.name("locals"), this.locals),
+            new DirectivesFrameValues(this.format, DirectivesFrame.name("stack"), this.stack)
         ).iterator();
     }
 
@@ -84,7 +84,7 @@ public final class DirectivesFrame implements Iterable<Directive> {
      * @param attribute Attribute name.
      * @return Attribute name.
      */
-    private String name(final String attribute) {
-        return String.format("%s-%d", attribute, this.hashCode());
+    private static String name(final String attribute) {
+        return attribute;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -47,10 +47,6 @@ public final class JcabiXmlNode implements XmlNode {
      *  This check later will be reduced from 'CRITICAL' to 'WARNING':
      *  https://github.com/objectionary/jeo-maven-plugin/issues/1366#issuecomment-3376125719
      *  When this is done, we should remove this suppression.
-     * @todo #1366:30min Remove 'compound-name' check suppression.
-     *  Currently, we have several objects with compound names which leads to
-     *  WARNING from 'compound-name' check. We should rename these objects to have
-     *  simple names only and then remove this suppression.
      */
     private static final Collection<String> IGNORE = new HashSet<>(
         Arrays.asList(
@@ -61,8 +57,7 @@ public final class JcabiXmlNode implements XmlNode {
             "sparse-decoration",
             "duplicate-names",
             "mandatory-package",
-            "idempotent-attribute-is-not-first",
-            "compound-name"
+            "idempotent-attribute-is-not-first"
         )
     );
 

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesFieldTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesFieldTest.java
@@ -35,10 +35,10 @@ final class DirectivesFieldTest {
             XhtmlMatchers.hasXPaths(
                 new JeoBaseXpath("/o", "field").toXpath(),
                 "/o[contains(@name,'unknown')]",
-                "/o/o[@name='access-unknown']",
-                "/o/o[@name='descriptor-unknown']",
-                "/o/o[@name='signature-unknown']",
-                "/o/o[contains(@base,'number') and @name='value-unknown']"
+                "/o/o[@name='access']",
+                "/o/o[@name='descriptor']",
+                "/o/o[@name='signature']",
+                "/o/o[contains(@base,'number') and @name='value']"
             )
         );
     }
@@ -63,10 +63,10 @@ final class DirectivesFieldTest {
             XhtmlMatchers.hasXPaths(
                 new JeoBaseXpath("/o", "field").toXpath(),
                 "/o[contains(@name,'serialVersionUID')]",
-                "/o/o[@name='access-serialVersionUID']",
-                "/o/o[@name='descriptor-serialVersionUID']",
-                "/o/o[@name='signature-serialVersionUID']",
-                "/o/o[@name='value-serialVersionUID']"
+                "/o/o[@name='access']",
+                "/o/o[@name='descriptor']",
+                "/o/o[@name='signature']",
+                "/o/o[@name='value']"
             )
         );
     }


### PR DESCRIPTION
This PR resolves puzzle `1366-189833df` by fixing compound names and removing the `compound-name` check suppression in `JcabiXmlNode.java`.

Fixes #1370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified directive and field naming to use fixed, prefix-only identifiers (e.g., "access", "descriptor", "signature", "value") instead of dynamic per-item names.
  * Standardized attribute keys to fixed names, removing instance-specific suffixing.

* **Tests**
  * Updated tests to assert the simplified directive names.

* **Chores**
  * Tightened defect detection by removing suppression for one compound-name case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->