### PR TITLE
refactor(#1315): remove todo and simplify child node access in XmlModule

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlChildren.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlChildren.java
@@ -7,10 +7,6 @@ package org.eolang.jeo.representation.xmir;
 /**
  * Node with children.
  * @since 0.15.0
- * @todo #1297:30min Use {@link XmlModuleOpened} in other places.
- *  Currently, this class is used only in {@link XmlModule}.
- *  It should be used in other places where child nodes are accessed by name.
- *  This will help to reduce code duplication and improve the quality of the code.
  */
 final class XmlChildren {
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlModule.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlModule.java
@@ -159,13 +159,6 @@ public final class XmlModule {
      * @throws IllegalStateException When child node is missing.
      */
     private XmlNode byName(final String name) {
-        return this.node.children()
-            .filter(n -> n.attribute("name").map(name::equals).orElse(false))
-            .findFirst()
-            .orElseThrow(
-                () -> new IllegalStateException(
-                    String.format("Module '%s' is missing in `%s`", name, this.node)
-                )
-            );
+        return new XmlChildren(this.node).byName(name);
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlModuleExported.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlModuleExported.java
@@ -85,13 +85,6 @@ public final class XmlModuleExported {
      * @throws IllegalStateException When child node is missing.
      */
     private XmlNode byName(final String name) {
-        return this.node.children()
-            .filter(n -> n.attribute("name").map(name::equals).orElse(false))
-            .findFirst()
-            .orElseThrow(
-                () -> new IllegalStateException(
-                    String.format("'%s' is missing in `%s`", name, this.node)
-                )
-            );
+        return new XmlChildren(this.node).byName(name);
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlModuleRequired.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlModuleRequired.java
@@ -79,13 +79,6 @@ public final class XmlModuleRequired {
      * @throws IllegalStateException When child node is missing.
      */
     private XmlNode byName(final String name) {
-        return this.node.children()
-            .filter(n -> n.attribute("name").map(name::equals).orElse(false))
-            .findFirst()
-            .orElseThrow(
-                () -> new IllegalStateException(
-                    String.format("'%s' is missing in `%s`", name, this.node)
-                )
-            );
+        return new XmlChildren(this.node).byName(name);
     }
 }


### PR DESCRIPTION
This PR refactors the `byName` method in `XmlModule`, `XmlModuleExported`, and `XmlModuleRequired` to utilize `XmlChildren`, addressing puzzle `1315`.

Related to #1315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization across core components for enhanced maintainability.

* **Documentation**
  * Cleaned up internal documentation by removing outdated notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->