### PR TITLE
refactor(#1129): remove TYPE_REFERENCE and CLASS_REFERENCE from DataType

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/DataType.java
@@ -6,7 +6,6 @@ package org.eolang.jeo.representation.bytecode;
 
 import java.util.Arrays;
 import java.util.Optional;
-import org.objectweb.asm.Type;
 
 /**
  * Enumeration of all supported data types in bytecode representation.
@@ -66,16 +65,6 @@ enum DataType {
      * Bytes.
      */
     BYTES("bytes", byte[].class),
-
-    /**
-     * Type reference.
-     */
-    TYPE_REFERENCE("type", Type.class),
-
-    /**
-     * Class reference.
-     */
-    CLASS_REFERENCE("class", Class.class),
 
     /**
      * Null.

--- a/src/main/java/org/eolang/jeo/representation/bytecode/EoCodec.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/EoCodec.java
@@ -42,8 +42,6 @@ public final class EoCodec implements Codec {
             case CHAR:
             case STRING:
             case BYTES:
-            case TYPE_REFERENCE:
-            case CLASS_REFERENCE:
             case NULL:
                 result = this.origin.encode(object, type);
                 break;
@@ -71,8 +69,6 @@ public final class EoCodec implements Codec {
             case CHAR:
             case STRING:
             case BYTES:
-            case TYPE_REFERENCE:
-            case CLASS_REFERENCE:
             case NULL:
                 result = this.origin.decode(bytes, type);
                 break;

--- a/src/main/java/org/eolang/jeo/representation/bytecode/JavaCodec.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/JavaCodec.java
@@ -7,7 +7,6 @@ package org.eolang.jeo.representation.bytecode;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-import org.objectweb.asm.Type;
 
 /**
  * Plain codec.
@@ -58,12 +57,6 @@ public final class JavaCodec implements Codec {
             case BYTES:
                 result = byte[].class.cast(value);
                 break;
-            case TYPE_REFERENCE:
-                result = JavaCodec.typeBytes(value);
-                break;
-            case CLASS_REFERENCE:
-                result = JavaCodec.hexClass(Class.class.cast(value).getName());
-                break;
             case NULL:
                 result = JavaCodec.EMPTY;
                 break;
@@ -109,12 +102,6 @@ public final class JavaCodec implements Codec {
             case BYTES:
                 result = bytes;
                 break;
-            case TYPE_REFERENCE:
-                result = Type.getType(String.format(new String(bytes, StandardCharsets.UTF_8)));
-                break;
-            case CLASS_REFERENCE:
-                result = JavaCodec.classReference(bytes);
-                break;
             case NULL:
                 result = null;
                 break;
@@ -122,23 +109,6 @@ public final class JavaCodec implements Codec {
                 throw new UnsupportedDataType(type);
         }
         return result;
-    }
-
-    /**
-     * Get class reference by bytes.
-     * @param bytes Bytes.
-     * @return Class.
-     */
-    private static Class<?> classReference(final byte[] bytes) {
-        final String name = new String(bytes, StandardCharsets.UTF_8);
-        try {
-            return Class.forName(name.replace('/', '.'));
-        } catch (final ClassNotFoundException exception) {
-            throw new IllegalStateException(
-                String.format("Class with name '%s' isn't found", name),
-                exception
-            );
-        }
     }
 
     /**
@@ -184,29 +154,5 @@ public final class JavaCodec implements Codec {
             result = new byte[]{0x00};
         }
         return result;
-    }
-
-    /**
-     * Convert a type to bytes.
-     * @param value Type.
-     * @return Bytes.
-     */
-    private static byte[] typeBytes(final Object value) {
-        try {
-            return JavaCodec.hexClass(((Type) value).getDescriptor());
-        } catch (final AssertionError exception) {
-            throw new IllegalStateException(
-                String.format("Failed to get class name for %s", value), exception
-            );
-        }
-    }
-
-    /**
-     * Convert class name to bytes.
-     * @param name Class name.
-     * @return Bytes.
-     */
-    private static byte[] hexClass(final String name) {
-        return name.replace('.', '/').getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeValueTest.java
@@ -4,14 +4,12 @@
  */
 package org.eolang.jeo.representation.bytecode;
 
-import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.objectweb.asm.Type;
 
 /**
  * Test case for {@link BytecodeValue}.
@@ -110,20 +108,6 @@ final class BytecodeValueTest {
                 "char",
                 new byte[]{0, 32},
                 ' '
-            ),
-            Arguments.of(
-                new BytecodeValue(BytecodeValue.class),
-                "class",
-                "org/eolang/jeo/representation/bytecode/BytecodeObject".getBytes(
-                    StandardCharsets.UTF_8
-                ),
-                BytecodeValue.class
-            ),
-            Arguments.of(
-                new BytecodeValue(Type.INT_TYPE),
-                "type",
-                "I".getBytes(StandardCharsets.UTF_8),
-                Type.INT_TYPE
             ),
             Arguments.of(
                 new BytecodeValue(null),

--- a/src/test/java/org/eolang/jeo/representation/bytecode/JavaCodecTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/JavaCodecTest.java
@@ -9,7 +9,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.objectweb.asm.Type;
 
 /**
  * Test case for {@link JavaCodec}.
@@ -54,16 +53,6 @@ final class JavaCodecTest {
             {'a', DataType.CHAR, new byte[]{0, 97}},
             {new byte[]{0, 1, 2, 3}, DataType.BYTES, new byte[]{0, 1, 2, 3}},
             {"hello, world!", DataType.STRING, "hello, world!".getBytes(StandardCharsets.UTF_8)},
-            {
-                Type.getType(Object.class),
-                DataType.TYPE_REFERENCE,
-                "Ljava/lang/Object;".getBytes(StandardCharsets.UTF_8),
-            },
-            {
-                Object.class,
-                DataType.CLASS_REFERENCE,
-                "java/lang/Object".getBytes(StandardCharsets.UTF_8),
-            },
         };
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.objectweb.asm.Type;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
 
@@ -162,16 +161,6 @@ final class DirectivesValueTest {
     }
 
     @Test
-    void encodesType() {
-        final String value = new DirectivesValue(0, new Format(), Type.INT_TYPE).hex(this.codec);
-        MatcherAssert.assertThat(
-            "Expected and actual hex values differ, the value for 'Type.INT_TYPE' should be '69 6E 74'",
-            value,
-            Matchers.equalTo("49-")
-        );
-    }
-
-    @Test
     void createsStringWithQuotedComment() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "We expect that string value will be quoted in the comment",
@@ -193,7 +182,6 @@ final class DirectivesValueTest {
             Arguments.of(true, "bool"),
             Arguments.of(0.1f, "float"),
             Arguments.of(0.1d, "double"),
-            Arguments.of(DirectivesValue.class, "class"),
             Arguments.of(' ', "char")
         );
     }
@@ -211,11 +199,7 @@ final class DirectivesValueTest {
             Arguments.of(true, "01-"),
             Arguments.of(false, "00-"),
             Arguments.of('a', "00-61"),
-            Arguments.of(0.1d, "3F-B9-99-99-99-99-99-9A"),
-            Arguments.of(
-                DirectivesValueTest.class,
-                "6F-72-67-2F-65-6F-6C-61-6E-67-2F-6A-65-6F-2F-72-65-70-72-65-73-65-6E-74-61-74-69-6F-6E-2F-64-69-72-65-63-74-69-76-65-73-2F-44-69-72-65-63-74-69-76-65-73-56-61-6C-75-65-54-65-73-74"
-            )
+            Arguments.of(0.1d, "3F-B9-99-99-99-99-99-9A")
         );
     }
 


### PR DESCRIPTION
This PR removes unused `TYPE_REFERENCE` and `CLASS_REFERENCE` from `DataType`.

Related to #1129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed support for type and class reference data types from bytecode encoding and decoding operations.
  * Eliminated associated helper methods and simplified codec logic by removing type/class reference conversion paths.

* **Tests**
  * Removed test cases validating type and class reference handling.
  * Updated test data sets to reflect the removal of these data type scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->