### PR TITLE
fix(#1167): update jcabi-maven-skin version to resolve logo rendering issue

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -7,7 +7,7 @@
   <skin>
     <groupId>com.jcabi</groupId>
     <artifactId>jcabi-maven-skin</artifactId>
-    <version>1.7.1</version>
+    <version>1.8.3</version>
   </skin>
   <bannerLeft>
     <name>jeo-maven-plugin</name>


### PR DESCRIPTION
This PR updates the `jcabi-maven-skin` version in `site.xml` to resolve the logo rendering issue.

Related to #1167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated site skin component to version 1.8.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->