### PR TITLE
fix(#1289): Remove 'duplicate-names' check suppression in JcabiXmlNode.java

### DIFF
--- a/src/it/custom-transformations/src/main/java/org/eolang/benchmark/B.java
+++ b/src/it/custom-transformations/src/main/java/org/eolang/benchmark/B.java
@@ -5,6 +5,7 @@
 package org.eolang.benchmark;
 
 class B {
+    private final int bar = 2;
     private final F f;
 
     B(F f) {
@@ -12,6 +13,6 @@ class B {
     }
 
     int bar() {
-        return f.foo() + 2;
+        return f.foo() + bar;
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -34,10 +34,6 @@ public final class JcabiXmlNode implements XmlNode {
 
     /**
      * Set of ignored defects.
-     * @todo #1278:30min Remove 'duplicate-names' check suppression.
-     *  We are ignoring 'duplicate-names' check because of records that usually have
-     *  the field names same as the method names which leads to false positives.
-     *  We should find a way to distinguish between fields and methods in XMIR.
      * @todo #1297:60min Remove 'mandatory-package' check suppression.
      *  We are ignoring 'mandatory-package' check because 'module-info' files don't
      *  have package declaration. We should find a way to identify 'module-info'
@@ -55,7 +51,6 @@ public final class JcabiXmlNode implements XmlNode {
             "duplicate-names-in-diff-context",
             "unit-test-missing",
             "sparse-decoration",
-            "duplicate-names",
             "mandatory-package",
             "idempotent-attribute-is-not-first"
         )


### PR DESCRIPTION
This PR resolves puzzle `1278-829c1db5` by removing the `duplicate-names` check suppression in `JcabiXmlNode.java`.

Related to #1289

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now correctly identifies duplicate-names defects that were previously ignored, improving error detection during validation checks.

* **Refactor**
  * Internal code optimizations and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->