### PR TITLE
refactor(#1314): remove 'mandatory-package' check from JcabiXmlNode.java

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/AbsentPackage.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/AbsentPackage.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+/**
+ * Representation of absent package.
+ *
+ * @since 0.15.0
+ */
+public final class AbsentPackage {
+
+    /**
+     * Default identifier for absent package.
+     */
+    private static final String ABSENT_PACKAGE = "jeo$packageless$jeo";
+
+    /**
+     * Identifier of the absent package.
+     */
+    private final String identifier;
+
+    /**
+     * Constructor.
+     */
+    public AbsentPackage() {
+        this(AbsentPackage.ABSENT_PACKAGE);
+    }
+
+    /**
+     * Constructor with custom identifier.
+     *
+     * @param identifier Custom identifier
+     */
+    private AbsentPackage(final String identifier) {
+        this.identifier = identifier;
+    }
+
+    @Override
+    public String toString() {
+        return this.identifier;
+    }
+}

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMetas.java
@@ -18,6 +18,11 @@ import org.xembly.Directives;
 public final class DirectivesMetas implements Iterable<Directive> {
 
     /**
+     * Absent package name.
+     */
+    private static final String ABSENT_PACKAGE = new AbsentPackage().toString();
+
+    /**
      * Class name.
      */
     private final ClassName name;
@@ -34,8 +39,11 @@ public final class DirectivesMetas implements Iterable<Directive> {
     public Iterator<Directive> iterator() {
         final Directives result = new Directives().add("metas");
         result.append(DirectivesMetas.home());
-        if (!this.name.pckg().isEmpty()) {
-            result.append(this.pckg());
+        final String pckg = this.name.pckg();
+        if (pckg.isEmpty()) {
+            result.append(DirectivesMetas.pckgd(DirectivesMetas.ABSENT_PACKAGE));
+        } else {
+            result.append(DirectivesMetas.pckgd(new PrefixedName(pckg).encode()));
         }
         result.append(DirectivesMetas.spdx());
         result.append(DirectivesMetas.version());
@@ -58,15 +66,15 @@ public final class DirectivesMetas implements Iterable<Directive> {
      * Prefixed package.
      * We intentionally add prefix to the packages, because sometimes they can be really
      * strange, <a href="https://github.com/objectionary/jeo-maven-plugin/issues/779">see</a>
-     * @return Prefixed package name.
+     * @param pckg Package name.
+     * @return Package name directives.
      */
-    private Directives pckg() {
-        final String prefixed = new PrefixedName(this.name.pckg()).encode();
+    private static Directives pckgd(final String pckg) {
         return new Directives()
             .add("meta")
             .add("head").set("package").up()
-            .add("tail").set(prefixed).up()
-            .add("part").set(prefixed).up()
+            .add("tail").set(pckg).up()
+            .add("part").set(pckg).up()
             .up();
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -34,10 +34,6 @@ public final class JcabiXmlNode implements XmlNode {
 
     /**
      * Set of ignored defects.
-     * @todo #1297:60min Remove 'mandatory-package' check suppression.
-     *  We are ignoring 'mandatory-package' check because 'module-info' files don't
-     *  have package declaration. We should find a way to identify 'module-info'
-     *  for XMIR.
      * @todo #1366:60min Remove 'idempotent-attribute-is-not-first' check suppression.
      *  This check has 'CRITITCAL' priority and it fails for XMIRs generated from EO sources.
      *  This check later will be reduced from 'CRITICAL' to 'WARNING':
@@ -51,7 +47,6 @@ public final class JcabiXmlNode implements XmlNode {
             "duplicate-names-in-diff-context",
             "unit-test-missing",
             "sparse-decoration",
-            "mandatory-package",
             "idempotent-attribute-is-not-first"
         )
     );

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlObject.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlObject.java
@@ -7,12 +7,18 @@ package org.eolang.jeo.representation.xmir;
 import com.jcabi.xml.XML;
 import org.eolang.jeo.representation.PrefixedName;
 import org.eolang.jeo.representation.bytecode.BytecodeObject;
+import org.eolang.jeo.representation.directives.AbsentPackage;
 
 /**
  * XMIR Program.
  * @since 0.1
  */
 public final class XmlObject {
+
+    /**
+     * Absent package name.
+     */
+    private static final String ABSENT_PACKAGE = new AbsentPackage().toString();
 
     /**
      * Root node.
@@ -89,6 +95,22 @@ public final class XmlObject {
             .findFirst()
             .map(PrefixedName::new)
             .map(PrefixedName::decode)
+            .map(XmlObject::realPackage)
             .orElse("");
+    }
+
+    /**
+     * Convert absent package to empty string.
+     * @param pckg Package name.
+     * @return Real package name.
+     */
+    private static String realPackage(final String pckg) {
+        final String result;
+        if (XmlObject.ABSENT_PACKAGE.equals(pckg)) {
+            result = "";
+        } else {
+            result = pckg;
+        }
+        return result;
     }
 }

--- a/src/test/java/org/eolang/jeo/XmirFilesTest.java
+++ b/src/test/java/org/eolang/jeo/XmirFilesTest.java
@@ -128,6 +128,21 @@ final class XmirFilesTest {
     }
 
     @Test
+    void verifiesXmirFileGeneratedFromModuleInfo(@TempDir final Path temp) throws IOException {
+        Files.write(
+            temp.resolve("open-module-info.xmir"),
+            new BytecodeRepresentation(new ResourceOf("open-module-info.class"))
+                .toXmir()
+                .toString()
+                .getBytes(StandardCharsets.UTF_8)
+        );
+        Assertions.assertDoesNotThrow(
+            () -> new XmirFiles(temp).verify(),
+            "We expected no exceptions when verifying the xmir file generated from module-info.class"
+        );
+    }
+
+    @Test
     void failsOnInvalidXmirFile(@TempDir final Path temp) throws IOException {
         Files.write(
             temp.resolve("Invalid.xmir"),

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMetasTest.java
@@ -61,10 +61,17 @@ final class DirectivesMetasTest {
 
     @Test
     void createsDirectivesWithEmptyPackage() {
+        final String pckg = new AbsentPackage().toString();
         MatcherAssert.assertThat(
             "We expect that <metas>/<package> won't be created if package is empty",
-            new Xembler(new DirectivesMetas(new ClassName("WithoutPackage"))).xmlQuietly(),
-            Matchers.not(XhtmlMatchers.hasXPath("/metas/meta[head[text()='package']]"))
+            new Xembler(
+                new DirectivesMetas(new ClassName("WithoutPackage"))
+            ).xmlQuietly(),
+            Matchers.allOf(
+                XhtmlMatchers.hasXPath("/metas/meta/head[text()='package']"),
+                XhtmlMatchers.hasXPath(String.format("/metas/meta/tail[text()='%s']", pckg)),
+                XhtmlMatchers.hasXPath(String.format("/metas/meta/part[text()='%s']", pckg))
+            )
         );
     }
 


### PR DESCRIPTION
This PR introduces the `AbsentPackage` class and updates related components to handle absent packages correctly, resolving the puzzle `1297-0f392ff5`.

Related to #1314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling entities without explicit package assignments

* **Improvements**
  * Enhanced package validation and normalization for better consistency

* **Tests**
  * Expanded test coverage for package handling scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->