### PR TITLE
chore(#1369): Update comment regarding 'idempotent-attribute-is-not-first' check

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -34,11 +34,9 @@ public final class JcabiXmlNode implements XmlNode {
 
     /**
      * Set of ignored defects.
-     * @todo #1366:60min Remove 'idempotent-attribute-is-not-first' check suppression.
-     *  This check has 'CRITITCAL' priority and it fails for XMIRs generated from EO sources.
-     *  This check later will be reduced from 'CRITICAL' to 'WARNING':
-     *  https://github.com/objectionary/jeo-maven-plugin/issues/1366#issuecomment-3376125719
-     *  When this is done, we should remove this suppression.
+     * We left 'idempotent-attribute-is-not-first' because it's not critical for XMIR correctness.
+     * You can find more details here:
+     * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/1369">1369</a>
      */
     private static final Collection<String> IGNORE = new HashSet<>(
         Arrays.asList(


### PR DESCRIPTION
This PR updates the comment in `JcabiXmlNode.java` regarding the suppression of the 'idempotent-attribute-is-not-first' check.

Related to #1369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation notes for improved clarity.

---

**Note:** This release contains only internal documentation updates with no end-user visible changes or new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->