### PR TITLE
feat(#1183): sort directives according to JVM specification

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesAnnotation.java
@@ -18,6 +18,15 @@ import org.xembly.Directives;
 
 /**
  * Directives Annotation.
+ * All the directives are sorted according to the JVM Spec:
+ * {@code
+ * annotation {
+ *     u2 type_index; {@link DirectivesAnnotation#descriptor}
+ *     u2 num_element_value_pairs; {@link DirectivesAnnotation#properties.size()}
+ *     {   u2            element_name_index;
+ *         element_value value;
+ *     } element_value_pairs[num_element_value_pairs]; {@link DirectivesAnnotation#properties}
+ * }}
  * @since 0.1
  */
 @ToString

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -19,7 +19,35 @@ import org.xembly.Directives;
  * <p>This class generates Xembly directives to create EO object representations
  * of Java classes, including their properties, fields, methods, annotations,
  * and attributes.</p>
+ * <p>All the class directives are sorted according to JVM specification
+ * {@code
+ * ClassFile {
+ *     u4             magic; (absent)
+ *     u2             minor_version; {@link DirectivesClassProperties}
+ *     u2             major_version; {@link DirectivesClassProperties}
+ *     u2             constant_pool_count; (incorporated to the directives)
+ *     cp_info        constant_pool[constant_pool_count-1]; (incorporated to the directives)
+ *     u2             access_flags; {@link DirectivesClassProperties}
+ *     u2             this_class; {@link DirectivesClass} (class name)
+ *     u2             super_class;  {@link DirectivesClassProperties}
+ *     u2             interfaces_count;  {@link DirectivesClassProperties}
+ *     u2             interfaces[interfaces_count];  {@link DirectivesClassProperties}
+ *     u2             fields_count; {@link DirectivesClass}
+ *     field_info     fields[fields_count]; {@link DirectivesClass}
+ *     u2             methods_count; {@link DirectivesClass}
+ *     method_info    methods[methods_count]; {@link DirectivesClass}
+ *     u2             attributes_count; {@link DirectivesClass}
+ *     attribute_info attributes[attributes_count]; {@link DirectivesClass}
+ * }}
+ * <a href="https://docs.oracle.com/javase/specs/jvms/se25/html/jvms-4.html#jvms-4.4.1">
+ *     You can read more in the official JVM specification.
+ * </a>
+ * </p>
  * @since 0.1.0
+ * @todo #1183:60min Class name should should be moved to DirectivesClassProperties
+ *  Otherwise it breaks component ordering (see the JVM specification).
+ *  The class name should be between access flags and superclasses - the both of them
+ *  are defined the the {@link DirectivesClassProperties}.
  */
 public final class DirectivesClass implements Iterable<Directive> {
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesEnclosingMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesEnclosingMethod.java
@@ -9,6 +9,15 @@ import org.xembly.Directive;
 
 /**
  * Directives for enclosing method attribute.
+ * <p>All the 'enclosing-method' attribute directives are sorted according to the JVM specification:
+ * {@code
+ * EnclosingMethod_attribute {
+ *     u2 attribute_name_index;
+ *     u4 attribute_length;
+ *     u2 class_index;
+ *     u2 method_index;
+ * }}
+ * </p>
  * @since 0.14.0
  */
 public final class DirectivesEnclosingMethod implements Iterable<Directive> {

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
@@ -33,6 +33,16 @@ import org.xembly.Directive;
  *       field 18 "I" "" "01" > bar
  *     }
  * </p>
+ * <p>All the directives inside this class are sorted according to the JVM specification:
+ * {@code
+ * field_info {
+ *     u2             access_flags;
+ *     u2             name_index;
+ *     u2             descriptor_index;
+ *     u2             attributes_count;
+ *     attribute_info attributes[attributes_count]; (signature, annotations, value)
+ * }}
+ * </p>
  *
  * @since 0.1
  */
@@ -160,6 +170,7 @@ public final class DirectivesField implements Iterable<Directive> {
             "field",
             new PrefixedName(this.name).encode(),
             new DirectivesValue(this.format, DirectivesField.title("access"), this.access),
+            new DirectivesValue(this.format, DirectivesField.title("name"), this.name),
             new DirectivesValue(this.format, DirectivesField.title("descriptor"), this.descriptor),
             new DirectivesValue(this.format, DirectivesField.title("signature"), this.signature),
             new DirectivesValue(this.format, DirectivesField.title("value"), this.value),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesFrame.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesFrame.java
@@ -9,7 +9,17 @@ import org.xembly.Directive;
 
 /**
  * Frame directives.
- *
+ * <p>All the directives of the frame are sorted according to the JVM specification:
+ * {@code
+ * full_frame {
+ *     u1 frame_type = FULL_FRAME;
+ *     u2 offset_delta;
+ *     u2 number_of_locals;
+ *     verification_type_info locals[number_of_locals];
+ *     u2 number_of_stack_items;
+ *     verification_type_info stack[number_of_stack_items];
+ * }}
+ * </p>
  * @since 0.3
  */
 public final class DirectivesFrame implements Iterable<Directive> {

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesLocalVariables.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesLocalVariables.java
@@ -10,7 +10,24 @@ import org.xembly.Directive;
 
 /**
  * Directives for local variables in a method.
+ * All local variable directives are sorted according to the JVM specification:
+ * {@code
+ * LocalVariableTable_attribute {
+ *     u2 attribute_name_index;
+ *     u4 attribute_length;
+ *     u2 local_variable_table_length;
+ *     {   u2 start_pc;
+ *         u2 length;
+ *         u2 name_index;
+ *         u2 descriptor_index;
+ *         u2 index;
+ *     } local_variable_table[local_variable_table_length];
+ * }}
  * @since 0.14.0
+ * @todo #1183:60min Sort out local variable directives according to the JVM specification.
+ *  Currently, the DirectivesLocalVariables class generates directives for local variables,
+ *  but they are not fully aligned with the JVM specification. The directives should be sorted
+ *  to match the structure outlined in the specification.
  */
 public final class DirectivesLocalVariables implements Iterable<Directive> {
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -17,11 +17,26 @@ import org.xembly.Directives;
 
 /**
  * Directives Method.
+ * All the directives are sorted according to JVM method specification:
+ * {@code
+ * method_info {
+ *     u2             access_flags; {@link DirectivesMethodProperties}
+ *     u2             name_index; {@link DirectivesMethodProperties}
+ *     u2             descriptor_index; {@link DirectivesMethodProperties}
+ *     u2             attributes_count; {@link DirectivesMethod}
+ *     attribute_info attributes[attributes_count]; {@link DirectivesMethod}
+ * }}
+ * Pay attention, that most of the information about methods are stored into attributes:
+ * - Body (Code)
+ * - Annotations
+ * - Try-catch blocks
+ * - Default value (for annotation methods)
+ * - And other attributes
  * @since 0.1
- * @todo #534:90min Refactor DirectivesMethod class to simplify the code.
- *  Currently, the class has a lot of methods and fields. It's kind of hard to understand
- *  what this class does. We need to refactor it to make it more readable and understandable.
- *  Moreover, in many places this class uses null checks, which is not good.
+ * @todo #1183:60min Method name should should be moved to DirectivesMethodProperties
+ *  Otherwise it breaks component ordering (see the JVM specification).
+ *  The method name should be between access flags and descriptor - the both of them
+ *  are defined the the {@link DirectivesMethodProperties}.
  */
 public final class DirectivesMethod implements Iterable<Directive> {
 
@@ -46,9 +61,9 @@ public final class DirectivesMethod implements Iterable<Directive> {
     private final List<Iterable<Directive>> instructions;
 
     /**
-     * Method exceptions.
+     * Method try-catch blocks.
      */
-    private final List<Iterable<Directive>> exceptions;
+    private final List<Iterable<Directive>> tryblocks;
 
     /**
      * Method annotations.
@@ -100,7 +115,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
      * @param name Method name
      * @param properties Method properties
      * @param instructions Method instructions
-     * @param exceptions Method exceptions
+     * @param tryblocks Method try-catch blocks
      * @param annotations Method annotations
      * @param dvalue Annotation default value
      * @param attributes Method attributes
@@ -111,7 +126,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
         final NumberedName name,
         final DirectivesMethodProperties properties,
         final List<Iterable<Directive>> instructions,
-        final List<Iterable<Directive>> exceptions,
+        final List<Iterable<Directive>> tryblocks,
         final DirectivesAnnotations annotations,
         final List<Iterable<Directive>> dvalue,
         final DirectivesAttributes attributes
@@ -120,7 +135,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
         this.name = name;
         this.properties = properties;
         this.instructions = instructions;
-        this.exceptions = exceptions;
+        this.tryblocks = tryblocks;
         this.annotations = annotations;
         this.dvalue = dvalue;
         this.attributes = attributes;
@@ -161,7 +176,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
                     this.properties,
                     this.annotations,
                     new DirectivesSeq("body", this.instructions),
-                    new DirectivesSeq("trycatchblocks", this.exceptions)
+                    new DirectivesSeq("trycatchblocks", this.tryblocks)
                 ),
                 Stream.concat(
                     this.dvalue.stream(),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
@@ -13,6 +13,15 @@ import org.xembly.Directives;
 
 /**
  * Method properties as Xembly directives.
+ * All the directives are sorted according to JVM method specification:
+ * {@code
+ * method_info {
+ *     u2             access_flags; {@link DirectivesMethodProperties}
+ *     u2             name_index; {@link DirectivesMethodProperties}
+ *     u2             descriptor_index; {@link DirectivesMethodProperties}
+ *     u2             attributes_count; {@link DirectivesMethod}
+ *     attribute_info attributes[attributes_count]; {@link DirectivesMethod}
+ * }}
  * @since 0.1
  */
 public final class DirectivesMethodProperties implements Iterable<Directive> {
@@ -34,21 +43,25 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
 
     /**
      * Method signature.
+     * Attribute "Signature_attribute".
      */
     private final String signature;
 
     /**
      * Method exceptions.
+     * Attribute "Exceptions_attribute".
      */
     private final String[] exceptions;
 
     /**
      * Method max stack and locals.
+     * Inside 'Code' attribute.
      */
     private final AtomicReference<DirectivesMaxs> max;
 
     /**
      * Method parameters.
+     * Attribute "MethodParameters" (since Java 1.8).
      */
     private final DirectivesMethodParams params;
 
@@ -135,18 +148,18 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        final Directives dirs = new Directives()
-            .append(new DirectivesValue(this.format, "access", this.access))
-            .append(new DirectivesValue(this.format, "descriptor", this.descriptor))
-            .append(new DirectivesValue(this.format, "signature", this.signature))
-            .append(
-                new DirectivesValues(this.format, "exceptions", (Object[]) this.exceptions)
-            )
-            .append(this.max.get())
-            .append(this.params);
+        final Directives dirs = new Directives();
+        dirs.append(new DirectivesValue(this.format, "access", this.access));
         if (this.format.modifiers()) {
             dirs.append(new DirectivesMethodModifiers(this.format, this.access));
         }
+        dirs.append(new DirectivesValue(this.format, "descriptor", this.descriptor));
+        dirs.append(new DirectivesValue(this.format, "signature", this.signature));
+        dirs.append(
+            new DirectivesValues(this.format, "exceptions", (Object[]) this.exceptions)
+        );
+        dirs.append(this.max.get());
+        dirs.append(this.params);
         return dirs.iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesModule.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesModule.java
@@ -13,7 +13,51 @@ import org.xembly.Directive;
 /**
  * Module of directives.
  * Mirrors {@link org.eolang.jeo.representation.bytecode.BytecodeModule}
+ * <p>All the directives are sorted according to the JVM specification:
+ * {@code
+ * Module_attribute {
+ *     u2 attribute_name_index;
+ *     u4 attribute_length;
+ *
+ *     u2 module_name_index;
+ *     u2 module_flags;
+ *     u2 module_version_index;
+ *
+ *     u2 requires_count;
+ *     {   u2 requires_index;
+ *         u2 requires_flags;
+ *         u2 requires_version_index;
+ *     } requires[requires_count];
+ *
+ *     u2 exports_count;
+ *     {   u2 exports_index;
+ *         u2 exports_flags;
+ *         u2 exports_to_count;
+ *         u2 exports_to_index[exports_to_count];
+ *     } exports[exports_count];
+ *
+ *     u2 opens_count;
+ *     {   u2 opens_index;
+ *         u2 opens_flags;
+ *         u2 opens_to_count;
+ *         u2 opens_to_index[opens_to_count];
+ *     } opens[opens_count];
+ *
+ *     u2 uses_count;
+ *     u2 uses_index[uses_count];
+ *
+ *     u2 provides_count;
+ *     {   u2 provides_index;
+ *         u2 provides_with_count;
+ *         u2 provides_with_index[provides_with_count];
+ *     } provides[provides_count];
+ * }}
+ * </p>
  * @since 0.15.0
+ * @todo #1183:60min Sort out the ordering of the components in this class.
+ *  The components of the DirectivesModule class should be ordered to match the JVM specification.
+ *  This includes ensuring that the order of requires, exports, opens, uses, and provides
+ *  aligns with the structure outlined in the specification.
  */
 public final class DirectivesModule implements Iterable<Directive> {
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesRecordComponent.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesRecordComponent.java
@@ -9,6 +9,16 @@ import org.xembly.Directive;
 
 /**
  * Directives Record Component.
+ * <p>All the directives in {@link DirectivesRecordComponent} are sorted according to the JVM
+ * specification:
+ * {@code
+ * record_component_info {
+ *     u2             name_index;
+ *     u2             descriptor_index;
+ *     u2             attributes_count;
+ *     attribute_info attributes[attributes_count];
+ * }}
+ * </p>
  * @since 0.15.0
  */
 public final class DirectivesRecordComponent implements Iterable<Directive> {

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesTryCatch.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesTryCatch.java
@@ -15,6 +15,15 @@ import org.xembly.Directives;
 
 /**
  * Try catch directives.
+ * <p>All the directives are sorted according to the JVM specification:
+ * {@code
+ *     {   u2 start_pc;
+ *         u2 end_pc;
+ *         u2 handler_pc;
+ *         u2 catch_type;
+ *     } exception_table[exception_table_length];
+ * }
+ * </p>
  * @since 0.1
  */
 public final class DirectivesTryCatch implements Iterable<Directive> {

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -160,6 +160,11 @@ public class XmlField {
         ACCESS,
 
         /**
+         * Field name.
+         */
+        NAME,
+
+        /**
          * Field descriptor.
          * For example, for field of type int the descriptor will be "I".
          */


### PR DESCRIPTION
This PR ensures that all directives in the `Directives` classes are sorted according to the JVM specification where it's possible, addressing issue #1183.

Related to #1183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured directive ordering and field structure follow JVM class-file expectations.
  * Field metadata now includes the name in the correct sequence.
  * Method handling updated to source try-catch blocks correctly.
  * Corrected XML-to-representation mapping to prevent mismatched field reads.

* **Documentation**
  * Added comprehensive JVM-spec alignment notes and TODOs across directive-related areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->