### PR TITLE
refactor(#1424): reorder components in DirectivesModule to match JVM spec

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesModule.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesModule.java
@@ -54,10 +54,6 @@ import org.xembly.Directive;
  * }}
  * </p>
  * @since 0.15.0
- * @todo #1183:60min Sort out the ordering of the components in this class.
- *  The components of the DirectivesModule class should be ordered to match the JVM specification.
- *  This includes ensuring that the order of requires, exports, opens, uses, and provides
- *  aligns with the structure outlined in the specification.
  */
 public final class DirectivesModule implements Iterable<Directive> {
 
@@ -81,16 +77,6 @@ public final class DirectivesModule implements Iterable<Directive> {
     private final String version;
 
     /**
-     * The internal name of the main class of this module.
-     */
-    private final String main;
-
-    /**
-     * The internal name of the packages declared by this module.
-     */
-    private final List<String> pckgs;
-
-    /**
      * The dependencies of this module.
      */
     private final List<DirectivesModuleRequired> requires;
@@ -106,14 +92,39 @@ public final class DirectivesModule implements Iterable<Directive> {
     private final List<DirectivesModuleOpened> opens;
 
     /**
+     * The internal names of the services used by this module.
+     */
+    private final List<String> uses;
+
+    /**
      *  The services provided by this module.
      *  */
     private final List<DirectivesModuleProvided> provides;
 
     /**
-     * The internal names of the services used by this module.
+     * The internal name of the main class of this module.
+     * JVM specification:
+     * {@code
+     * ModuleMainClass_attribute {
+     *     u2 attribute_name_index;
+     *     u4 attribute_length;
+     *     u2 main_class_index;
+     * }}
      */
-    private final List<String> uses;
+    private final String main;
+
+    /**
+     * The internal name of the packages declared by this module.
+     * JVM specification:
+     * {@code
+     * ModulePackages_attribute {
+     *     u2 attribute_name_index;
+     *     u4 attribute_length;
+     *     u2 package_count;
+     *     u2 package_index[package_count];
+     * }}
+     */
+    private final List<String> pckgs;
 
     /**
      * Constructor.
@@ -165,13 +176,13 @@ public final class DirectivesModule implements Iterable<Directive> {
             new DirectivesValue(this.format, "name", this.name),
             new DirectivesValue(this.format, "access", this.access),
             new DirectivesValue(this.format, "version", this.version),
-            new DirectivesValue(this.format, "main", this.main),
-            new DirectivesSeq("packages", this.packages()),
             new DirectivesSeq("requires", this.requires),
             new DirectivesSeq("exports", this.exports),
             new DirectivesSeq("opens", this.opens),
+            new DirectivesSeq("uses", this.use()),
             new DirectivesSeq("provides", this.provides),
-            new DirectivesSeq("uses", this.use())
+            new DirectivesValue(this.format, "main", this.main),
+            new DirectivesSeq("packages", this.packages())
         ).iterator();
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesModuleExported.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesModuleExported.java
@@ -12,6 +12,13 @@ import org.xembly.Directive;
 
 /**
  * Directives for module exported.
+ * JVM Specification:
+ * {@code
+ *     {   u2 exports_index; {@link #pckg}
+ *         u2 exports_flags; {@link #access}
+ *         u2 exports_to_count; {@link #modules.size()}
+ *         u2 exports_to_index[exports_to_count]; {@link #modules}
+ *     }}
  * @since 0.15.0
  */
 public final class DirectivesModuleExported implements Iterable<Directive> {

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesModuleOpened.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesModuleOpened.java
@@ -12,6 +12,12 @@ import org.xembly.Directive;
 
 /**
  * Directives for module opened.
+ * JVM Specification:
+ * {@code
+ * {   u2 opens_index; {@link #pckg}
+ *     u2 opens_flags; {@link #access}
+ *     u2 opens_to_count; {@link #modules.size()}
+ *     u2 opens_to_index[opens_to_count]; }} {@link #modules}
  * @since 0.15.0
  */
 public final class DirectivesModuleOpened implements Iterable<Directive> {

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesModuleProvided.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesModuleProvided.java
@@ -12,6 +12,12 @@ import org.xembly.Directive;
 
 /**
  * Directives for module provided.
+ * JVM Specification:
+ * {@code
+ * {   u2 provides_index; {@link #service}
+ *     u2 provides_with_count; {@link #providers.size()}
+ *     u2 provides_with_index[provides_with_count]; {@link #providers}
+ * }}
  * @since 0.15.0
  */
 public final class DirectivesModuleProvided implements Iterable<Directive> {

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesModuleRequired.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesModuleRequired.java
@@ -10,6 +10,12 @@ import org.xembly.Directive;
 /**
  * Directives for module required.
  * Mirrors {@link org.eolang.jeo.representation.bytecode.BytecodeModuleRequired}.
+ * JVM Specification:
+ * {@code
+ *     {   u2 requires_index;
+ *         u2 requires_flags; {@link #access}
+ *         u2 requires_version_index; {@link #version}
+ *     }}
  * @since 0.15.0
  */
 public final class DirectivesModuleRequired implements Iterable<Directive> {
@@ -18,11 +24,6 @@ public final class DirectivesModuleRequired implements Iterable<Directive> {
      * Directives format.
      */
     private final Format format;
-
-    /**
-     * The fully qualified name (using dots) of the dependence.
-     * */
-    private final String module;
 
     /**
      * The access flag of the dependence.
@@ -35,6 +36,11 @@ public final class DirectivesModuleRequired implements Iterable<Directive> {
      * The module version at compile time.
      */
     private final String version;
+
+    /**
+     * The fully qualified name (using dots) of the dependence.
+     * */
+    private final String module;
 
     /**
      * Constructor.
@@ -57,9 +63,9 @@ public final class DirectivesModuleRequired implements Iterable<Directive> {
         return new DirectivesJeoObject(
             "required",
             "required",
-            new DirectivesValue(this.format, "module", this.module),
             new DirectivesValue(this.format, "access", this.access),
-            new DirectivesValue(this.format, "version", this.version)
+            new DirectivesValue(this.format, "version", this.version),
+            new DirectivesValue(this.format, "module", this.module)
         ).iterator();
     }
 }


### PR DESCRIPTION
This PR resolves puzzle `1183` by sorting the components in `DirectivesModule.java` according to the JVM specification.

Fixes #1424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved module directive handling with reorganized field structure and adjusted directive emission sequence for better consistency.

* **Documentation**
  * Enhanced JVM specification documentation across module directive classes with detailed notes on directive structure mappings, field relationships, and attribute handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->