### PR TITLE
refactor(#1423): Move method name to DirectivesMethodProperties

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethodProperties.java
@@ -179,6 +179,7 @@ public final class BytecodeMethodProperties {
     public DirectivesMethodProperties directives(final BytecodeMaxs maxs, final Format format) {
         return new DirectivesMethodProperties(
             this.access,
+            this.name,
             this.descr,
             this.signature,
             this.exceptions,

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -33,10 +33,6 @@ import org.xembly.Directives;
  * - Default value (for annotation methods)
  * - And other attributes
  * @since 0.1
- * @todo #1183:60min Method name should should be moved to DirectivesMethodProperties
- *  Otherwise it breaks component ordering (see the JVM specification).
- *  The method name should be between access flags and descriptor - the both of them
- *  are defined the the {@link DirectivesMethodProperties}.
  */
 public final class DirectivesMethod implements Iterable<Directive> {
 
@@ -85,7 +81,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
      * @param name Method name
      */
     public DirectivesMethod(final String name) {
-        this(name, new DirectivesMethodProperties());
+        this(name, new DirectivesMethodProperties(name));
     }
 
     /**
@@ -167,10 +163,9 @@ public final class DirectivesMethod implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        final String mname = this.name.toString();
         return new DirectivesJeoObject(
             "method",
-            new PrefixedName("jm$", mname).encode(),
+            new PrefixedName("jm$", this.name.toString()).encode(),
             Stream.concat(
                 Stream.of(
                     this.properties,
@@ -180,10 +175,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
                 ),
                 Stream.concat(
                     this.dvalue.stream(),
-                    Stream.of(
-                        this.attributes,
-                        new DirectivesValue(this.format, "name", mname)
-                    )
+                    Stream.of(this.attributes)
                 )
             ).map(Directives::new).collect(Collectors.toList())
         ).iterator();

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethodProperties.java
@@ -37,6 +37,11 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
     private final int access;
 
     /**
+     * Method name.
+     */
+    private final String name;
+
+    /**
      * Method descriptor.
      */
     private final String descriptor;
@@ -69,12 +74,21 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
      * Constructor.
      */
     public DirectivesMethodProperties() {
-        this(Opcodes.ACC_PUBLIC, "()V", "");
+        this("main");
+    }
+
+    /**
+     * Constructor.
+     * @param name Method name.
+     */
+    public DirectivesMethodProperties(final String name) {
+        this(Opcodes.ACC_PUBLIC, name, "()V", "");
     }
 
     /**
      * Constructor.
      * @param access Access modifiers.
+     * @param name Method name.
      * @param descriptor Method descriptor.
      * @param signature Method signature.
      * @param exceptions Method exceptions.
@@ -82,12 +96,14 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
      */
     public DirectivesMethodProperties(
         final int access,
+        final String name,
         final String descriptor,
         final String signature,
         final String... exceptions
     ) {
         this(
             access,
+            name,
             descriptor,
             signature,
             exceptions,
@@ -99,6 +115,7 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
     /**
      * Constructor.
      * @param access Access modifiers.
+     * @param name Method name.
      * @param descriptor Method descriptor.
      * @param signature Method signature.
      * @param exceptions Method exceptions.
@@ -108,18 +125,20 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
      */
     public DirectivesMethodProperties(
         final int access,
+        final String name,
         final String descriptor,
         final String signature,
         final String[] exceptions,
         final DirectivesMaxs max,
         final DirectivesMethodParams params
     ) {
-        this(access, descriptor, signature, exceptions, max, params, new Format());
+        this(access, name, descriptor, signature, exceptions, max, params, new Format());
     }
 
     /**
      * Constructor.
      * @param access Access modifiers.
+     * @param name Method name.
      * @param descriptor Method descriptor.
      * @param signature Method signature.
      * @param exceptions Method exceptions.
@@ -130,6 +149,7 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
      */
     public DirectivesMethodProperties(
         final int access,
+        final String name,
         final String descriptor,
         final String signature,
         final String[] exceptions,
@@ -138,6 +158,7 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
         final Format format
     ) {
         this.access = access;
+        this.name = name;
         this.descriptor = Optional.ofNullable(descriptor).orElse("");
         this.signature = Optional.ofNullable(signature).orElse("");
         this.exceptions = Optional.ofNullable(exceptions).orElse(new String[0]).clone();
@@ -153,6 +174,7 @@ public final class DirectivesMethodProperties implements Iterable<Directive> {
         if (this.format.modifiers()) {
             dirs.append(new DirectivesMethodModifiers(this.format, this.access));
         }
+        dirs.append(new DirectivesValue(this.format, "name", this.name));
         dirs.append(new DirectivesValue(this.format, "descriptor", this.descriptor));
         dirs.append(new DirectivesValue(this.format, "signature", this.signature));
         dirs.append(

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -431,6 +431,7 @@ public final class XmlMethod {
                     name,
                     new DirectivesMethodProperties(
                         access,
+                        name,
                         descriptor,
                         "",
                         exceptions,

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeMethodTest.java
@@ -118,7 +118,7 @@ final class BytecodeMethodTest {
                         new Format(),
                         new NumberedName(1, "printSum"),
                         new DirectivesMethodProperties(
-                            Opcodes.ACC_PUBLIC, "(II)V", ""
+                            Opcodes.ACC_PUBLIC, "printSum", "(II)V", ""
                         ),
                         Arrays.asList(
                             new DirectivesInstruction(0, format, Opcodes.NEW, "ParametersExample"),

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodPropertiesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodPropertiesTest.java
@@ -27,6 +27,7 @@ final class DirectivesMethodPropertiesTest {
                 new Directives().add("o").append(
                     new DirectivesMethodProperties(
                         Opcodes.ACC_PUBLIC,
+                        "main",
                         "()V",
                         "",
                         new String[]{},
@@ -52,6 +53,7 @@ final class DirectivesMethodPropertiesTest {
                 new Directives().add("o").append(
                     new DirectivesMethodProperties(
                         Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL,
+                        "main",
                         "()V",
                         "",
                         new String[]{},

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodTest.java
@@ -91,13 +91,14 @@ final class DirectivesMethodTest {
     void generatesMethodWithSimpleBodyName() throws ImpossibleModificationException {
         final String descriptor = "()I";
         final Format format = new Format();
+        final String name = "checks1063";
         MatcherAssert.assertThat(
             "We expect that the method body name will be generated correctly without any suffixes and prefixes",
             new Xembler(
                 new DirectivesMethod(
                     format,
-                    new NumberedName(1, "checks1063"),
-                    new DirectivesMethodProperties(1, descriptor, ""),
+                    new NumberedName(1, name),
+                    new DirectivesMethodProperties(1, name, descriptor, ""),
                     Collections.singletonList(new DirectivesInstruction(0, format, Opcodes.RETURN)),
                     Collections.emptyList(),
                     new DirectivesAnnotations(),

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlMethodTest.java
@@ -44,7 +44,7 @@ final class XmlMethodTest {
                     new Xembler(
                         new DirectivesMethod(
                             name,
-                            new DirectivesMethodProperties(access, descriptor, signature)
+                            new DirectivesMethodProperties(access, name, descriptor, signature)
                         )
                     ).xml()
                 )

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlObjectTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlObjectTest.java
@@ -118,6 +118,7 @@ final class XmlObjectTest {
                         "printElement",
                         new DirectivesMethodProperties(
                             Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
+                            name.full(),
                             "(Ljava/lang/Object;)V",
                             "<T:Ljava/lang/Object;>(TT;)V"
                         )
@@ -159,14 +160,16 @@ final class XmlObjectTest {
      */
     private static String classWithException() {
         final ClassName name = new ClassName("Foo");
+        final String method = "bar";
         return new Xembler(
             new DirectivesObject(
                 new DirectivesClass(
                     name,
                     new DirectivesMethod(
-                        "bar",
+                        method,
                         new DirectivesMethodProperties(
                             Opcodes.ACC_PUBLIC,
+                            method,
                             "()V",
                             null,
                             "java/lang/Exception"


### PR DESCRIPTION
This PR resolves puzzle `1183-f42af202` by moving the method name to `DirectivesMethodProperties`, ensuring correct component ordering.

Fixes #1423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced method name handling in bytecode representation system by ensuring method names are consistently tracked and propagated through the directive generation pipeline, improving metadata consistency across method properties and directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->