### PR TITLE
refactor(#1421): Move class signature to DirectivesClass from properties

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -297,6 +297,7 @@ public final class BytecodeClass {
             this.cmethods.stream()
                 .map(method -> method.directives(this.mnumber(method), format))
                 .collect(Collectors.toList()),
+            this.props.signature(),
             this.annotations.directives(format),
             this.attributes.directives(format, "attributes")
         );

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClassProperties.java
@@ -138,7 +138,6 @@ public final class BytecodeClassProperties {
             format,
             this.version,
             this.access,
-            this.signature,
             this.supername,
             this.interfaces
         );

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.PrefixedName;
 import org.xembly.Directive;
@@ -77,6 +78,11 @@ public final class DirectivesClass implements Iterable<Directive> {
     private final List<DirectivesMethod> methods;
 
     /**
+     * Class Signature.
+     */
+    private final String signature;
+
+    /**
      * Annotations.
      */
     private final DirectivesAnnotations annotations;
@@ -97,10 +103,24 @@ public final class DirectivesClass implements Iterable<Directive> {
     /**
      * Constructor.
      * @param classname The class name
+     * @param signature The class signature
      * @param properties The class properties
      */
-    public DirectivesClass(final String classname, final DirectivesClassProperties properties) {
-        this(new ClassName(classname), properties);
+    public DirectivesClass(
+        final String classname,
+        final String signature,
+        final DirectivesClassProperties properties
+    ) {
+        this(
+            new Format(),
+            new ClassName(classname),
+            properties,
+            new ArrayList<>(0),
+            new ArrayList<>(0),
+            signature,
+            new DirectivesAnnotations(),
+            new DirectivesAttributes()
+        );
     }
 
     /**
@@ -124,6 +144,7 @@ public final class DirectivesClass implements Iterable<Directive> {
      * @param properties The class properties
      * @param fields The class fields
      * @param methods The class methods
+     * @param signature The class signature
      * @param annotations The annotations
      * @param attributes The attributes
      * @checkstyle ParameterNumberCheck (5 lines)
@@ -134,6 +155,7 @@ public final class DirectivesClass implements Iterable<Directive> {
         final DirectivesClassProperties properties,
         final List<DirectivesField> fields,
         final List<DirectivesMethod> methods,
+        final String signature,
         final DirectivesAnnotations annotations,
         final DirectivesAttributes attributes
     ) {
@@ -142,6 +164,7 @@ public final class DirectivesClass implements Iterable<Directive> {
         this.properties = properties;
         this.fields = fields;
         this.methods = methods;
+        this.signature = signature;
         this.annotations = annotations;
         this.attributes = attributes;
     }
@@ -189,6 +212,7 @@ public final class DirectivesClass implements Iterable<Directive> {
             properties,
             fields,
             methods,
+            "",
             new DirectivesAnnotations(),
             new DirectivesAttributes()
         );
@@ -203,8 +227,22 @@ public final class DirectivesClass implements Iterable<Directive> {
             new DirectivesValue(this.format, "name", this.name.full().replace('.', '/')),
             this.fields.stream().map(Directives::new).reduce(new Directives(), Directives::append),
             this.methods.stream().map(Directives::new).reduce(new Directives(), Directives::append),
+            new DirectivesValue(this.format, "signature", this.sign()),
             this.annotations,
             this.attributes
         ).iterator();
+    }
+
+    /**
+     * The "signature" refers to generic type information in Java bytecode.
+     * Contains information about:
+     * Type parameters (generics) for classes and methods
+     * Type bounds for generic parameters
+     * Generic superclasses and interfaces
+     * Generic field and method types
+     * @return Signature of the class.
+     */
+    private String sign() {
+        return Optional.ofNullable(this.signature).orElse("");
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
@@ -5,7 +5,6 @@
 package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
-import java.util.Optional;
 import org.eolang.jeo.representation.DefaultVersion;
 import org.xembly.Directive;
 import org.xembly.Directives;
@@ -52,11 +51,6 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
     private final int access;
 
     /**
-     * Class Signature.
-     */
-    private final String signature;
-
-    /**
      * Class supername.
      */
     private final String supername;
@@ -75,14 +69,6 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
 
     /**
      * Constructor.
-     * @param access Access modifiers.
-     */
-    public DirectivesClassProperties(final int access) {
-        this(access, "");
-    }
-
-    /**
-     * Constructor.
      * @param format Format of the directives.
      * @param access Access modifiers.
      */
@@ -92,7 +78,6 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
             new DefaultVersion().bytecode(),
             access,
             "",
-            "",
             DirectivesClassProperties.EMPTY_INTERFACES
         );
     }
@@ -100,23 +85,20 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
     /**
      * Constructor.
      * @param access Access modifiers.
-     * @param signature Class Signature.
      */
-    public DirectivesClassProperties(final int access, final String signature) {
-        this(access, signature, "", DirectivesClassProperties.EMPTY_INTERFACES);
+    public DirectivesClassProperties(final int access) {
+        this(access, "", DirectivesClassProperties.EMPTY_INTERFACES);
     }
 
     /**
      * Constructor.
      * @param access Access modifiers.
-     * @param signature Class Signature.
      * @param supername Class supername.
      * @param interfaces Class interfaces.
      * @checkstyle ParameterNumberCheck (5 lines)
      */
     public DirectivesClassProperties(
         final int access,
-        final String signature,
         final String supername,
         final String... interfaces
     ) {
@@ -124,7 +106,6 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
             new Format(),
             new DefaultVersion().bytecode(),
             access,
-            signature,
             supername,
             interfaces.clone()
         );
@@ -135,7 +116,6 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
      * @param format Format of the directives.
      * @param version Bytecode version.
      * @param access Access modifiers.
-     * @param signature Class Signature.
      * @param supername Class supername.
      * @param interfaces Class interfaces.
      * @checkstyle ParameterNumberCheck (6 lines)
@@ -144,14 +124,12 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
         final Format format,
         final int version,
         final int access,
-        final String signature,
         final String supername,
         final String... interfaces
     ) {
         this.format = format;
         this.version = version;
         this.access = access;
-        this.signature = signature;
         this.supername = supername;
         this.interfaces = interfaces.clone();
     }
@@ -170,23 +148,6 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
         if (this.interfaces != null) {
             directives.append(new DirectivesValues(this.format, "interfaces", this.interfaces));
         }
-        directives.append(new DirectivesValue(this.format, "signature", this.sign()));
         return directives.iterator();
-    }
-
-    /**
-     * The "signature" refers to generic type information in Java bytecode.
-     * Contains information about:
-     * Type parameters (generics) for classes and methods
-     * Type bounds for generic parameters
-     * Generic superclasses and interfaces
-     * Generic field and method types
-     * @return Signature of the class.
-     * @todo #1183:90min Signature is a class attribute, not a property.
-     *  Since 'signature' is a class attribute, but not a property, it makes sense to move
-     *  it to a {@link DirectivesClass}, to attributes section.
-     */
-    private String sign() {
-        return Optional.ofNullable(this.signature).orElse("");
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -66,10 +66,15 @@ public final class XmlClass {
     /**
      * Constructor.
      * @param classname The class name
+     * @param sign The class signature
      * @param properties The class properties
      */
-    XmlClass(final String classname, final DirectivesClassProperties properties) {
-        this("", XmlClass.withProps(classname, properties));
+    XmlClass(
+        final String classname,
+        final String sign,
+        final DirectivesClassProperties properties
+    ) {
+        this("", XmlClass.withProps(classname, sign, properties));
     }
 
     /**
@@ -183,22 +188,23 @@ public final class XmlClass {
      * @return Class node.
      */
     private static XmlNode empty(final String classname) {
-        return XmlClass.withProps(classname, new DirectivesClassProperties(Opcodes.ACC_PUBLIC));
+        return XmlClass.withProps(classname, "", new DirectivesClassProperties(Opcodes.ACC_PUBLIC));
     }
 
     /**
      * Generate class node with given name and access.
      * @param classname Class name.
+     * @param sign Class signature.
      * @param props Class properties.
      * @return Class node.
      */
     private static XmlNode withProps(
-        final String classname, final DirectivesClassProperties props
+        final String classname, final String sign, final DirectivesClassProperties props
     ) {
         return new NativeXmlNode(
             new XMLDocument(
                 new Xembler(
-                    new DirectivesClass(classname, props),
+                    new DirectivesClass(classname, sign, props),
                     new Transformers.Node()
                 ).xmlQuietly()
             ).deepCopy().getFirstChild()

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassPropertiesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassPropertiesTest.java
@@ -30,7 +30,6 @@ final class DirectivesClassPropertiesTest {
                         new DirectivesClassProperties(
                             1,
                             "org/eolang/SomeClass",
-                            "java/lang/Object",
                             "org/eolang/SomeInterface"
                         )
                     ).up()
@@ -38,59 +37,9 @@ final class DirectivesClassPropertiesTest {
             XhtmlMatchers.hasXPaths(
                 "/o/o[contains(@base,'number') and contains(@name,'version')]",
                 "/o/o[contains(@base,'number') and contains(@name,'access')]",
-                "/o/o[contains(@base,'string') and contains(@name,'signature')]",
                 "/o/o[contains(@base,'string') and contains(@name,'supername')]",
                 new JeoBaseXpath("./o/o", "seq.of1").toXpath(),
                 "/o/o[contains(@name,'interfaces')]"
-            )
-        );
-    }
-
-    @Test
-    void createsDirectivesWithMandatorySignature() throws ImpossibleModificationException {
-        MatcherAssert.assertThat(
-            "Can't create proper xml with mandatory signature",
-            new Xembler(
-                new Directives()
-                    .add("o")
-                    .append(
-                        new DirectivesClassProperties(
-                            1,
-                            null,
-                            "java/lang/Object",
-                            "org/eolang/SomeInterface"
-                        )
-                    ).up()
-            ).xml(),
-            XhtmlMatchers.hasXPaths(
-                "//o[contains(@name,'signature')]"
-            )
-        );
-    }
-
-    /**
-     * This test was added to ensure that when a null signature is passed,
-     * it is converted to an empty string in the XML output.
-     * See more details in
-     * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/1246">#1246</a>
-     * @throws ImpossibleModificationException in case of XML modification failure.
-     */
-    @Test
-    void convertsNullSignatureToEmptyString() throws ImpossibleModificationException {
-        MatcherAssert.assertThat(
-            "Signature should be empty string when null is passed",
-            new Xembler(
-                new Directives().add("o").append(
-                    new DirectivesClassProperties(
-                        1,
-                        null,
-                        "java/lang/Object",
-                        "org/eolang/SomeInterface"
-                    )
-                ).up()
-            ).xml(),
-            XhtmlMatchers.hasXPath(
-                "//o[@name='signature']/o[contains(@base,'bytes')]/o[text()='--']"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -13,6 +13,7 @@ import org.eolang.jeo.representation.bytecode.JavaCodec;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.xembly.Directives;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Transformers;
 import org.xembly.Xembler;
@@ -38,6 +39,7 @@ final class DirectivesClassTest {
                     new DirectivesClassProperties(),
                     Collections.emptyList(),
                     Collections.emptyList(),
+                    "",
                     new DirectivesAnnotations(
                         "annotations", new DirectivesAnnotation("Override", true)
                     ),
@@ -108,6 +110,53 @@ final class DirectivesClassTest {
                     new DirectivesValue(0, new Format(), name.replace('.', '/'))
                         .hex(new JavaCodec())
                 )
+            )
+        );
+    }
+
+    @Test
+    void createsDirectivesWithMandatorySignature() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "Can't create proper xml with mandatory signature",
+            new Xembler(
+                new Directives()
+                    .add("o")
+                    .append(
+                        new DirectivesClass(
+                            "MyClass",
+                            "org/eolang/SomeClass",
+                            new DirectivesClassProperties()
+                        )
+                    ).up()
+            ).xml(),
+            XhtmlMatchers.hasXPaths(
+                "//o[contains(@name,'signature')]"
+            )
+        );
+    }
+
+    /**
+     * This test was added to ensure that when a null signature is passed,
+     * it is converted to an empty string in the XML output.
+     * See more details in
+     * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/1246">#1246</a>
+     * @throws ImpossibleModificationException in case of XML modification failure.
+     */
+    @Test
+    void convertsNullSignatureToEmptyString() throws ImpossibleModificationException {
+        MatcherAssert.assertThat(
+            "Signature should be empty string when null is passed",
+            new Xembler(
+                new Directives().add("o").append(
+                    new DirectivesClass(
+                        "MyClass",
+                        null,
+                        new DirectivesClassProperties()
+                    )
+                ).up()
+            ).xml(),
+            XhtmlMatchers.hasXPath(
+                "//o[@name='signature']/o[contains(@base,'bytes')]/o[text()='--']"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlClassPropertiesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlClassPropertiesTest.java
@@ -27,9 +27,9 @@ final class XmlClassPropertiesTest {
             "We expect that the properties will be created correctly and contain the correct values",
             new XmlClass(
                 "Language",
+                signature,
                 new DirectivesClassProperties(
                     access,
-                    signature,
                     supername,
                     interfaces
                 )

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlClassTest.java
@@ -60,9 +60,9 @@ final class XmlClassTest {
                     new Xembler(
                         new DirectivesClass(
                             name,
+                            signature,
                             new DirectivesClassProperties(
                                 access,
-                                signature,
                                 supername,
                                 interfce
                             )


### PR DESCRIPTION
This PR resolves the puzzle regarding the `signature` attribute in `DirectivesClassProperties`, moving it to `DirectivesClass`.

Fixes #1421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured class signature handling in bytecode representation to improve organization of class-level metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->