### PR TITLE
refactor(#1420): move class name to DirectivesClassProperties to fix ordering

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -291,8 +291,8 @@ public final class BytecodeClass {
     public DirectivesClass directives(final Format format) {
         return new DirectivesClass(
             format,
-            this.name,
-            this.props.directives(format),
+            this.name(),
+            this.props.directives(format, this.name()),
             this.fields.stream().map(f -> f.directives(format)).collect(Collectors.toList()),
             this.cmethods.stream()
                 .map(method -> method.directives(this.mnumber(method), format))
@@ -312,7 +312,7 @@ public final class BytecodeClass {
             visitor.visit(
                 this.props.version(),
                 this.props.access(),
-                this.name.full(),
+                this.name().full(),
                 this.props.signature(),
                 this.supername(),
                 this.props.interfaces()

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClassProperties.java
@@ -6,6 +6,7 @@ package org.eolang.jeo.representation.bytecode;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.DefaultVersion;
 import org.eolang.jeo.representation.directives.DirectivesClassProperties;
 import org.eolang.jeo.representation.directives.Format;
@@ -31,11 +32,6 @@ public final class BytecodeClassProperties {
     private final int access;
 
     /**
-     * Signature.
-     */
-    private final String signature;
-
-    /**
      * Supername.
      */
     private final String supername;
@@ -44,6 +40,11 @@ public final class BytecodeClassProperties {
      * Interfaces.
      */
     private final String[] interfaces;
+
+    /**
+     * Signature.
+     */
+    private final String signature;
 
     /**
      * Constructor.
@@ -133,11 +134,12 @@ public final class BytecodeClassProperties {
         return this.interfaces.clone();
     }
 
-    public DirectivesClassProperties directives(final Format format) {
+    public DirectivesClassProperties directives(final Format format, final ClassName name) {
         return new DirectivesClassProperties(
             format,
             this.version,
             this.access,
+            name,
             this.supername,
             this.interfaces
         );

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -45,11 +45,7 @@ import org.xembly.Directives;
  * </a>
  * </p>
  * @since 0.1.0
- * @todo #1183:60min Class name should should be moved to DirectivesClassProperties
- *  Otherwise it breaks component ordering (see the JVM specification).
- *  The class name should be between access flags and superclasses - the both of them
- *  are defined the the {@link DirectivesClassProperties}.
- */
+*/
 public final class DirectivesClass implements Iterable<Directive> {
 
     /**
@@ -224,7 +220,6 @@ public final class DirectivesClass implements Iterable<Directive> {
             "class",
             new PrefixedName(this.name.name()).encode(),
             this.properties,
-            new DirectivesValue(this.format, "name", this.name.full().replace('.', '/')),
             this.fields.stream().map(Directives::new).reduce(new Directives(), Directives::append),
             this.methods.stream().map(Directives::new).reduce(new Directives(), Directives::append),
             new DirectivesValue(this.format, "signature", this.sign()),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClassProperties.java
@@ -5,6 +5,7 @@
 package org.eolang.jeo.representation.directives;
 
 import java.util.Iterator;
+import org.eolang.jeo.representation.ClassName;
 import org.eolang.jeo.representation.DefaultVersion;
 import org.xembly.Directive;
 import org.xembly.Directives;
@@ -51,6 +52,11 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
     private final int access;
 
     /**
+     * Class name.
+     */
+    private final ClassName name;
+
+    /**
      * Class supername.
      */
     private final String supername;
@@ -77,6 +83,22 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
             format,
             new DefaultVersion().bytecode(),
             access,
+            new ClassName("SomeClass"),
+            "",
+            DirectivesClassProperties.EMPTY_INTERFACES
+        );
+    }
+
+    /**
+     * Constructor.
+     * @param name Name of the class.
+     */
+    public DirectivesClassProperties(final String name) {
+        this(
+            new Format(),
+            new DefaultVersion().bytecode(),
+            0,
+            new ClassName(name),
             "",
             DirectivesClassProperties.EMPTY_INTERFACES
         );
@@ -106,6 +128,7 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
             new Format(),
             new DefaultVersion().bytecode(),
             access,
+            new ClassName("SomeClass"),
             supername,
             interfaces.clone()
         );
@@ -116,6 +139,7 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
      * @param format Format of the directives.
      * @param version Bytecode version.
      * @param access Access modifiers.
+     * @param name Class name.
      * @param supername Class supername.
      * @param interfaces Class interfaces.
      * @checkstyle ParameterNumberCheck (6 lines)
@@ -124,12 +148,14 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
         final Format format,
         final int version,
         final int access,
+        final ClassName name,
         final String supername,
         final String... interfaces
     ) {
         this.format = format;
         this.version = version;
         this.access = access;
+        this.name = name;
         this.supername = supername;
         this.interfaces = interfaces.clone();
     }
@@ -142,6 +168,9 @@ public final class DirectivesClassProperties implements Iterable<Directive> {
         if (this.format.modifiers()) {
             directives.append(new DirectivesClassModifiers(this.format, this.access));
         }
+        directives.append(
+            new DirectivesValue(this.format, "name", this.name.full().replace('.', '/'))
+        );
         if (this.supername != null) {
             directives.append(new DirectivesValue(this.format, "supername", this.supername));
         }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -15,6 +15,7 @@ import org.eolang.jeo.representation.PrefixedName;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.eolang.jeo.representation.bytecode.BytecodeAttributes;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
+import org.eolang.jeo.representation.bytecode.BytecodeClassProperties;
 import org.eolang.jeo.representation.directives.DirectivesClass;
 import org.eolang.jeo.representation.directives.DirectivesClassProperties;
 import org.objectweb.asm.Opcodes;
@@ -82,6 +83,7 @@ public final class XmlClass {
      * @return Bytecode class.
      */
     public BytecodeClass bytecode() {
+        final BytecodeClassProperties props = this.properties().bytecode();
         try {
             return new BytecodeClass(
                 new ClassName(
@@ -98,7 +100,7 @@ public final class XmlClass {
                 this.attributes()
                     .map(XmlAttributes::attributes)
                     .orElseGet(BytecodeAttributes::new),
-                this.properties().bytecode()
+                props
             );
         } catch (final IllegalStateException exception) {
             throw new ParsingException(
@@ -109,21 +111,6 @@ public final class XmlClass {
                 exception
             );
         }
-    }
-
-    /**
-     * Class name.
-     * @return Name.
-     */
-    private String name() {
-        return this.node.attribute("name").orElseThrow(
-            () -> new IllegalStateException(
-                String.format(
-                    "Class name is not defined, expected attribute 'name' in %s",
-                    this.node
-                )
-            )
-        );
     }
 
     /**
@@ -145,6 +132,21 @@ public final class XmlClass {
      */
     private XmlClassProperties properties() {
         return new XmlClassProperties(this.node);
+    }
+
+    /**
+     * Class name.
+     * @return Name.
+     */
+    private String name() {
+        return this.node.attribute("name").orElseThrow(
+            () -> new IllegalStateException(
+                String.format(
+                    "Class name is not defined, expected attribute 'name' in %s",
+                    this.node
+                )
+            )
+        );
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -101,7 +101,8 @@ final class DirectivesClassTest {
             "Can't append fully qualified class name",
             new Xembler(
                 new DirectivesClass(
-                    new ClassName(name)
+                    new ClassName(name),
+                    new DirectivesClassProperties(name)
                 )
             ).xml(),
             XhtmlMatchers.hasXPath(


### PR DESCRIPTION
This PR resolves puzzle `1183-dfb4a741` by moving the class name to `DirectivesClassProperties`, ensuring proper component ordering.

Fixes #1420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal class representation handling to improve consistency in how class information is processed throughout the bytecode generation pipeline.
  * Updated class properties construction to better support class name management across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->