### PR TITLE
chore(deps): update org.eolang:eo-maven-plugin to v0.59.0 and remove deprecated executions

### DIFF
--- a/src/it/annotations/pom.xml
+++ b/src/it/annotations/pom.xml
@@ -46,24 +46,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eolang</groupId>
-        <artifactId>eo-maven-plugin</artifactId>
-        <version>0.57.2</version>
-        <executions>
-          <execution>
-            <id>convert-xmir-to-eo</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>xmir-to-phi</goal>
-            </goals>
-            <configuration>
-              <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
-              <phiOutputDir>${project.build.directory}/generated-sources/jeo-eo</phiOutputDir>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.6.2</version>

--- a/src/it/bytecode-to-eo/pom.xml
+++ b/src/it/bytecode-to-eo/pom.xml
@@ -55,24 +55,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.eolang</groupId>
-        <artifactId>eo-maven-plugin</artifactId>
-        <version>0.57.2</version>
-        <executions>
-          <execution>
-            <id>convert-xmir-to-phi</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>xmir-to-phi</goal>
-            </goals>
-            <configuration>
-              <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
-              <phiOutputDir>${project.build.directory}/generated-sources/jeo-phi</phiOutputDir>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
   <profiles>
@@ -86,7 +68,7 @@
           <plugin>
             <groupId>org.eolang</groupId>
             <artifactId>eo-maven-plugin</artifactId>
-            <version>0.57.2</version>
+            <version>0.59.0</version>
             <executions>
               <execution>
                 <id>convert-xmir-to-eo</id>

--- a/src/it/bytecode-to-eo/verify.groovy
+++ b/src/it/bytecode-to-eo/verify.groovy
@@ -10,7 +10,6 @@ assert log.contains("Foo.class disassembled to ")
 assert log.contains("WithoutPackage.class disassembled to ")
 assert log.contains("BUILD SUCCESS")
 //Check that we have generated XMIR object file.
-assert new File(basedir, 'target/generated-sources/jeo-phi/org/eolang/jeo/Application.phi').exists()
 File app = new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/Application.xmir')
 assert app.exists()
 assert app.text.contains("<listing>") : "We enabled listings (see the omitListings=false option) in the XMIR file, but it is absent"

--- a/src/it/custom-transformations/pom.xml
+++ b/src/it/custom-transformations/pom.xml
@@ -50,7 +50,7 @@
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>
-        <version>0.57.2</version>
+        <version>0.59.0</version>
         <executions>
           <execution>
             <id>convert-xmir-to-eo</id>
@@ -61,18 +61,6 @@
             <configuration>
               <printSourcesDir>${project.build.directory}/generated-sources/jeo-xmir</printSourcesDir>
               <printOutputDir>${project.build.directory}/generated-sources/jeo-eo</printOutputDir>
-            </configuration>
-          </execution>
-          <execution>
-            <id>convert-xmir-to-phi</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>xmir-to-phi</goal>
-            </goals>
-            <configuration>
-              <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
-              <phiOutputDir>${project.build.directory}/generated-sources/jeo-phi</phiOutputDir>
-              <stack-size>256M</stack-size>
             </configuration>
           </execution>
         </executions>

--- a/src/it/exceptions/pom.xml
+++ b/src/it/exceptions/pom.xml
@@ -64,24 +64,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.eolang</groupId>
-        <artifactId>eo-maven-plugin</artifactId>
-        <version>0.57.2</version>
-        <executions>
-          <execution>
-            <id>convert-xmir-to-eo</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>xmir-to-phi</goal>
-            </goals>
-            <configuration>
-              <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
-              <phiOutputDir>${project.build.directory}/generated-sources/jeo-eo</phiOutputDir>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/it/excludes-includes/pom.xml
+++ b/src/it/excludes-includes/pom.xml
@@ -72,24 +72,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.eolang</groupId>
-        <artifactId>eo-maven-plugin</artifactId>
-        <version>0.57.2</version>
-        <executions>
-          <execution>
-            <id>convert-xmir-to-eo</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>xmir-to-phi</goal>
-            </goals>
-            <configuration>
-              <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
-              <phiOutputDir>${project.build.directory}/generated-sources/jeo-eo</phiOutputDir>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/it/generics/pom.xml
+++ b/src/it/generics/pom.xml
@@ -47,24 +47,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eolang</groupId>
-        <artifactId>eo-maven-plugin</artifactId>
-        <version>0.57.2</version>
-        <executions>
-          <execution>
-            <id>convert-xmir-to-eo</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>xmir-to-phi</goal>
-            </goals>
-            <configuration>
-              <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
-              <phiOutputDir>${project.build.directory}/generated-sources/jeo-phi</phiOutputDir>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.6.2</version>

--- a/src/it/jna/pom.xml
+++ b/src/it/jna/pom.xml
@@ -192,7 +192,7 @@
           <plugin>
             <groupId>org.eolang</groupId>
             <artifactId>eo-maven-plugin</artifactId>
-            <version>0.57.2</version>
+            <version>0.59.0</version>
             <executions>
               <execution>
                 <id>xmir-to-phi</id>

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -65,24 +65,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.eolang</groupId>
-        <artifactId>eo-maven-plugin</artifactId>
-        <version>0.57.2</version>
-        <executions>
-          <execution>
-            <id>convert-xmir-to-phi</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>xmir-to-phi</goal>
-            </goals>
-            <configuration>
-              <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
-              <phiOutputDir>${project.build.directory}/generated-sources/phi-jeo</phiOutputDir>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <!--
         We clean target/classes directory to be sure
         that bytecode verification works without old

--- a/src/it/takes/pom.xml
+++ b/src/it/takes/pom.xml
@@ -63,24 +63,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eolang</groupId>
-        <artifactId>eo-maven-plugin</artifactId>
-        <version>0.57.2</version>
-        <executions>
-          <execution>
-            <id>convert-xmir-to-phi</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>xmir-to-phi</goal>
-            </goals>
-            <configuration>
-              <phiInputDir>${project.build.directory}/generated-sources/jeo-xmir</phiInputDir>
-              <phiOutputDir>${project.build.directory}/generated-sources/jeo-phi</phiOutputDir>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.6.2</version>


### PR DESCRIPTION
# Pull Request Description

This pull request updates the `org.eolang:eo-maven-plugin` dependency from version `0.57.2` to `0.59.0` across multiple Maven POM files. 

Fixes #1201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed xmir-to-phi conversion step from multiple integration test build configurations.
  * Updated plugin version to 0.59.0 in select modules.
  * Simplified build pipeline by eliminating intermediate conversion steps.
  * Removed related verification assertions from test validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->