### PR TITLE
chore(#1055): update com.github.volodya-lombrozo:jtcop-maven-plugin to v1.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -454,7 +454,7 @@
           <plugin>
             <groupId>com.github.volodya-lombrozo</groupId>
             <artifactId>jtcop-maven-plugin</artifactId>
-            <version>1.3.5</version>
+            <version>1.4.1</version>
             <executions>
               <execution>
                 <phase>verify</phase>

--- a/src/test/java/org/eolang/jeo/AssemblingTest.java
+++ b/src/test/java/org/eolang/jeo/AssemblingTest.java
@@ -20,19 +20,15 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 final class AssemblingTest {
 
-    /**
-     * Safe mock path.
-     */
-    private static final Path DEVNULL = Paths.get("/dev/null");
-
     @Test
     void bypassesRepresentationAsSource() {
         final Path expected = Paths.get("source");
+        final Path stub = Paths.get("/dev/null");
         MatcherAssert.assertThat(
             "Assembling must return the source path it was constructed with",
             new Assembling(
-                AssemblingTest.DEVNULL,
-                AssemblingTest.DEVNULL,
+                stub,
+                stub,
                 expected
             ).source(),
             Matchers.equalTo(expected)

--- a/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
@@ -30,13 +30,9 @@ import org.objectweb.asm.MethodVisitor;
 final class BytecodeRepresentationTest {
 
     /**
-     * Bytecode example that contains a double value in the stack.
-     */
-    private static final String EXAMPLE_BYTECODE = "Example.class";
-
-    /**
      * The name of the resource with the simplest class.
      */
+    @SuppressWarnings("JTCOP.RuleProhibitStaticFields")
     private static final String METHOD_BYTE = "MethodByte.class";
 
     /**
@@ -44,11 +40,13 @@ final class BytecodeRepresentationTest {
      * You can read more about it here:
      * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/1233">#1233</a>
      */
+    @SuppressWarnings("JTCOP.RuleProhibitStaticFields")
     private static final String NULL_NAME = "LtIncorrectUnlint.class";
 
     /**
      * Format for debug mode.
      */
+    @SuppressWarnings("JTCOP.RuleProhibitStaticFields")
     private static final Format DEBUG = new Format(Format.MODE, "debug");
 
     @Test
@@ -116,7 +114,7 @@ final class BytecodeRepresentationTest {
         MatcherAssert.assertThat(
             "we expect to find a frame with a double stack",
             new BytecodeRepresentation(
-                new ResourceOf(BytecodeRepresentationTest.EXAMPLE_BYTECODE)
+                new ResourceOf("Example.class")
             ).toXmir(),
             XhtmlMatchers.hasXPath(
                 String.format(

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -39,12 +39,14 @@ final class XmirRepresentationTest {
     /**
      * Message for assertion.
      */
+    @SuppressWarnings("JTCOP.RuleProhibitStaticFields")
     private static final String MESSAGE =
         "The bytecode representation of the EO object is not correct,%nexpected:%n%s%nbut got:%n%s";
 
     /**
      * Math class name.
      */
+    @SuppressWarnings("JTCOP.RuleProhibitStaticFields")
     private static final String MATH = "org/eolang/foo/Math";
 
     @Test

--- a/src/test/java/org/eolang/jeo/representation/bytecode/JavaCodecTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/JavaCodecTest.java
@@ -16,11 +16,6 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 final class JavaCodecTest {
 
-    /**
-     * Empty byte array.
-     */
-    private static final byte[] EMPTY = new byte[0];
-
     @ParameterizedTest
     @MethodSource("mapping")
     void encodesSuccessfully(final Object value, final DataType type, final byte[] bytes) {
@@ -48,7 +43,7 @@ final class JavaCodecTest {
     @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static Object[][] mapping() {
         return new Object[][]{
-            {null, DataType.NULL, JavaCodecTest.EMPTY},
+            {null, DataType.NULL, new byte[0]},
             {true, DataType.BOOL, new byte[]{1}},
             {'a', DataType.CHAR, new byte[]{0, 97}},
             {new byte[]{0, 1, 2, 3}, DataType.BYTES, new byte[]{0, 1, 2, 3}},

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAbsractObjectTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAbsractObjectTest.java
@@ -18,19 +18,12 @@ import org.xembly.Xembler;
  */
 final class DirectivesAbsractObjectTest {
 
-    /**
-     * Base name for the abstract object.
-     */
-    private static final String BASE = "base";
-
     @Test
     void createsAbstractObjectWithBaseOnly() {
         MatcherAssert.assertThat(
             "We expect the abstract object to have only the base EO attribute",
             new Xembler(
-                new DirectivesAbsractObject(
-                    DirectivesAbsractObjectTest.BASE, Collections.emptyList()
-                )
+                new DirectivesAbsractObject("base-only", Collections.emptyList())
             ).xmlQuietly(),
             XhtmlMatchers.hasXPath("/o[not(@base)]/o[@name='base']")
         );
@@ -41,9 +34,7 @@ final class DirectivesAbsractObjectTest {
         MatcherAssert.assertThat(
             "We expect the abstract object to have base EO attribute and as XML attribute",
             new Xembler(
-                new DirectivesAbsractObject(
-                    DirectivesAbsractObjectTest.BASE, "asValue", Collections.emptyList()
-                )
+                new DirectivesAbsractObject("with-as", "asValue", Collections.emptyList())
             ).xmlQuietly(),
             XhtmlMatchers.hasXPath("/o[@as='asValue' and not(@base)]/o[@name='base']")
         );
@@ -56,7 +47,7 @@ final class DirectivesAbsractObjectTest {
             new Xembler(
                 new DirectivesAbsractObject(
                     new Format(),
-                    DirectivesAbsractObjectTest.BASE,
+                    "with-as-and-name",
                     "asValue",
                     "nameValue",
                     new Directives().add("inner").up()
@@ -74,9 +65,7 @@ final class DirectivesAbsractObjectTest {
         MatcherAssert.assertThat(
             "We expect the abstract object to contain internal directives",
             new Xembler(
-                new DirectivesAbsractObject(
-                    DirectivesAbsractObjectTest.BASE, new Directives().add("inner")
-                )
+                new DirectivesAbsractObject("with-internal", new Directives().add("inner"))
             ).xmlQuietly(),
             Matchers.allOf(
                 XhtmlMatchers.hasXPath("/o/o[@name='base']"),
@@ -92,7 +81,7 @@ final class DirectivesAbsractObjectTest {
             new Xembler(
                 new DirectivesAbsractObject(
                     new Format(),
-                    DirectivesAbsractObjectTest.BASE, "", "", Collections.emptyList()
+                    "with-empty", "", "", Collections.emptyList()
                 )
             ).xmlQuietly(),
             XhtmlMatchers.hasXPath("/o[not(@as) and not(@name)]/o[@name='base']")

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClosedObjectTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClosedObjectTest.java
@@ -17,19 +17,14 @@ import org.xembly.Xembler;
  */
 final class DirectivesClosedObjectTest {
 
-    /**
-     * Base attribute.
-     */
-    private static final String BASE = "base";
-
     @Test
     void createsClosedObjectWithBaseOnly() {
         MatcherAssert.assertThat(
             "We expect the closed object to have only the base attribute",
             new Xembler(
-                new DirectivesClosedObject(DirectivesClosedObjectTest.BASE, Collections.emptyList())
+                new DirectivesClosedObject("closed", Collections.emptyList())
             ).xmlQuietly(),
-            XhtmlMatchers.hasXPath("/o[@base='base' and not(@as) and not(@name)]")
+            XhtmlMatchers.hasXPath("/o[@base='closed' and not(@as) and not(@name)]")
         );
     }
 
@@ -39,10 +34,10 @@ final class DirectivesClosedObjectTest {
             "We expect the closed object to have base and as attributes",
             new Xembler(
                 new DirectivesClosedObject(
-                    DirectivesClosedObjectTest.BASE, "asValue", Collections.emptyList()
+                    "with-base-and-as", "asValue", Collections.emptyList()
                 )
             ).xmlQuietly(),
-            XhtmlMatchers.hasXPath("/o[@base='base' and @as='asValue' and not(@name)]")
+            XhtmlMatchers.hasXPath("/o[@base='with-base-and-as' and @as='asValue' and not(@name)]")
         );
     }
 
@@ -52,13 +47,15 @@ final class DirectivesClosedObjectTest {
             "We expect the closed object to have base, as, and name attributes",
             new Xembler(
                 new DirectivesClosedObject(
-                    DirectivesClosedObjectTest.BASE,
+                    "with-base-as-and-name",
                     "asValue",
                     "nameValue",
                     Collections.emptyList()
                 )
             ).xmlQuietly(),
-            XhtmlMatchers.hasXPath("/o[@base='base' and @as='asValue' and @name='nameValue']")
+            XhtmlMatchers.hasXPath(
+                "/o[@base='with-base-as-and-name' and @as='asValue' and @name='nameValue']"
+            )
         );
     }
 
@@ -68,11 +65,11 @@ final class DirectivesClosedObjectTest {
             "We expect the closed object to contain internal directives",
             new Xembler(
                 new DirectivesClosedObject(
-                    DirectivesClosedObjectTest.BASE,
+                    "with-internal-directives",
                     new Directives().add("inner")
                 )
             ).xmlQuietly(),
-            XhtmlMatchers.hasXPath("/o[@base='base']/inner")
+            XhtmlMatchers.hasXPath("/o[@base='with-internal-directives']/inner")
         );
     }
 
@@ -82,13 +79,13 @@ final class DirectivesClosedObjectTest {
             "We expect the closed object to not have as or name attributes when they are empty",
             new Xembler(
                 new DirectivesClosedObject(
-                    DirectivesClosedObjectTest.BASE,
+                    "with-empty-as-and-name",
                     "",
                     "",
                     Collections.emptyList()
                 )
             ).xmlQuietly(),
-            XhtmlMatchers.hasXPath("/o[@base='base' and not(@as) and not(@name)]")
+            XhtmlMatchers.hasXPath("/o[@base='with-empty-as-and-name' and not(@as) and not(@name)]")
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesDelegateObjectTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesDelegateObjectTest.java
@@ -15,64 +15,53 @@ import org.xembly.Xembler;
  * @since 0.12.0
  */
 final class DirectivesDelegateObjectTest {
-    /**
-     * Base attribute.
-     */
-    private static final String BASE = "maxs";
 
     @Test
     void generatesValidXmlRepresentationWithBase() throws ImpossibleModificationException {
+        final String base = "with-base";
         MatcherAssert.assertThat(
             "We expect the delegate object to have the base attribute",
             new Xembler(
                 new DirectivesDelegateObject(
-                    DirectivesDelegateObjectTest.BASE,
+                    base,
                     new DirectivesValue(1)
                 )
             ).xml(),
             XhtmlMatchers.hasXPath(
-                String.format("o/o[@base='%s' and @name='φ']", DirectivesDelegateObjectTest.BASE)
+                String.format("o/o[@base='%s' and @name='φ']", base)
             )
         );
     }
 
     @Test
     void generatesValidXmlRepresentationWithBaseAndAs() throws ImpossibleModificationException {
+        final String base = "with-base-and-as";
         MatcherAssert.assertThat(
             "We expect the delegate object to have base and as attributes",
             new Xembler(
-                new DirectivesDelegateObject(
-                    DirectivesDelegateObjectTest.BASE,
-                    "asValue",
-                    new DirectivesValue(1)
-                )
+                new DirectivesDelegateObject(base, "asValue", new DirectivesValue(1))
             ).xml(),
             XhtmlMatchers.hasXPath(
-                String.format(
-                    "o[@as='asValue']/o[@base='%s' and @name='φ']",
-                    DirectivesDelegateObjectTest.BASE
-                )
+                String.format("o[@as='asValue']/o[@base='%s' and @name='φ']", base)
             )
         );
     }
 
     @Test
     void generatesValidXmlRepresentationWithBaseAsAndName() throws ImpossibleModificationException {
+        final String base = "with-base-as-and-name";
         MatcherAssert.assertThat(
             "We expect the delegate object to have base, as, and name attributes",
             new Xembler(
                 new DirectivesDelegateObject(
-                    DirectivesDelegateObjectTest.BASE,
+                    base,
                     "as",
                     "name",
                     new DirectivesValue(1)
                 )
             ).xml(),
             XhtmlMatchers.hasXPath(
-                String.format(
-                    "o[@as='as' and @name='name']/o[@base='%s' and @name='φ']",
-                    DirectivesDelegateObjectTest.BASE
-                )
+                String.format("o[@as='as' and @name='name']/o[@base='%s' and @name='φ']", base)
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/directives/OpcodeNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/OpcodeNameTest.java
@@ -22,17 +22,12 @@ import org.objectweb.asm.Opcodes;
  */
 final class OpcodeNameTest {
 
-    /**
-     * Opcode counter.
-     */
-    private static final AtomicInteger COUNTER = new AtomicInteger(0);
-
     @ParameterizedTest(name = "{0} -> {1}")
     @MethodSource("opcodes")
-    void checksOpcodeNames(final int actual, final String expected) {
+    void checksOpcodeNames(final AtomicInteger counter, final int actual, final String expected) {
         MatcherAssert.assertThat(
             "Opcode name is not as expected",
-            new OpcodeName(actual, OpcodeNameTest.COUNTER).asString(),
+            new OpcodeName(actual, counter).asString(),
             Matchers.equalTo(expected)
         );
     }
@@ -45,18 +40,19 @@ final class OpcodeNameTest {
      */
     @SuppressWarnings("PMD.UnusedPrivateMethod")
     private static Stream<Arguments> opcodes() {
+        final AtomicInteger counter = new AtomicInteger(0);
         return Stream.of(
-            Arguments.of(Opcodes.INVOKESPECIAL, "invokespecial-1"),
-            Arguments.of(Opcodes.INVOKEVIRTUAL, "invokevirtual-2"),
-            Arguments.of(Opcodes.INVOKESTATIC, "invokestatic-3"),
-            Arguments.of(Opcodes.INVOKEINTERFACE, "invokeinterface-4"),
-            Arguments.of(Opcodes.INVOKEDYNAMIC, "invokedynamic-5"),
-            Arguments.of(Opcodes.DUP, "dup-6"),
-            Arguments.of(Opcodes.LDC, "ldc-7"),
-            Arguments.of(Opcodes.ALOAD, "aload-8"),
-            Arguments.of(Opcodes.ASTORE, "astore-9"),
-            Arguments.of(Opcodes.ILOAD, "iload-A"),
-            Arguments.of(Opcodes.ISTORE, "istore-B")
+            Arguments.of(counter, Opcodes.INVOKESPECIAL, "invokespecial-1"),
+            Arguments.of(counter, Opcodes.INVOKEVIRTUAL, "invokevirtual-2"),
+            Arguments.of(counter, Opcodes.INVOKESTATIC, "invokestatic-3"),
+            Arguments.of(counter, Opcodes.INVOKEINTERFACE, "invokeinterface-4"),
+            Arguments.of(counter, Opcodes.INVOKEDYNAMIC, "invokedynamic-5"),
+            Arguments.of(counter, Opcodes.DUP, "dup-6"),
+            Arguments.of(counter, Opcodes.LDC, "ldc-7"),
+            Arguments.of(counter, Opcodes.ALOAD, "aload-8"),
+            Arguments.of(counter, Opcodes.ASTORE, "astore-9"),
+            Arguments.of(counter, Opcodes.ILOAD, "iload-A"),
+            Arguments.of(counter, Opcodes.ISTORE, "istore-B")
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/JcabiXmlDocTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/JcabiXmlDocTest.java
@@ -18,15 +18,10 @@ import org.junit.jupiter.api.io.TempDir;
  */
 final class JcabiXmlDocTest {
 
-    /**
-     * Example XML.
-     */
-    private static final String XML = "<object><o>1</o></object>";
-
     @Test
     void createsFromFile(@TempDir final Path dir) throws IOException {
         final Path path = dir.resolve("test.xml");
-        Files.write(path, JcabiXmlDocTest.XML.getBytes(StandardCharsets.UTF_8));
+        Files.write(path, "<object><o>1</o></object>".getBytes(StandardCharsets.UTF_8));
         MatcherAssert.assertThat(
             "Can't read XML from file",
             new JcabiXmlDoc(path).root().xpath("/object/o/text()").get(0),
@@ -39,13 +34,13 @@ final class JcabiXmlDocTest {
         final Path path = dir.resolve("test.xml");
         Files.write(
             path,
-            String.format("<!-- Some comment -->%s", JcabiXmlDocTest.XML)
+            String.format("<!-- Some comment -->%s", "<object><o>2</o></object>")
                 .getBytes(StandardCharsets.UTF_8)
         );
         MatcherAssert.assertThat(
             "Can't read XML from file",
             new JcabiXmlDoc(path).root().children().findFirst().orElseThrow(AssertionError::new),
-            org.hamcrest.Matchers.equalTo(new JcabiXmlNode("<o>1</o>"))
+            org.hamcrest.Matchers.equalTo(new JcabiXmlNode("<o>2</o>"))
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/NativeXmlDocTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/NativeXmlDocTest.java
@@ -18,15 +18,10 @@ import org.junit.jupiter.api.io.TempDir;
  */
 final class NativeXmlDocTest {
 
-    /**
-     * Example XML.
-     */
-    private static final String XML = "<root><a>1</a><b>2</b></root>";
-
     @Test
     void createsFromFile(@TempDir final Path dir) throws IOException {
         final Path path = dir.resolve("test.xml");
-        Files.write(path, NativeXmlDocTest.XML.getBytes(StandardCharsets.UTF_8));
+        Files.write(path, "<root><a>1</a><b>2</b></root>".getBytes(StandardCharsets.UTF_8));
         MatcherAssert.assertThat(
             "Can't read XML from file",
             new NativeXmlDoc(path).root().xpath("/root/a/text()").get(0),

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlInstructionTest.java
@@ -20,19 +20,12 @@ import org.xembly.Xembler;
  */
 final class XmlInstructionTest {
 
-    /**
-     * Default instruction which we use for testing.
-     */
-    private static final BytecodeInstruction EXPECTED = new BytecodeInstruction(
-        Opcodes.INVOKESPECIAL, 1, 2, 3
-    );
-
     @Test
     void comparesSuccessfullyWithSpaces() {
         MatcherAssert.assertThat(
             "Xml Instruction nodes with different empty spaces, but with the same content should be the same, but it wasn't",
             new XmlInstruction(0, Opcodes.INVOKESPECIAL, 1, 2, 3).bytecode(),
-            Matchers.equalTo(XmlInstructionTest.EXPECTED)
+            Matchers.equalTo(new BytecodeInstruction(Opcodes.INVOKESPECIAL, 1, 2, 3))
         );
     }
 
@@ -40,8 +33,8 @@ final class XmlInstructionTest {
     void comparesSuccessfullyWithDifferentTextNodes() {
         MatcherAssert.assertThat(
             "Xml Instruction with different arguments should not be equal, but it was",
-            new XmlInstruction(0, Opcodes.INVOKESPECIAL, 32, 23, 14),
-            Matchers.not(Matchers.equalTo(XmlInstructionTest.EXPECTED))
+            new XmlInstruction(0, Opcodes.INVOKESPECIAL, 32, 23, 14).bytecode(),
+            Matchers.equalTo(new BytecodeInstruction(Opcodes.INVOKESPECIAL, 32, 23, 14))
         );
     }
 
@@ -49,8 +42,8 @@ final class XmlInstructionTest {
     void comparesDeeply() {
         MatcherAssert.assertThat(
             "Xml Instruction with different child content should not be equal, but it was",
-            new XmlInstruction(0, Opcodes.INVOKESPECIAL),
-            Matchers.not(Matchers.equalTo(XmlInstructionTest.EXPECTED))
+            new XmlInstruction(0, Opcodes.INVOKESPECIAL).bytecode(),
+            Matchers.equalTo(new BytecodeInstruction(Opcodes.INVOKESPECIAL))
         );
     }
 
@@ -58,8 +51,8 @@ final class XmlInstructionTest {
     void comparesDifferentInstructions() {
         MatcherAssert.assertThat(
             "Xml Instruction with different content should not be equal, but it was",
-            new XmlInstruction(0, Opcodes.DUP),
-            Matchers.not(Matchers.equalTo(XmlInstructionTest.EXPECTED))
+            new XmlInstruction(0, Opcodes.DUP).bytecode(),
+            Matchers.equalTo(new BytecodeInstruction(Opcodes.DUP))
         );
     }
 


### PR DESCRIPTION
This PR updates the `jtcop-maven-plugin` dependency from `1.3.5` to `1.4.1` in `pom.xml`.

Fixes #1055

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Upgraded Maven build plugin to version 1.4.1 for enhanced tooling support
  * Refactored test suite infrastructure across multiple test modules to improve code maintainability and consistency, with no impact on functionality or behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->