### PR TITLE
ci(#1464): remove hone profile from release pipeline to prevent errors

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -23,5 +23,5 @@ release:
     [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit -1
     mvn versions:set "-DnewVersion=${tag}"
     git commit -am "${tag}"
-    mvn clean install -Pqulice,hone --errors --batch-mode -Dinvoker.skip -DskipITs
+    mvn clean install -Pqulice --errors --batch-mode -Dinvoker.skip -DskipITs
     mvn clean deploy -Pobjectionary -Psonatype --errors --settings ../settings.xml -Dstyle.color=never


### PR DESCRIPTION
This PR removes the `hone` profile from the release pipeline in `.rultor.yml` to prevent errors during Docker execution.

Fixes #1464

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Maven profile configuration in the release build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->