### PR TITLE
feat(#1137): replace eo-maven-plugin with phino for XMIR/PHI conversion

### DIFF
--- a/.github/workflows/phino.yml
+++ b/.github/workflows/phino.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: phino
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+concurrency:
+  group: phino-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 21
+      - uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-
+      - name: Install phino
+        run: |
+          sudo curl -L -o /usr/local/bin/phino http://phino.objectionary.com/releases/ubuntu-24.04/phino-0.0.0.67
+          sudo chmod +x /usr/local/bin/phino
+          phino --version
+      - run: mvn clean install -D"skipTests" -D"invoker.test=phi-unphi" --errors --batch-mode

--- a/src/it/phi-unphi/phino.sh
+++ b/src/it/phi-unphi/phino.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+
+set -e
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <input_directory> <output_directory>"
+    echo "Example: $0 target/generated-sources/jeo-disassemble target/generated-sources/eo-unphi"
+    exit 1
+fi
+
+INPUT_DIR="$1"
+OUTPUT_DIR="$2"
+
+echo "phino xmir->xmir: input=$INPUT_DIR output=$OUTPUT_DIR"
+
+mkdir -p "$OUTPUT_DIR"
+
+find "$INPUT_DIR" -name "*.xmir" | while IFS= read -r input_file; do
+    relative="${input_file#${INPUT_DIR}/}"
+    output_file="${OUTPUT_DIR}/${relative}"
+    mkdir -p "$(dirname "$output_file")"
+    echo "Transforming: $input_file -> $output_file"
+    phino rewrite --input=xmir --output=xmir "$input_file" -t "$output_file"
+done
+
+echo "phino xmir->xmir: done, output in $OUTPUT_DIR"

--- a/src/it/phi-unphi/phino.sh
+++ b/src/it/phi-unphi/phino.sh
@@ -19,7 +19,7 @@ echo "phino xmir->xmir: input=$INPUT_DIR output=$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR"
 
 find "$INPUT_DIR" -name "*.xmir" | while IFS= read -r input_file; do
-    relative="${input_file#${INPUT_DIR}/}"
+    relative="${input_file#"${INPUT_DIR}/"}"
     output_file="${OUTPUT_DIR}/${relative}"
     mkdir -p "$(dirname "$output_file")"
     echo "Transforming: $input_file -> $output_file"

--- a/src/it/phi-unphi/pom.xml
+++ b/src/it/phi-unphi/pom.xml
@@ -73,7 +73,7 @@
             <id>phino-transformations</id>
             <phase>process-classes</phase>
             <goals>
-               <goal>exec</goal>
+              <goal>exec</goal>
             </goals>
             <configuration>
               <executable>/bin/bash</executable>

--- a/src/it/phi-unphi/pom.xml
+++ b/src/it/phi-unphi/pom.xml
@@ -12,17 +12,13 @@
   <description>
      This test resembles the hone-maven-plugin integration test that can be
      found here: (https://github.com/objectionary/hone-maven-plugin/tree/master/src/it/simple
-     When it is needed, I will update this test according
-     to the changes made in the hone-maven-plugin integration test.
   </description>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <eo.version>0.59.0</eo.version>
     <stack-size>256M</stack-size>
     <jeo.disassemble>${project.build.directory}/generated-sources/jeo-disassemble</jeo.disassemble>
-    <eo.phi>${project.build.directory}/generated-sources/eo-phi</eo.phi>
     <eo.unphi>${project.build.directory}/generated-sources/eo-unphi</eo.unphi>
     <jeo.assemble>jeo-assemble</jeo.assemble>
   </properties>
@@ -69,39 +65,25 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eolang</groupId>
-        <artifactId>eo-maven-plugin</artifactId>
-        <version>${eo.version}</version>
-        <executions>
-          <execution>
-            <id>xmir-to-phi</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>xmir-to-phi</goal>
-            </goals>
-            <configuration>
-              <phiInputDir>${jeo.disassemble}</phiInputDir>
-              <phiOutputDir>${eo.phi}</phiOutputDir>
-            </configuration>
-          </execution>
-          <execution>
-            <id>phi-to-xmir</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>phi-to-xmir</goal>
-            </goals>
-            <configuration>
-              <unphiInputDir>${eo.phi}</unphiInputDir>
-              <unphiOutputDir>${eo.unphi}</unphiOutputDir>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.6.2</version>
         <executions>
+          <execution>
+            <id>phino-transformations</id>
+            <phase>process-classes</phase>
+            <goals>
+               <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>/bin/bash</executable>
+              <arguments>
+                <argument>${project.basedir}/phino.sh</argument>
+                <argument>${jeo.disassemble}</argument>
+                <argument>${eo.unphi}</argument>
+              </arguments>
+            </configuration>
+          </execution>
           <execution>
             <phase>
               verify
@@ -109,16 +91,16 @@
             <goals>
               <goal>exec</goal>
             </goals>
+            <configuration>
+              <executable>java</executable>
+              <arguments>
+                <argument>-classpath</argument>
+                <argument>${jeo.assemble}</argument>
+                <argument>org.eolang.hone.App</argument>
+              </arguments>
+            </configuration>
           </execution>
         </executions>
-        <configuration>
-          <executable>java</executable>
-          <arguments>
-            <argument>-classpath</argument>
-            <argument>${jeo.assemble}</argument>
-            <argument>org.eolang.hone.App</argument>
-          </arguments>
-        </configuration>
       </plugin>
       <!--
         We clean target/classes directory to be sure

--- a/src/it/phi-unphi/verify.groovy
+++ b/src/it/phi-unphi/verify.groovy
@@ -7,89 +7,12 @@ import java.nio.file.Files
 String log = new File(basedir, 'build.log').text;
 assert log.contains("BUILD SUCCESS"): assertionMessage("BUILD FAILED")
 assert log.contains("sin(42.000000) = -0.916522"): assertionMessage("sin(42.000000) = -0.916522 not found")
-def phi = new File(basedir, "target/generated-sources/eo-phi/org/eolang/hone/App.phi").text
-assert phi.contains("Φ.jeo.opcode.dup(89)"): assertionMessage("We can't find the correct PHI integer representation")
-assert phi.contains("arg0 ↦ Φ.jeo.param("): assertionMessage("We can't find the correct PHI parameter representation")
-assert new File(basedir, "target/generated-sources/eo-phi/org/eolang/hone/mess/A.phi").text
-  .contains("j\$print-3"): assertionMessage("We can't find overloaded method in PHI (with an additional number that is allow us to distinguish between overloaded methods)")
 
 private String assertionMessage(String message) {
-    generateGitHubIssue()
     return String.format(
       "'%s', you can find the entire log in the 'file://%s' file",
       message,
       new File(basedir, 'build.log').absolutePath)
-}
-
-private void generateGitHubIssue() {
-    new File(basedir, 'build.log').text
-    copyAll('org/eolang/hone/App')
-    copyAll('org/eolang/hone/param/Parameter')
-    def issue = new File(basedir, "issue.md")
-    issue.text = '''I run the following [integration test](https://github.com/objectionary/jeo-maven-plugin/tree/master/src/it/phi-unphi):
-
- bytecode -> (disassemble) `xmir`  -> `phi` -> `unphi` -> `xmir` (assemble) -> bytecode.
-
- And this test fails because `phi/unphi` alter the original `xmir` file.
-
- **Steps to reproduce:**
-
- 1) I generate `App.xmir` from `App.class` file (`jeo:disassemble`):
- [App.xmir.disassemble.txt](todo)
- 2) Then I use `eo:0.39.0:xmir-to-phi` to generate `App.phi`:
- [App.phi.txt](todo)
- 3) Then I run `eo:0.39.0:phi-to-xmir` to generate `App.xmir` (and it is generated):
- [App.xmir.unphi.txt](todo)
-
- **Expected behaviour:**
-
- `App.xmir.disassemble.txt` and `App.xmir.unphi.txt` files should be the same. In other words, `phi/unphi` does not
- have to change the original `xmir` file.
-
- **Actual behaviour:**
-
- `App.xmir.disassemble.txt` and `App.xmir.unphi.txt` files are different. `phi/unphi` significantly changes the original `xmir`.
-
- **Details:**
-    '''
-
-    // Generate the Bash script
-    def bashScript = """#!/usr/bin/env bash
-
-# Attachments
-file1="App.xmir.disassemble.txt"
-file2="App.phi.txt"
-file3="App.xmir.unphi.txt"
-
-# Create the issue using the 'gh' CLI
-gh issue create \\
-    --title "Integration Test Failure: `phi/unphi` alters xmir file" \\
-    --body "\$(cat ${basedir}/issue.md)" \\
-    --label "bug" \\
-    --repo objectionary/eo
-    """
-
-    def file = new File(basedir, "create_issue.sh")
-    file.text = bashScript
-    println "Bash script generated: file://${basedir}/create_issue.sh"
-}
-
-private void copyAll(final String subpath) {
-    def name = subpath.tokenize('/').last()
-    copy('target/generated-sources/jeo-disassemble/' + subpath + ".xmir", name + '.xmir.disassemble.txt')
-    copy('target/generated-sources/eo-phi/' + subpath + ".phi", name + '.phi.txt')
-    copy('target/generated-sources/eo-unphi/' + subpath + '.xmir', name + '.xmir.unphi.txt')
-}
-
-private void copy(final String source, final String destination) {
-    def sourceFile = new File(basedir, source).toPath()
-    def destinationFile = new File(basedir, destination).toPath()
-    Files.copy(sourceFile, destinationFile);
-    if (Files.exists(destinationFile)) {
-        println "'${source}' moved and renamed to '${destination}'!"
-    } else {
-        println "Failed to move the '${source}' file to '${destination}'."
-    }
 }
 
 true


### PR DESCRIPTION
This PR replaces `eo-maven-plugin` XMIR/PHI conversion with `phino` binary usage to check that `jeo-maven-plugin` works correctly with `phino`. 

Fixes #1137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated the build pipeline's file transformation processing, replacing the previous approach with a new method for converting and processing source files.
  * Streamlined build configuration by consolidating transformation execution steps.

* **Tests**
  * Simplified test verification procedures by removing redundant assertions and artifact validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->