### PR TITLE
#1469: remove unreachable null check in AsmUnknownAttribute.write()

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/asm/AsmUnknownAttribute.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmUnknownAttribute.java
@@ -79,11 +79,6 @@ public final class AsmUnknownAttribute extends Attribute {
         final int stack,
         final int locals
     ) {
-        if (this.data == null) {
-            throw new IllegalArgumentException(
-                String.format("Attribute data is null for type `%s`", this.type)
-            );
-        }
         return new ByteVector().putByteArray(this.data, 0, this.data.length);
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/asm/AsmUnknownAttributeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/AsmUnknownAttributeTest.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.asm;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ByteVector;
+
+/**
+ * Test case for {@link AsmUnknownAttribute}.
+ * @since 0.15.0
+ */
+final class AsmUnknownAttributeTest {
+
+    @Test
+    void writesNullDataAsEmpty() {
+        final ByteVector result = new AsmUnknownAttribute("Test", null)
+            .write(null, null, 0, 0, 0);
+        MatcherAssert.assertThat(
+            "Writing attribute with null data should produce empty ByteVector, not throw",
+            result,
+            Matchers.notNullValue()
+        );
+    }
+
+    @Test
+    void writesNonEmptyData() {
+        final byte[] data = {0x01, 0x02, 0x03};
+        final ByteVector result = new AsmUnknownAttribute("Test", data)
+            .write(null, null, 0, 0, 0);
+        MatcherAssert.assertThat(
+            "Writing attribute with data should produce non-null ByteVector",
+            result,
+            Matchers.notNullValue()
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/asm/AsmUnknownAttributeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/AsmUnknownAttributeTest.java
@@ -11,37 +11,25 @@ import org.objectweb.asm.ByteVector;
 
 /**
  * Test case for {@link AsmUnknownAttribute}.
- * @since 0.15.0
+ * @since 0.16.0
  */
 final class AsmUnknownAttributeTest {
 
-    /**
-     * Verifies that {@link AsmUnknownAttribute#write} returns a non-null
-     * {@link ByteVector} when the attribute data is null.
-     */
     @Test
     void writesNullDataAsEmpty() {
-        final ByteVector result = new AsmUnknownAttribute("Test", null)
-            .write(null, null, 0, 0, 0);
         MatcherAssert.assertThat(
             "Writing attribute with null data should produce empty ByteVector, not throw",
-            result,
+            new AsmUnknownAttribute("Test", null).write(null, null, 0, 0, 0),
             Matchers.notNullValue()
         );
     }
 
-    /**
-     * Verifies that {@link AsmUnknownAttribute#write} returns a non-null
-     * {@link ByteVector} when the attribute data is non-empty.
-     */
     @Test
     void writesNonEmptyData() {
-        final byte[] data = {0x01, 0x02, 0x03};
-        final ByteVector result = new AsmUnknownAttribute("Test", data)
-            .write(null, null, 0, 0, 0);
         MatcherAssert.assertThat(
             "Writing attribute with data should produce non-null ByteVector",
-            result,
+            new AsmUnknownAttribute("Test", new byte[]{0x01, 0x02, 0x03})
+                .write(null, null, 0, 0, 0),
             Matchers.notNullValue()
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/asm/AsmUnknownAttributeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/AsmUnknownAttributeTest.java
@@ -7,7 +7,6 @@ package org.eolang.jeo.representation.asm;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.objectweb.asm.ByteVector;
 
 /**
  * Test case for {@link AsmUnknownAttribute}.

--- a/src/test/java/org/eolang/jeo/representation/asm/AsmUnknownAttributeTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/AsmUnknownAttributeTest.java
@@ -15,6 +15,10 @@ import org.objectweb.asm.ByteVector;
  */
 final class AsmUnknownAttributeTest {
 
+    /**
+     * Verifies that {@link AsmUnknownAttribute#write} returns a non-null
+     * {@link ByteVector} when the attribute data is null.
+     */
     @Test
     void writesNullDataAsEmpty() {
         final ByteVector result = new AsmUnknownAttribute("Test", null)
@@ -26,6 +30,10 @@ final class AsmUnknownAttributeTest {
         );
     }
 
+    /**
+     * Verifies that {@link AsmUnknownAttribute#write} returns a non-null
+     * {@link ByteVector} when the attribute data is non-empty.
+     */
     @Test
     void writesNonEmptyData() {
         final byte[] data = {0x01, 0x02, 0x03};


### PR DESCRIPTION
The constructor assigns `this.data` via:

```java
this.data = Optional.ofNullable(data).orElse(AsmUnknownAttribute.EMPTY).clone();
```

This guarantees `this.data` is never `null` after construction. The `null` check in `write()` is therefore unreachable and has been removed.

A test is added to verify that `write()` works correctly when constructed with `null` data (falls back to empty array) and with non-empty data.

Closes #1469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for attribute data writing with null and non-null inputs.

* **Bug Fixes**
  * Improved null data handling in attribute writing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->