### PR TITLE
Cache compiled PathMatcher instances in GlobFilter (#1470)

### DIFF
--- a/src/main/java/org/eolang/jeo/GlobFilter.java
+++ b/src/main/java/org/eolang/jeo/GlobFilter.java
@@ -33,6 +33,16 @@ public final class GlobFilter implements Predicate<Path> {
     private final Set<String> excludes;
 
     /**
+     * Compiled include matchers.
+     */
+    private final Set<PathMatcher> whitelist;
+
+    /**
+     * Compiled exclude matchers.
+     */
+    private final Set<PathMatcher> blacklist;
+
+    /**
      * Ctor.
      *
      * @param includes Glob patterns to include
@@ -41,6 +51,12 @@ public final class GlobFilter implements Predicate<Path> {
     GlobFilter(final Set<String> includes, final Set<String> excludes) {
         this.includes = includes;
         this.excludes = excludes;
+        this.whitelist = includes.stream()
+            .map(GlobFilter::matcher)
+            .collect(Collectors.toSet());
+        this.blacklist = excludes.stream()
+            .map(GlobFilter::matcher)
+            .collect(Collectors.toSet());
     }
 
     @Override
@@ -74,17 +90,11 @@ public final class GlobFilter implements Predicate<Path> {
 
     @Override
     public boolean test(final Path path) {
-        final Set<PathMatcher> whitelist = this.includes.stream()
-            .map(GlobFilter::matcher)
-            .collect(Collectors.toSet());
-        final Set<PathMatcher> blacklist = this.excludes.stream()
-            .map(GlobFilter::matcher)
-            .collect(Collectors.toSet());
         final boolean included;
-        if (blacklist.stream().anyMatch(m -> m.matches(path))) {
+        if (this.blacklist.stream().anyMatch(m -> m.matches(path))) {
             included = false;
         } else {
-            included = whitelist.isEmpty() || whitelist.stream()
+            included = this.whitelist.isEmpty() || this.whitelist.stream()
                 .anyMatch(matcher -> matcher.matches(path));
         }
         return included;

--- a/src/test/java/org/eolang/jeo/GlobFilterTest.java
+++ b/src/test/java/org/eolang/jeo/GlobFilterTest.java
@@ -7,10 +7,13 @@ package org.eolang.jeo;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -44,6 +47,32 @@ final class GlobFilterTest {
             "We expect the filter to match the path correctly",
             new GlobFilter(includes, excludes).test(path),
             Matchers.is(expected)
+        );
+    }
+
+    @Test
+    @DisplayName("Compiles include patterns eagerly at construction time")
+    void compilesIncludePatternsAtConstruction() {
+        Assertions.assertThrows(
+            PatternSyntaxException.class,
+            () -> new GlobFilter(
+                GlobFilterTest.setOf("{unclosed"),
+                GlobFilterTest.setOf()
+            ),
+            "Invalid include glob must be rejected at construction, not lazily on test()"
+        );
+    }
+
+    @Test
+    @DisplayName("Compiles exclude patterns eagerly at construction time")
+    void compilesExcludePatternsAtConstruction() {
+        Assertions.assertThrows(
+            PatternSyntaxException.class,
+            () -> new GlobFilter(
+                GlobFilterTest.setOf(),
+                GlobFilterTest.setOf("[abc")
+            ),
+            "Invalid exclude glob must be rejected at construction, not lazily on test()"
         );
     }
 


### PR DESCRIPTION
Closes #1470.

## Summary

Move compilation of the `includes` and `excludes` glob patterns from `GlobFilter.test(Path)` into the constructor and store the compiled `PathMatcher` instances as `final` instance fields. `test(Path)` now uses the cached matchers directly, so the glob patterns are compiled exactly once per `GlobFilter` instead of once per filtered path.

## Reproduction test

Added two tests in `GlobFilterTest` that fail against `master` and pass with the fix:

- `compilesIncludePatternsAtConstruction` -- an invalid include glob (`{unclosed`) is rejected at construction time with `PatternSyntaxException`, not silently accepted and only thrown on the first call to `test()`.
- `compilesExcludePatternsAtConstruction` -- same contract for exclude globs (`[abc`).

Both tests are a direct consequence of compiling the matchers once at construction, which is the fix requested in the issue.

## Why this is a fix

`FileSystems.getDefault().getPathMatcher(...)` compiles the glob on every call. In a Maven plugin that filters hundreds or thousands of `.class` files, the old `test()` recompiled every pattern once per filtered path. Since `includes` and `excludes` are immutable, the matchers are fully determined by constructor arguments and belong in `final` fields.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized glob pattern compilation for filtering operations to improve performance by precompiling patterns during initialization rather than on each invocation.

* **Tests**
  * Added validation tests to ensure invalid glob patterns are detected during initialization, providing earlier error feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->