### PR TITLE
#1087 Track eo-maven-plugin version in integration-test poms via Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track org.eolang:eo-maven-plugin version embedded in integration-test poms under src/it/",
+      "fileMatch": ["^src/it/.*/pom\\.xml$"],
+      "matchStrings": [
+        "<groupId>org\\.eolang</groupId>\\s*<artifactId>eo-maven-plugin</artifactId>\\s*<version>(?<currentValue>[^<]+)</version>"
+      ],
+      "depNameTemplate": "org.eolang:eo-maven-plugin",
+      "datasourceTemplate": "maven"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #1087.

The `org.eolang:eo-maven-plugin` version is hard-coded in three integration-test poms:

- [src/it/bytecode-to-eo/pom.xml#L70-L71](src/it/bytecode-to-eo/pom.xml#L70-L71)
- [src/it/custom-transformations/pom.xml#L52-L53](src/it/custom-transformations/pom.xml#L52-L53)
- [src/it/jna/pom.xml#L194-L195](src/it/jna/pom.xml#L194-L195)

These poms are not part of the project reactor, so Renovate's stock Maven manager skips them — the version was being bumped by hand whenever the main `eo-parser` dependency was upgraded.

## Approach

Add a Renovate `customManagers` regex entry that:

- matches files under `src/it/*/pom.xml`
- captures the `<version>` of `org.eolang:eo-maven-plugin` across the three-line `<groupId>/<artifactId>/<version>` block
- delegates resolution to the `maven` datasource so updates flow from Maven Central

This is a lighter alternative to the workflow + Python pipeline used in [`objectionary/home`](https://github.com/objectionary/home/blob/master/.github/workflows/releases.yml) (referenced in [#1084](https://github.com/objectionary/jeo-maven-plugin/pull/1084#issuecomment-2879668833)). It piggybacks on Renovate, which is already running in this repo, and produces a regular Renovate PR for each new release.

## Test plan

- [x] Regex verified locally against all three IT poms — matches each `eo-maven-plugin` version block.
- [ ] Once merged, watch for the next Renovate cycle to confirm a PR is opened when a newer `eo-maven-plugin` is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)