### PR TITLE
chore(site): update jcabi-maven-skin to 2.0.1

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -3,18 +3,14 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
  * SPDX-License-Identifier: MIT
 -->
-<project xmlns="http://maven.apache.org/DECORATION/1.3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd" name="jeo-maven-plugin">
+<site xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd" name="jeo-maven-plugin">
   <skin>
     <groupId>com.jcabi</groupId>
     <artifactId>jcabi-maven-skin</artifactId>
-    <version>1.8.3</version>
+    <version>2.0.1</version>
   </skin>
-  <bannerLeft>
-    <name>jeo-maven-plugin</name>
-    <src>https://www.objectionary.com/cactus.svg</src>
-    <href>https://objectionary.github.io/jeo-maven-plugin/index.html</href>
-    <width>92</width>
-    <height>92</height>
+  <bannerLeft name="jeo-maven-plugin" href="https://objectionary.github.io/jeo-maven-plugin/index.html">
+    <image src="https://www.objectionary.com/cactus.svg" alt="jeo-maven-plugin" width="92" height="92"/>
   </bannerLeft>
   <body>
     <head>
@@ -26,4 +22,4 @@
     </menu>
     <menu ref="reports"/>
   </body>
-</project>
+</site>


### PR DESCRIPTION
## Summary

- Update `jcabi-maven-skin` from `1.8.3` to `2.0.1` in `src/site/site.xml`
- Migrate the descriptor to the new `SITE/2.0.0` namespace (root element `<site>` instead of `<project>`/`DECORATION/1.3.0`)
- Adapt `<bannerLeft>` to the new format (attributes + nested `<image>`), matching the configuration used in [jcabi/jcabi](https://github.com/jcabi/jcabi/blob/master/src/site/site.xml)

## Test plan

- [x] `mvn site` succeeds locally
- [x] Output reports `Rendering content with com.jcabi:jcabi-maven-skin:jar:2.0.1 skin`
- [x] `target/site/index.html` and report pages are generated

cc @volodya-lombrozo

https://claude.ai/code/session_01VKGxdeYnLhfKRcnFRJeKom

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKGxdeYnLhfKRcnFRJeKom)_