### PR TITLE
feat(#1497): add configurable threads parameter to assemble/disassemble

### DIFF
--- a/src/it/configurable-threads/invoker.properties
+++ b/src/it/configurable-threads/invoker.properties
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+invoker.goals=clean process-classes
+invoker.java.version = 17+

--- a/src/it/configurable-threads/pom.xml
+++ b/src/it/configurable-threads/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eolang</groupId>
+  <artifactId>jeo-configurable-threads-it</artifactId>
+  <version>@project.version@</version>
+  <packaging>jar</packaging>
+  <description>
+    This integration test verifies that the 'threads' parameter works correctly
+    for both 'disassemble' (with a single thread) and 'assemble' (with many threads).
+    If you need to run only this test, use the following command:
+    "mvn clean integration-test -Dinvoker.test=configurable-threads -DskipTests"
+  </description>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <stack-size>256M</stack-size>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>jeo-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>bytecode-to-xmir</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>disassemble</goal>
+            </goals>
+            <configuration>
+              <threads>1</threads>
+            </configuration>
+          </execution>
+          <execution>
+            <id>xmir-to-bytecode</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>assemble</goal>
+            </goals>
+            <configuration>
+              <threads>4</threads>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/configurable-threads/src/main/java/org/eolang/jeo/ct/Application.java
+++ b/src/it/configurable-threads/src/main/java/org/eolang/jeo/ct/Application.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.ct;
+
+public class Application {
+    public static void main(String[] args) {
+        System.out.println("Configurable threads test passed!");
+    }
+}

--- a/src/it/configurable-threads/verify.groovy
+++ b/src/it/configurable-threads/verify.groovy
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+String log = new File(basedir, 'build.log').text
+assert log.contains('BUILD SUCCESS')
+assert log.contains('Using 1 thread(s) for parallel processing') : 'Disassemble should use exactly 1 thread'
+assert log.contains('Using 4 thread(s) for parallel processing') : 'Assemble should use exactly 4 threads'
+File xmir = new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/ct/Application.xmir')
+assert xmir.exists() : "Disassembled XMIR file was not created: ${xmir}"
+File clazz = new File(basedir, 'target/classes/org/eolang/jeo/ct/Application.class')
+assert clazz.exists() : "Assembled class file was not created: ${clazz}"
+true

--- a/src/main/java/org/eolang/jeo/AssembleMojo.java
+++ b/src/main/java/org/eolang/jeo/AssembleMojo.java
@@ -131,6 +131,21 @@ public final class AssembleMojo extends AbstractMojo {
     @Parameter(property = "jeo.assemble.debug", defaultValue = "false")
     private boolean debug;
 
+    /**
+     * Number of threads for parallel assembling.
+     * <p>
+     * When set to {@code 0} (default), the plugin automatically selects the number of threads
+     * based on {@link Runtime#availableProcessors()}. When set to a positive value, the plugin
+     * uses exactly that many threads, scoped to a dedicated {@code ForkJoinPool} so that
+     * the setting does not affect the rest of the build.
+     * </p>
+     *
+     * @since 0.15.0
+     * @checkstyle MemberNameCheck (6 lines)
+     */
+    @Parameter(property = "jeo.assemble.threads", defaultValue = "0")
+    private int threads;
+
     @Override
     public void execute() throws MojoExecutionException {
         final Path src = new MavenPath(this.sourcesDir).resolve();
@@ -148,7 +163,8 @@ public final class AssembleMojo extends AbstractMojo {
                 new Assembler(
                     src,
                     out,
-                    this.debug
+                    this.debug,
+                    this.threads
                 ).assemble();
                 if (this.skipVerification) {
                     Logger.info(this, "Bytecode verification is disabled, skipping");

--- a/src/main/java/org/eolang/jeo/Assembler.java
+++ b/src/main/java/org/eolang/jeo/Assembler.java
@@ -37,15 +37,36 @@ public final class Assembler {
     private final boolean debug;
 
     /**
+     * Number of threads for parallel processing.
+     * <p>When 0, the number of available processors is used automatically.</p>
+     */
+    private final int threads;
+
+    /**
      * Constructor.
      * @param input Input folder with "xmir" files.
      * @param output Output folder for the assembled classes.
      * @param debug Enables detailed debug logging.
      */
     public Assembler(final Path input, final Path output, final boolean debug) {
+        this(input, output, debug, 0);
+    }
+
+    /**
+     * Constructor.
+     * @param input Input folder with "xmir" files.
+     * @param output Output folder for the assembled classes.
+     * @param debug Enables detailed debug logging.
+     * @param threads Number of threads (0 = use available processors automatically).
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    public Assembler(
+        final Path input, final Path output, final boolean debug, final int threads
+    ) {
         this.input = input;
         this.output = output;
         this.debug = debug;
+        this.threads = threads;
     }
 
     /**
@@ -62,7 +83,7 @@ public final class Assembler {
             assembled,
             this.input.toString(),
             this.output,
-            new ParallelTranslator(path -> this.assemble(path, counter))
+            new ParallelTranslator(path -> this.assemble(path, counter), this.threads)
         ).apply(files.all());
         all.forEach(this::log);
         all.close();

--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -230,6 +230,21 @@ public final class DisassembleMojo extends AbstractMojo {
     @Parameter(property = "jeo.disassemble.debug", defaultValue = "false")
     private boolean debug;
 
+    /**
+     * Number of threads for parallel disassembly.
+     * <p>
+     * When set to {@code 0} (default), the plugin automatically selects the number of threads
+     * based on {@link Runtime#availableProcessors()}. When set to a positive value, the plugin
+     * uses exactly that many threads, scoped to a dedicated {@code ForkJoinPool} so that
+     * the setting does not affect the rest of the build.
+     * </p>
+     *
+     * @since 0.15.0
+     * @checkstyle MemberNameCheck (6 lines)
+     */
+    @Parameter(property = "jeo.disassemble.threads", defaultValue = "0")
+    private int threads;
+
     @Override
     public void execute() throws MojoExecutionException {
         final Path src = new MavenPath(this.sourcesDir).resolve();
@@ -263,7 +278,8 @@ public final class DisassembleMojo extends AbstractMojo {
                         Format.PRETTY, this.prettyXmir,
                         Format.MODE, this.mode
                     ),
-                    this.debug
+                    this.debug,
+                    this.threads
                 ).disassemble();
                 if (this.xmirVerification) {
                     Logger.info(this, "Verifying all the XMIR files after disassembling");

--- a/src/main/java/org/eolang/jeo/Disassembler.java
+++ b/src/main/java/org/eolang/jeo/Disassembler.java
@@ -44,6 +44,12 @@ public final class Disassembler {
     private final boolean debug;
 
     /**
+     * Number of threads for parallel processing.
+     * <p>When 0, the number of available processors is used automatically.</p>
+     */
+    private final int threads;
+
+    /**
      * Constructor.
      * @param classes Directory containing compiled class files
      * @param target Target directory where XMIR files will be saved
@@ -83,10 +89,30 @@ public final class Disassembler {
         final Format params,
         final boolean debug
     ) {
+        this(classes, target, params, debug, 0);
+    }
+
+    /**
+     * Constructor.
+     * @param classes Project compiled classes
+     * @param target Where to save decompiled classes
+     * @param params Disassembling params.
+     * @param debug Enables detailed debug logging
+     * @param threads Number of threads (0 = use available processors automatically)
+     * @checkstyle ParameterNumberCheck (10 lines)
+     */
+    public Disassembler(
+        final Classes classes,
+        final Path target,
+        final Format params,
+        final boolean debug,
+        final int threads
+    ) {
         this.classes = classes;
         this.target = target;
         this.params = params;
         this.debug = debug;
+        this.threads = threads;
     }
 
     /**
@@ -101,7 +127,7 @@ public final class Disassembler {
             disassembled,
             this.classes.toString(),
             this.target,
-            new ParallelTranslator(path -> this.disassemble(path, counter))
+            new ParallelTranslator(path -> this.disassemble(path, counter), this.threads)
         ).apply(this.classes.all());
         stream.forEach(this::log);
         stream.close();

--- a/src/main/java/org/eolang/jeo/ParallelTranslator.java
+++ b/src/main/java/org/eolang/jeo/ParallelTranslator.java
@@ -5,7 +5,11 @@
 package org.eolang.jeo;
 
 import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -29,17 +33,54 @@ public final class ParallelTranslator implements Translator {
     private final ClassLoader loader;
 
     /**
+     * Number of threads for parallel processing.
+     * <p>When 0, the number of available processors is used automatically.</p>
+     */
+    private final int threads;
+
+    /**
      * Constructor.
      * @param translation Function to apply to each path representation
      */
     ParallelTranslator(final Function<? super Path, ? extends Path> translation) {
+        this(translation, 0);
+    }
+
+    /**
+     * Constructor.
+     * @param translation Function to apply to each path representation
+     * @param threads Number of threads (0 = use available processors automatically)
+     */
+    ParallelTranslator(
+        final Function<? super Path, ? extends Path> translation,
+        final int threads
+    ) {
         this.translation = translation;
         this.loader = Thread.currentThread().getContextClassLoader();
+        this.threads = threads;
     }
 
     @Override
     public Stream<Path> apply(final Stream<Path> representations) {
-        return representations.parallel().map(this::translate);
+        final int parallelism;
+        if (this.threads == 0) {
+            parallelism = Runtime.getRuntime().availableProcessors();
+        } else {
+            parallelism = this.threads;
+        }
+        final ForkJoinPool pool = new ForkJoinPool(parallelism);
+        try {
+            return pool.submit(
+                () -> representations.parallel().map(this::translate).collect(Collectors.toList())
+            ).get().stream();
+        } catch (final InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Parallel translation was interrupted", exception);
+        } catch (final ExecutionException exception) {
+            throw new IllegalStateException("Parallel translation failed", exception);
+        } finally {
+            pool.shutdown();
+        }
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/ParallelTranslator.java
+++ b/src/main/java/org/eolang/jeo/ParallelTranslator.java
@@ -4,8 +4,8 @@
  */
 package org.eolang.jeo;
 
+import com.jcabi.log.Logger;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
@@ -68,6 +68,8 @@ public final class ParallelTranslator implements Translator {
         } else {
             parallelism = this.threads;
         }
+        Logger.info(this, "Using %d thread(s) for parallel processing", parallelism);
+        @SuppressWarnings("PMD.CloseResource")
         final ForkJoinPool pool = new ForkJoinPool(parallelism);
         try {
             return pool.submit(


### PR DESCRIPTION
Adds a `threads` parameter to `assemble` and `disassemble` goals, allowing users to control parallelism via a dedicated `ForkJoinPool` instead of the shared common pool. Defaults to `0` (auto-detect via `availableProcessors`) for backward compatibility.

Related to #1497