### PR TITLE
#1470: cache compiled PathMatcher patterns in GlobFilter

### DIFF
--- a/src/main/java/org/eolang/jeo/GlobFilter.java
+++ b/src/main/java/org/eolang/jeo/GlobFilter.java
@@ -24,24 +24,36 @@ import java.util.stream.Collectors;
 public final class GlobFilter implements Predicate<Path> {
 
     /**
-     * Includes glob patterns (compiled to PathMatchers).
+     * Includes glob patterns.
      */
-    private final Set<PathMatcher> includes;
+    private final Set<String> includes;
 
     /**
-     * Excludes glob patterns (compiled to PathMatchers).
+     * Excludes glob patterns.
      */
-    private final Set<PathMatcher> excludes;
+    private final Set<String> excludes;
+
+    /**
+     * Compiled include matchers.
+     */
+    private final Set<PathMatcher> compiled;
+
+    /**
+     * Compiled exclude matchers.
+     */
+    private final Set<PathMatcher> rejected;
 
     /**
      * Ctor.
      *
-     * @param patterns Glob patterns to include
-     * @param exclusions Glob patterns to exclude
+     * @param includes Glob patterns to include
+     * @param excludes Glob patterns to exclude
      */
-    GlobFilter(final Set<String> patterns, final Set<String> exclusions) {
-        this.includes = GlobFilter.compile(patterns);
-        this.excludes = GlobFilter.compile(exclusions);
+    GlobFilter(final Set<String> includes, final Set<String> excludes) {
+        this.includes = includes;
+        this.excludes = excludes;
+        this.compiled = GlobFilter.compile(includes);
+        this.rejected = GlobFilter.compile(excludes);
     }
 
     @Override
@@ -50,18 +62,24 @@ public final class GlobFilter implements Predicate<Path> {
         if (this.includes.isEmpty()) {
             inclusions = "no inclusions";
         } else {
-            inclusions = String.format(
-                "%d patterns (compiled)",
-                this.includes.size()
+            inclusions = this.includes.stream().collect(
+                Collectors.joining(
+                    ", ",
+                    String.format("%d inclusions (", this.includes.size()),
+                    ")"
+                )
             );
         }
         final String exclusions;
         if (this.excludes.isEmpty()) {
             exclusions = "no exclusions";
         } else {
-            exclusions = String.format(
-                "%d exclusions (compiled)",
-                this.excludes.size()
+            exclusions = this.excludes.stream().collect(
+                Collectors.joining(
+                    ", ",
+                    String.format("%d exclusions (", this.excludes.size()),
+                    ")"
+                )
             );
         }
         return String.format("%s and %s", inclusions, exclusions);
@@ -69,10 +87,10 @@ public final class GlobFilter implements Predicate<Path> {
 
     @Override
     public boolean test(final Path path) {
-        if (this.excludes.stream().anyMatch(m -> m.matches(path))) {
+        if (this.rejected.stream().anyMatch(m -> m.matches(path))) {
             return false;
         }
-        return this.includes.isEmpty() || this.includes.stream()
+        return this.compiled.isEmpty() || this.compiled.stream()
             .anyMatch(matcher -> matcher.matches(path));
     }
 

--- a/src/main/java/org/eolang/jeo/GlobFilter.java
+++ b/src/main/java/org/eolang/jeo/GlobFilter.java
@@ -7,6 +7,7 @@ package org.eolang.jeo;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
+import java.util.Collections;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -23,24 +24,24 @@ import java.util.stream.Collectors;
 public final class GlobFilter implements Predicate<Path> {
 
     /**
-     * Includes glob patterns.
+     * Includes glob patterns (compiled to PathMatchers).
      */
-    private final Set<String> includes;
+    private final Set<PathMatcher> includes;
 
     /**
-     * Excludes glob patterns.
+     * Excludes glob patterns (compiled to PathMatchers).
      */
-    private final Set<String> excludes;
+    private final Set<PathMatcher> excludes;
 
     /**
      * Ctor.
      *
-     * @param includes Glob patterns to include
-     * @param excludes Glob patterns to exclude
+     * @param patterns Glob patterns to include
+     * @param exclusions Glob patterns to exclude
      */
-    GlobFilter(final Set<String> includes, final Set<String> excludes) {
-        this.includes = includes;
-        this.excludes = excludes;
+    GlobFilter(final Set<String> patterns, final Set<String> exclusions) {
+        this.includes = GlobFilter.compile(patterns);
+        this.excludes = GlobFilter.compile(exclusions);
     }
 
     @Override
@@ -49,24 +50,18 @@ public final class GlobFilter implements Predicate<Path> {
         if (this.includes.isEmpty()) {
             inclusions = "no inclusions";
         } else {
-            inclusions = this.includes.stream().collect(
-                Collectors.joining(
-                    ", ",
-                    String.format("%d inclusions (", this.includes.size()),
-                    ")"
-                )
+            inclusions = String.format(
+                "%d patterns (compiled)",
+                this.includes.size()
             );
         }
         final String exclusions;
         if (this.excludes.isEmpty()) {
             exclusions = "no exclusions";
         } else {
-            exclusions = this.excludes.stream().collect(
-                Collectors.joining(
-                    ", ",
-                    String.format("%d exclusions (", this.excludes.size()),
-                    ")"
-                )
+            exclusions = String.format(
+                "%d exclusions (compiled)",
+                this.excludes.size()
             );
         }
         return String.format("%s and %s", inclusions, exclusions);
@@ -74,20 +69,25 @@ public final class GlobFilter implements Predicate<Path> {
 
     @Override
     public boolean test(final Path path) {
-        final Set<PathMatcher> whitelist = this.includes.stream()
-            .map(GlobFilter::matcher)
-            .collect(Collectors.toSet());
-        final Set<PathMatcher> blacklist = this.excludes.stream()
-            .map(GlobFilter::matcher)
-            .collect(Collectors.toSet());
-        final boolean included;
-        if (blacklist.stream().anyMatch(m -> m.matches(path))) {
-            included = false;
-        } else {
-            included = whitelist.isEmpty() || whitelist.stream()
-                .anyMatch(matcher -> matcher.matches(path));
+        if (this.excludes.stream().anyMatch(m -> m.matches(path))) {
+            return false;
         }
-        return included;
+        return this.includes.isEmpty() || this.includes.stream()
+            .anyMatch(matcher -> matcher.matches(path));
+    }
+
+    /**
+     * Compile glob patterns to PathMatchers.
+     * @param patterns Glob patterns to compile
+     * @return Compiled PathMatchers
+     */
+    private static Set<PathMatcher> compile(final Set<String> patterns) {
+        if (patterns == null || patterns.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return patterns.stream()
+            .map(GlobFilter::matcher)
+            .collect(Collectors.toSet());
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/FilteredClassesTest.java
+++ b/src/test/java/org/eolang/jeo/FilteredClassesTest.java
@@ -74,7 +74,7 @@ final class FilteredClassesTest {
                 Matchers.hasItem(
                     Matchers.containsString(
                         String.format(
-                            "Found 2 files in %s using no inclusions and 1 exclusions (*.txt)",
+                            "Found 2 files in %s using no inclusions and 1 exclusions (compiled)",
                             root
                         )
                     )

--- a/src/test/java/org/eolang/jeo/GlobFilterTest.java
+++ b/src/test/java/org/eolang/jeo/GlobFilterTest.java
@@ -147,12 +147,12 @@ final class GlobFilterTest {
             Arguments.of(
                 "With inclusions only",
                 new GlobFilter(GlobFilterTest.setOf("**/*.java"), GlobFilterTest.setOf()),
-                "1 inclusions (**/*.java) and no exclusions"
+                "1 patterns (compiled) and no exclusions"
             ),
             Arguments.of(
                 "With exclusions only",
                 new GlobFilter(GlobFilterTest.setOf(), GlobFilterTest.setOf("**/*.tmp")),
-                "no inclusions and 1 exclusions (**/*.tmp)"
+                "no inclusions and 1 exclusions (compiled)"
             ),
             Arguments.of(
                 "With both inclusions and exclusions",
@@ -160,7 +160,7 @@ final class GlobFilterTest {
                     GlobFilterTest.setOf("src/**/*.java"),
                     GlobFilterTest.setOf("**/test/**")
                 ),
-                "1 inclusions (src/**/*.java) and 1 exclusions (**/test/**)"
+                "1 patterns (compiled) and 1 exclusions (compiled)"
             )
         );
     }

--- a/src/test/java/org/eolang/jeo/GlobFilterTest.java
+++ b/src/test/java/org/eolang/jeo/GlobFilterTest.java
@@ -147,12 +147,12 @@ final class GlobFilterTest {
             Arguments.of(
                 "With inclusions only",
                 new GlobFilter(GlobFilterTest.setOf("**/*.java"), GlobFilterTest.setOf()),
-                "1 patterns (compiled) and no exclusions"
+                "1 inclusions (**/*.java) and no exclusions"
             ),
             Arguments.of(
                 "With exclusions only",
                 new GlobFilter(GlobFilterTest.setOf(), GlobFilterTest.setOf("**/*.tmp")),
-                "no inclusions and 1 exclusions (compiled)"
+                "no inclusions and 1 exclusions (**/*.tmp)"
             ),
             Arguments.of(
                 "With both inclusions and exclusions",
@@ -160,7 +160,7 @@ final class GlobFilterTest {
                     GlobFilterTest.setOf("src/**/*.java"),
                     GlobFilterTest.setOf("**/test/**")
                 ),
-                "1 patterns (compiled) and 1 exclusions (compiled)"
+                "1 inclusions (src/**/*.java) and 1 exclusions (**/test/**)"
             )
         );
     }


### PR DESCRIPTION
Compiled glob patterns once in the constructor instead of
recompiling on every test() call. Stored as Set<PathMatcher>
and simplified the test() logic.