### PR TITLE
fix: remove erroneous 'of' in Caching.transform() error message

### DIFF
--- a/src/main/java/org/eolang/jeo/Caching.java
+++ b/src/main/java/org/eolang/jeo/Caching.java
@@ -49,7 +49,7 @@ public final class Caching implements Transformation {
         } catch (final IOException exception) {
             throw new IllegalStateException(
                 String.format(
-                    "Failed to transform of '%s' to '%s'",
+                    "Failed to transform '%s' to '%s'",
                     this.source(),
                     this.target()
                 ),


### PR DESCRIPTION
## Summary
Fix grammatically incorrect error message in Caching.java: 'Failed to transform of' → 'Failed to transform'

## Issue
Fixes #1535

## Change
- src/main/java/org/eolang/jeo/Caching.java line 52: removed erroneous 'of' preposition