### PR TITLE
fix #1535 drop stray 'of' from Caching.transform() error

### DIFF
--- a/src/main/java/org/eolang/jeo/Caching.java
+++ b/src/main/java/org/eolang/jeo/Caching.java
@@ -49,7 +49,7 @@ public final class Caching implements Transformation {
         } catch (final IOException exception) {
             throw new IllegalStateException(
                 String.format(
-                    "Failed to transform of '%s' to '%s'",
+                    "Failed to transform '%s' to '%s'",
                     this.source(),
                     this.target()
                 ),


### PR DESCRIPTION
The format string at src/main/java/org/eolang/jeo/Caching.java:52 carries an extra `of` between `transform` and the source path, producing the ungrammatical `Failed to transform of '<src>' to '<dst>'` inside the IllegalStateException that wraps an IOException from tryTransform(). Issue #1535 traces the wording to that single literal and asks for `of` to be dropped, leaving `Failed to transform '%s' to '%s'`.

The change removes one word from the format string. No callers move, no signatures change, and the only difference at runtime is the wording of the log line a user sees when a cached transformation fails to write through.

The edit is text-only inside a runtime error message, so no behaviour, control flow, or assertion is touched. A grep for the old phrasing returns no remaining occurrences, the new phrasing already matches the wording used by sibling class `Informative` at src/main/java/org/eolang/jeo/Informative.java:47, and no existing test fixture pins the old string. The full Maven build was not run locally inside this routine.

Closes #1535