### PR TITLE
#1535 drop spurious 'of' in caching transform error message

### DIFF
--- a/src/main/java/org/eolang/jeo/Caching.java
+++ b/src/main/java/org/eolang/jeo/Caching.java
@@ -49,7 +49,7 @@ public final class Caching implements Transformation {
         } catch (final IOException exception) {
             throw new IllegalStateException(
                 String.format(
-                    "Failed to transform of '%s' to '%s'",
+                    "Failed to transform '%s' to '%s'",
                     this.source(),
                     this.target()
                 ),


### PR DESCRIPTION
The error message produced by Caching.transform() when tryTransform() throws an IOException previously read "Failed to transform of '%s' to '%s'" — the preposition "of" does not belong in that position and made the build log message harder to read and to grep for.

The format string in src/main/java/org/eolang/jeo/Caching.java line 52 now reads "Failed to transform '%s' to '%s'", which is the only visible effect of the change. No callers are affected because the argument list is unchanged.

The change is a single-character edit confined to one string literal; the existing surrounding test coverage exercises the same path, and Caching.java compiles unchanged under the project's source set.

Closes #1535

---
_Generated by [Claude Code](https://claude.ai/code)_