### PR TITLE
Replace α0 with data and as-bytes in generated XMIR

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesBytes.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesBytes.java
@@ -69,14 +69,14 @@ public final class DirectivesBytes implements Iterable<Directive> {
             directives = new DirectivesClosedObject(
                 new EoFqn("bytes").fqn(),
                 this.as,
-                new Directives().add("o").attr("as", "α0").set(this.hex).up()
+                new Directives().add("o").attr("as", "data").set(this.hex).up()
             );
         } else {
             directives = new DirectivesClosedObject(
                 new EoFqn("bytes").fqn(),
                 this.as,
                 this.name,
-                new Directives().add("o").attr("as", "α0").set(this.hex).up()
+                new Directives().add("o").attr("as", "data").set(this.hex).up()
             );
         }
         return directives.iterator();

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesNumber.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesNumber.java
@@ -67,7 +67,7 @@ final class DirectivesNumber implements Iterable<Directive> {
             new EoFqn("number").fqn(),
             this.as,
             this.name,
-            new DirectivesBytes(this.hex, "", "α0")
+            new DirectivesBytes(this.hex, "", "as-bytes")
         ).iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesValue.java
@@ -255,7 +255,7 @@ public final class DirectivesValue implements Iterable<Directive> {
             this.name,
             this.as,
             new DirectivesComment(this.format, this.comment()),
-            new DirectivesBytes(this.hex(codec), "", "α0")
+            new DirectivesBytes(this.hex(codec), "", "as-bytes")
         );
     }
 

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesBytesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesBytesTest.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link DirectivesBytes}.
+ * This class verifies that bytes expose their payload through a named
+ * attribute instead of the positional attribute of phi-calculus.
+ *
+ * @since 0.6
+ */
+final class DirectivesBytesTest {
+
+    @Test
+    void bindsPayloadWithNamedAttribute() {
+        MatcherAssert.assertThat(
+            "Bytes must expose their payload through the 'data' attribute",
+            new Xembler(new DirectivesBytes("01-02-03")).xmlQuietly(),
+            XhtmlMatchers.hasXPath(
+                "/o[contains(@base,'bytes')]/o[@as='data' and text()='01-02-03']"
+            )
+        );
+    }
+
+    @Test
+    void avoidsPositionalAttribute() {
+        MatcherAssert.assertThat(
+            "Bytes XMIR must not contain the positional attribute α0",
+            new Xembler(new DirectivesBytes("01-02-03")).xmlQuietly(),
+            Matchers.not(Matchers.containsString("α0"))
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesNumberTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesNumberTest.java
@@ -6,6 +6,7 @@ package org.eolang.jeo.representation.directives;
 
 import com.jcabi.matchers.XhtmlMatchers;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.xembly.Xembler;
 
@@ -25,8 +26,17 @@ final class DirectivesNumberTest {
             new Xembler(new DirectivesNumber("42")).xmlQuietly(),
             XhtmlMatchers.hasXPaths(
                 "/o[contains(@base,'number')]",
-                "/o[contains(@base,'number')]/o[contains(@base, 'bytes')]/o[text()='42']"
+                "/o[contains(@base,'number')]/o[@as='as-bytes' and contains(@base, 'bytes')]/o[@as='data' and text()='42']"
             )
+        );
+    }
+
+    @Test
+    void avoidsPositionalAttribute() {
+        MatcherAssert.assertThat(
+            "Number XMIR must not contain the positional attribute α0",
+            new Xembler(new DirectivesNumber("42")).xmlQuietly(),
+            Matchers.not(Matchers.containsString("α0"))
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValueTest.java
@@ -161,6 +161,26 @@ final class DirectivesValueTest {
     }
 
     @Test
+    void bindsStringBytesWithNamedAttributes() {
+        MatcherAssert.assertThat(
+            "String must bind its bytes through 'as-bytes' and 'data', not the positional attribute",
+            new Xembler(new DirectivesValue(0, new Format(), "Hello!")).xmlQuietly(),
+            XhtmlMatchers.hasXPath(
+                "./o[contains(@base,'string')]/o[@as='as-bytes' and contains(@base,'bytes')]/o[@as='data' and text()='48-65-6C-6C-6F-21']"
+            )
+        );
+    }
+
+    @Test
+    void avoidsPositionalAttributeInString() {
+        MatcherAssert.assertThat(
+            "String XMIR must not contain the positional attribute α0",
+            new Xembler(new DirectivesValue(0, new Format(), "Hello!")).xmlQuietly(),
+            Matchers.not(Matchers.containsString("α0"))
+        );
+    }
+
+    @Test
     void createsStringWithQuotedComment() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "We expect that string value will be quoted in the comment",


### PR DESCRIPTION
Data objects used to carry the phi-calculus positional attribute `α0` in the XMIR that jeo generates. This drops it everywhere: the bytes payload now binds through `as="data"`, and a `bytes` object binds into its `string` or `number` parent through `as="as-bytes"`.

We're getting rid of positional attributes like `α0` in phi-calculus, so any XMIR that still leans on them will eventually stop parsing. Moving to named bindings now keeps the output valid ahead of that change.

The reader side already picks up the payload by reading the first child's text, so the round-trip is unaffected — the full representation test suite (907 tests) stays green. New unit tests cover bytes, strings, and numbers, and assert that `α0` no longer appears in the output.

Closes #1563