### PR TITLE
fix(#1538): descriptive error instead of NPE in toString() and root()

### DIFF
--- a/src/main/java/org/eolang/jeo/BytecodeClasses.java
+++ b/src/main/java/org/eolang/jeo/BytecodeClasses.java
@@ -40,7 +40,7 @@ final class BytecodeClasses implements Classes {
 
     @Override
     public String toString() {
-        return this.input.toString();
+        return this.checked().toString();
     }
 
     @Override
@@ -50,7 +50,7 @@ final class BytecodeClasses implements Classes {
 
     @Override
     public Path root() {
-        return this.input;
+        return this.checked();
     }
 
     @Override
@@ -76,19 +76,28 @@ final class BytecodeClasses implements Classes {
     }
 
     /**
-     * Find all bytecode files.
-     * @return Collection of bytecode files
-     * @throws IOException If some I/O problem arises
+     * Check that the classes directory is set.
+     * @return Classes directory
      */
-    private Collection<Path> classes() throws IOException {
+    private Path checked() {
         if (Objects.isNull(this.input)) {
             throw new IllegalStateException(
                 "The classes directory is not set, jeo-maven-plugin does not know where to look for classes."
             );
         }
+        return this.input;
+    }
+
+    /**
+     * Find all bytecode files.
+     * @return Collection of bytecode files
+     * @throws IOException If some I/O problem arises
+     */
+    private Collection<Path> classes() throws IOException {
+        final Path directory = this.checked();
         final Collection<Path> result;
-        if (Files.exists(this.input)) {
-            try (Stream<Path> walk = Files.walk(this.input)) {
+        if (Files.exists(directory)) {
+            try (Stream<Path> walk = Files.walk(directory)) {
                 result = walk
                     .filter(Files::isRegularFile)
                     .filter(path -> path.toString().endsWith(".class"))
@@ -99,7 +108,7 @@ final class BytecodeClasses implements Classes {
                 this,
                 String.format(
                     "The classes directory '%s' does not exist, jeo-maven-plugin does not know where to look for classes.",
-                    this.input
+                    directory
                 )
             );
             result = Collections.emptyList();

--- a/src/test/java/org/eolang/jeo/BytecodeClassesTest.java
+++ b/src/test/java/org/eolang/jeo/BytecodeClassesTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -23,6 +24,32 @@ final class BytecodeClassesTest {
             "BytecodeClasses toString() should return the correct path",
             new BytecodeClasses(path).toString(),
             Matchers.equalTo(path.toString())
+        );
+    }
+
+    @Test
+    void throwsDescriptiveExceptionWhenConvertingNullInputToString() {
+        final IllegalStateException exception = Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new BytecodeClasses(null).toString()
+        );
+        MatcherAssert.assertThat(
+            "BytecodeClasses toString() should describe the missing classes directory",
+            exception.getMessage(),
+            Matchers.containsString("The classes directory is not set")
+        );
+    }
+
+    @Test
+    void throwsDescriptiveExceptionWhenGettingRootFromNullInput() {
+        final IllegalStateException exception = Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new BytecodeClasses(null).root()
+        );
+        MatcherAssert.assertThat(
+            "BytecodeClasses root() should describe the missing classes directory",
+            exception.getMessage(),
+            Matchers.containsString("The classes directory is not set")
         );
     }
 


### PR DESCRIPTION
Closes #1538 (reported by @morphqdd; @volodya-lombrozo approved the change on Jul 6).

`BytecodeClasses.toString()` threw a bare `NullPointerException` and `root()` handed out `null` when the `input` directory was not set, while `classes()` already failed with a descriptive `IllegalStateException`. All three now go through one private `checked()` guard that throws the same descriptive message, so a misconfigured run fails with a clear diagnostic instead of an NPE at some later call site.

Tests first: two regression tests reproducing the bare NPE / silent null (red on `master`), then the fix turns them green. `mvn clean install -Pqulice` passes locally on JDK 11.

Disclosure: this change was implemented with AI assistance under my direct review; I read and own every line. A signed self-run record of the checks (contributor self-run, not maintainer verification): https://northset-oss.github.io/verification-pilot/
