### PR TITLE
fix(#1578): name() now fails with a descriptive error when the object name is absent

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
+++ b/src/main/java/org/eolang/jeo/representation/XmirRepresentation.java
@@ -6,6 +6,7 @@ package org.eolang.jeo.representation;
 
 import com.jcabi.xml.XML;
 import java.nio.file.Path;
+import java.util.List;
 import org.eolang.jeo.representation.bytecode.Bytecode;
 import org.eolang.jeo.representation.xmir.JcabiXmlDoc;
 import org.eolang.jeo.representation.xmir.XmlDoc;
@@ -65,12 +66,18 @@ public final class XmirRepresentation {
      */
     public String name() {
         final XmlNode root = this.xml.root();
+        final List<String> names = root.xpath("/object/o/@name");
+        if (names.isEmpty()) {
+            throw new IllegalStateException(
+                String.format("Can't find the object name in XMIR from '%s'", this.source)
+            );
+        }
         return new ClassName(
             root.xpath("/object/metas/meta[head[text()]='package']/tail/text()")
                 .stream()
                 .findFirst()
                 .orElse(""),
-            root.xpath("/object/o/@name").get(0)
+            names.get(0)
         ).full();
     }
 

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -34,6 +34,7 @@ import org.xembly.Xembler;
  *
  * @since 0.1.0
  */
+@SuppressWarnings("PMD.TooManyMethods")
 final class XmirRepresentationTest {
 
     /**
@@ -69,6 +70,26 @@ final class XmirRepresentationTest {
             ),
             actual,
             Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    void throwsDescriptiveExceptionWhenNameAttributeIsAbsent() {
+        final XML broken = new XMLDocument(
+            new Xembler(
+                new Directives().xpath("/object/o/@name").remove()
+            ).applyQuietly(
+                new BytecodeObject(new BytecodeClass("Math")).xml().inner()
+            )
+        );
+        final IllegalStateException exception = Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new XmirRepresentation(broken).name()
+        );
+        MatcherAssert.assertThat(
+            "XmirRepresentation#name should describe the missing object name",
+            exception.getMessage(),
+            Matchers.containsString("object name")
         );
     }
 


### PR DESCRIPTION
Fixes #1578.

## Problem
`XmirRepresentation#name()` (`src/main/java/org/eolang/jeo/representation/XmirRepresentation.java`, lines 66-74) reads the top-level object's `name` attribute unguarded: `root.xpath("/object/o/@name").get(0)`. When the top-level `<o>` has metas but no `name` attribute, the xpath returns an empty list and `.get(0)` throws a bare `com.jcabi.xml.ListWrapper$NodeNotFoundException` (`Index (0) is out of bounds (size=0)`), with no hint about what actually went wrong.

The sibling xpath for the package lookup (three lines above) already handles the "no match" case with `.stream().findFirst().orElse("")`.

This is the same bug class already fixed by maintainers in this exact area: PR #1573 (issue #1538) replaced a bare, undescriptive exception in `BytecodeClasses` with a clear `IllegalStateException`.

## Solution
Guard the `name` xpath result before indexing: if the list is empty, throw a descriptive `IllegalStateException` including the XMIR source:

```java
throw new IllegalStateException(
    String.format("Can't find the object name in XMIR from '%s'", this.source)
);
```

## Tests
- `throwsDescriptiveExceptionWhenNameAttributeIsAbsent` in `XmirRepresentationTest` — fails on `master` (bare `NodeNotFoundException`) and passes on this branch.

Verified locally: `mvn clean install -Pqulice --errors` (960 tests, 0 failures).