### PR TITLE
fix(#1539): compile glob matchers lazily and cache them with cactoos primitives

### DIFF
--- a/src/main/java/org/eolang/jeo/GlobFilter.java
+++ b/src/main/java/org/eolang/jeo/GlobFilter.java
@@ -8,8 +8,13 @@ import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.cactoos.Scalar;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Synced;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * Filter that matches paths against a set of glob patterns.
@@ -33,14 +38,53 @@ public final class GlobFilter implements Predicate<Path> {
     private final Set<String> excludes;
 
     /**
+     * Compiled include matchers, computed lazily and cached.
+     */
+    private final Scalar<Set<PathMatcher>> whitelist;
+
+    /**
+     * Compiled exclude matchers, computed lazily and cached.
+     */
+    private final Scalar<Set<PathMatcher>> blacklist;
+
+    /**
      * Ctor.
      *
      * @param includes Glob patterns to include
      * @param excludes Glob patterns to exclude
      */
     GlobFilter(final Set<String> includes, final Set<String> excludes) {
+        this(includes, excludes, GlobFilter::matcher);
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param includes Glob patterns to include
+     * @param excludes Glob patterns to exclude
+     * @param compiler Factory that compiles a glob pattern into a matcher
+     */
+    GlobFilter(
+        final Set<String> includes,
+        final Set<String> excludes,
+        final Function<String, PathMatcher> compiler
+    ) {
         this.includes = includes;
         this.excludes = excludes;
+        this.whitelist = new Synced<>(
+            new Sticky<>(
+                () -> includes.stream()
+                    .map(compiler)
+                    .collect(Collectors.toSet())
+            )
+        );
+        this.blacklist = new Synced<>(
+            new Sticky<>(
+                () -> excludes.stream()
+                    .map(compiler)
+                    .collect(Collectors.toSet())
+            )
+        );
     }
 
     @Override
@@ -74,17 +118,13 @@ public final class GlobFilter implements Predicate<Path> {
 
     @Override
     public boolean test(final Path path) {
-        final Set<PathMatcher> whitelist = this.includes.stream()
-            .map(GlobFilter::matcher)
-            .collect(Collectors.toSet());
-        final Set<PathMatcher> blacklist = this.excludes.stream()
-            .map(GlobFilter::matcher)
-            .collect(Collectors.toSet());
+        final Set<PathMatcher> white = new Unchecked<>(this.whitelist).value();
+        final Set<PathMatcher> black = new Unchecked<>(this.blacklist).value();
         final boolean included;
-        if (blacklist.stream().anyMatch(m -> m.matches(path))) {
+        if (black.stream().anyMatch(matcher -> matcher.matches(path))) {
             included = false;
         } else {
-            included = whitelist.isEmpty() || whitelist.stream()
+            included = white.isEmpty() || white.stream()
                 .anyMatch(matcher -> matcher.matches(path));
         }
         return included;

--- a/src/test/java/org/eolang/jeo/GlobFilterTest.java
+++ b/src/test/java/org/eolang/jeo/GlobFilterTest.java
@@ -4,13 +4,18 @@
  */
 package org.eolang.jeo;
 
+import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -44,6 +49,42 @@ final class GlobFilterTest {
             "We expect the filter to match the path correctly",
             new GlobFilter(includes, excludes).test(path),
             Matchers.is(expected)
+        );
+    }
+
+    @Test
+    void compilesMatchersOnlyOnce() {
+        final AtomicInteger compiled = new AtomicInteger();
+        final GlobFilter filter = new GlobFilter(
+            GlobFilterTest.setOf("**/*.class"),
+            GlobFilterTest.setOf("target/**"),
+            pattern -> {
+                compiled.incrementAndGet();
+                return FileSystems.getDefault().getPathMatcher(
+                    String.format("glob:%s", pattern)
+                );
+            }
+        );
+        filter.test(Paths.get("src/main/Main.java"));
+        filter.test(Paths.get("src/main/Helper.java"));
+        filter.test(Paths.get("src/main/Util.java"));
+        MatcherAssert.assertThat(
+            "Each glob pattern must be compiled once, not on every test() call",
+            compiled.get(),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
+    void keepsGlobCompilationLazy() {
+        final GlobFilter filter = new GlobFilter(
+            GlobFilterTest.setOf("{unclosed"),
+            GlobFilterTest.setOf()
+        );
+        Assertions.assertThrows(
+            PatternSyntaxException.class,
+            () -> filter.test(Paths.get("any/file.java")),
+            "An invalid glob must fail on the first test() call, not at construction time"
         );
     }
 


### PR DESCRIPTION
Fixes #1539.

## Problem
`GlobFilter.test()` (`src/main/java/org/eolang/jeo/GlobFilter.java`) rebuilds the `whitelist` and `blacklist` sets of `PathMatcher` on **every** invocation by streaming over the glob pattern strings. Since `GlobFilter` is a `Predicate<Path>` passed to `Stream.filter()` in `FilteredClasses.all()`, it runs once per `.class` file: for a project with hundreds of classes and several patterns this means thousands of redundant `PathMatcher` constructions per build.

## Solution
Follow the architecture decision from the discussion in #1539: use **cactoos primitives** (`Scalar`, `Sticky`, `Synced`) as suggested by @volodya-lombrozo — instead of eagerly precompiling matchers into `final` fields (as PR #1473 does).

- `whitelist`/`blacklist` are now `Scalar<Set<PathMatcher>>` built as `Synced<>(new Sticky<>(...))`, so each glob pattern is compiled **exactly once** (on the first `test()` call) and cached.
- `Synced` makes the cached computation thread-safe — important because `Disassembler` invokes the filter from a parallel stream (`ParallelTranslator`).
- An extra package-private constructor accepts a `Function<String, PathMatcher>` compiler to make the caching behavior testable.

Behavior is fully preserved (unlike #1473): glob compilation stays **lazy** — an invalid glob pattern still fails on the first `test()` call with `PatternSyntaxException`, not at construction time.

## Tests
- `compilesMatchersOnlyOnce` — injects a counting compiler and asserts each of the two patterns is compiled once across three `test()` calls (fails on `master` where compilation happens per call).
- `keepsGlobCompilationLazy` — guards against the eager-compilation regression: an invalid glob must not throw at construction, only on the first `test()`.

Verified locally: `mvn clean install -Pqulice --errors` (961 tests, 0 failures).

Note: this supersedes/contrasts with PR #1473 (same issue, eager `final`-field caching). Happy to close either one.