### PR TITLE
fix(#1593): reject negative thread count with a descriptive error in ParallelTranslator and mojos

### DIFF
--- a/src/main/java/org/eolang/jeo/AssembleMojo.java
+++ b/src/main/java/org/eolang/jeo/AssembleMojo.java
@@ -148,6 +148,7 @@ public final class AssembleMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        this.checkedThreads();
         final Path src = new MavenPath(this.sourcesDir).resolve();
         final Path out = new MavenPath(this.outputDir).resolve();
         try {
@@ -176,6 +177,21 @@ public final class AssembleMojo extends AbstractMojo {
             }
         } catch (final DependencyResolutionRequiredException exception) {
             throw new MojoExecutionException(exception);
+        }
+    }
+
+    /**
+     * Check that the number of threads is valid.
+     * @throws MojoExecutionException If the number of threads is negative
+     */
+    private void checkedThreads() throws MojoExecutionException {
+        if (this.threads < 0) {
+            throw new MojoExecutionException(
+                String.format(
+                    "The number of threads must be 0 or positive, but got: %d",
+                    this.threads
+                )
+            );
         }
     }
 }

--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -247,6 +247,7 @@ public final class DisassembleMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        this.checkedThreads();
         final Path src = new MavenPath(this.sourcesDir).resolve();
         final Path out = new MavenPath(this.outputDir).resolve();
         try {
@@ -294,6 +295,21 @@ public final class DisassembleMojo extends AbstractMojo {
             throw new MojoExecutionException(
                 String.format("Failed to transpile bytecode to EO, from '%s' to '%s'", src, out),
                 exception
+            );
+        }
+    }
+
+    /**
+     * Check that the number of threads is valid.
+     * @throws MojoExecutionException If the number of threads is negative
+     */
+    private void checkedThreads() throws MojoExecutionException {
+        if (this.threads < 0) {
+            throw new MojoExecutionException(
+                String.format(
+                    "The number of threads must be 0 or positive, but got: %d",
+                    this.threads
+                )
             );
         }
     }

--- a/src/main/java/org/eolang/jeo/ParallelTranslator.java
+++ b/src/main/java/org/eolang/jeo/ParallelTranslator.java
@@ -62,6 +62,14 @@ public final class ParallelTranslator implements Translator {
 
     @Override
     public Stream<Path> apply(final Stream<Path> representations) {
+        if (this.threads < 0) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "The number of threads must be 0 or positive, but got: %d",
+                    this.threads
+                )
+            );
+        }
         final int parallelism;
         if (this.threads == 0) {
             parallelism = Runtime.getRuntime().availableProcessors();

--- a/src/test/java/org/eolang/jeo/ParallelTranslatorTest.java
+++ b/src/test/java/org/eolang/jeo/ParallelTranslatorTest.java
@@ -15,7 +15,9 @@ import java.util.stream.Stream;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.eolang.jeo.representation.bytecode.BytecodeObject;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.hamcrest.io.FileMatchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -99,6 +101,21 @@ final class ParallelTranslatorTest {
                 .resolve("Fake.class")
                 .toFile(),
             FileMatchers.anExistingFile()
+        );
+    }
+
+    @Test
+    void rejectsNegativeThreads() {
+        final IllegalArgumentException exception = Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new ParallelTranslator(ParallelTranslatorTest::transform, -1)
+                .apply(Stream.empty()),
+            "A negative thread count must be rejected with a descriptive error"
+        );
+        MatcherAssert.assertThat(
+            "The error must explain that only 0 or a positive number is allowed",
+            exception.getMessage(),
+            Matchers.containsString("0 or positive")
         );
     }
 


### PR DESCRIPTION
Fixes #1593.

## Problem
`jeo.assemble.threads` and `jeo.disassemble.threads` document only two valid modes: `0` (automatic) and a positive number. However, Maven accepts a negative value and the plugin passes it straight to `ForkJoinPool`, producing an unhelpful unchecked exception:

- `ParallelTranslator.apply()` maps only `0` to the CPU count and otherwise invokes `new ForkJoinPool(parallelism)` (`ParallelTranslator.java:65-74`), whose constructor rejects `-1` with a raw `IllegalArgumentException`.
- Both mojos pass the parameter through unchanged (`AssembleMojo.java:167`, `DisassembleMojo.java:282`).

Reproduced: `new ParallelTranslator(path -> path, -1).apply(Stream.<Path>empty())` throws `java.lang.IllegalArgumentException` after logging `Using -1 thread(s) for parallel processing`.

## Solution
Validate the thread count at the configuration boundary:

- **`ParallelTranslator.apply()`** now rejects a negative count defensively with a descriptive `IllegalArgumentException`: `The number of threads must be 0 or positive, but got: -1`.
- **`AssembleMojo.execute()`** and **`DisassembleMojo.execute()`** now call a `checkedThreads()` helper that throws a `MojoExecutionException` (actionable Maven configuration error) before any processing starts — matching the issue's preferred error type.

## Tests
- `rejectsNegativeThreads` in `ParallelTranslatorTest` — fails on `master` (raw `IllegalArgumentException` from `ForkJoinPool`) and passes on this branch with the descriptive message.

Verified locally: `mvn clean install -Pqulice --errors` (963 tests, 0 failures).