### PR TITLE
fix(#1460): remove eo-maven-plugin:print usage from integration tests

### DIFF
--- a/src/it/bytecode-to-eo/invoker.properties
+++ b/src/it/bytecode-to-eo/invoker.properties
@@ -1,4 +1,3 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 invoker.goals=clean process-classes
-invoker.java.version = 17+

--- a/src/it/bytecode-to-eo/pom.xml
+++ b/src/it/bytecode-to-eo/pom.xml
@@ -57,34 +57,4 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>Print EO</id>
-      <activation>
-        <jdk>[11,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eolang</groupId>
-            <artifactId>eo-maven-plugin</artifactId>
-            <version>0.63.0</version>
-            <executions>
-              <execution>
-                <id>convert-xmir-to-eo</id>
-                <phase>process-classes</phase>
-                <goals>
-                  <goal>print</goal>
-                </goals>
-                <configuration>
-                  <printSourcesDir>${project.build.directory}/generated-sources/jeo-xmir</printSourcesDir>
-                  <printOutputDir>${project.build.directory}/generated-sources/jeo-eo</printOutputDir>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/src/it/custom-transformations/invoker.properties
+++ b/src/it/custom-transformations/invoker.properties
@@ -1,4 +1,3 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 invoker.goals=clean process-classes
-invoker.java.version = 17+

--- a/src/it/custom-transformations/pom.xml
+++ b/src/it/custom-transformations/pom.xml
@@ -48,24 +48,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eolang</groupId>
-        <artifactId>eo-maven-plugin</artifactId>
-        <version>0.63.0</version>
-        <executions>
-          <execution>
-            <id>convert-xmir-to-eo</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>print</goal>
-            </goals>
-            <configuration>
-              <printSourcesDir>${project.build.directory}/generated-sources/jeo-xmir</printSourcesDir>
-              <printOutputDir>${project.build.directory}/generated-sources/jeo-eo</printOutputDir>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.6.3</version>


### PR DESCRIPTION
Fixes #1460.

## Problem
`eo-maven-plugin:print` (goal `print`) is used in two integration tests — `bytecode-to-eo` and `custom-transformations` — to convert the generated XMIR into EO. `eo-maven-plugin` requires Java 17, which conflicts with the plugin's Java 8 target and forces these ITs to be **skipped on JDK 11** (`invoker.java.version = 17+` in their `invoker.properties`).

The current workaround only skips the tests on older JDKs; it does not fix the root cause. This is why the issue got the `bug` label (added 2026-09-01).

## Key finding
The `print` output (`target/generated-sources/jeo-eo`) is **not asserted anywhere**:
- `bytecode-to-eo/verify.groovy` checks only the XMIR output (`<listing>`, comments, indentation).
- `custom-transformations/verify.groovy` has the EO assertion **commented out** (`//assert new File(...jeo-eo...).exists()`).

So `eo-maven-plugin:print` is effectively dead weight that only drags in the Java 17 requirement.

## Solution
Remove the `eo-maven-plugin:print` usage (this is the second option proposed in the issue body — "remove `eo-maven-plugin:print` usage"):
- `src/it/bytecode-to-eo/pom.xml` — drop the `Print EO` profile.
- `src/it/custom-transformations/pom.xml` — drop the `eo-maven-plugin` plugin block.
- Both `invoker.properties` — drop `invoker.java.version = 17+`, so the ITs run again on JDK 11 (more coverage, no Java 17 requirement in the default CI run).

XMIR validity in these ITs is still guarded by `xmirVerification` (objectionary/lints), so nothing is lost.

Verified locally: `mvn clean install -Pqulice --errors` (962 tests, 0 failures) — both ITs pass on local JDK 21 without the plugin; the default invoker run stays green.