### PR TITLE
fix(#1577): enable dependency check in qulice and clean up dependencies

### DIFF
--- a/.github/workflows/maven.qulice.yml
+++ b/.github/workflows/maven.qulice.yml
@@ -29,4 +29,4 @@ jobs:
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
-      - run: mvn qulice:check -P"qulice" --errors --batch-mode
+      - run: mvn clean test-compile qulice:check -P"qulice" --errors --batch-mode

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,18 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-tree</artifactId>
+      <version>9.10.1</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-analysis</artifactId>
+      <version>9.10.1</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>com.jcabi.incubator</groupId>
       <artifactId>xembly</artifactId>
       <version>0.32.2</version>
@@ -184,16 +196,6 @@
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
       <version>0.61.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.github.volodya-lombrozo</groupId>
-      <artifactId>jsmith</artifactId>
-      <version>0.1.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.yegor256</groupId>
-      <artifactId>jhome</artifactId>
-      <version>0.0.5</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -440,14 +442,15 @@
                 <exclude>checkstyle:/src/it/.*</exclude>
                 <exclude>duplicatefinder:.*</exclude>
                 <!--
-                @todo #30:30min Enable dependency check.
-                The qulice library has an issue related to dependency check.
-                You can find more details here:
-                - https://github.com/yegor256/qulice/issues/1145
-                When this issue is fixed, we should enable dependency check.
-                Don't forget to remove the exclude below and this puzzle.
+                Transitive dependencies that are not used directly in the code:
+                'byte-buddy' comes from mockito, 'junit-platform-commons' from
+                junit-jupiter, and 'xnav' from objectionary/lints. The dependency
+                analyzer detects them in the compiled bytecode, but there are no
+                direct references, so they are excluded individually.
                 -->
-                <exclude>dependencies:.*</exclude>
+                <exclude>dependencies:net.bytebuddy:byte-buddy</exclude>
+                <exclude>dependencies:org.junit.platform:junit-platform-commons</exclude>
+                <exclude>dependencies:com.github.volodya-lombrozo:xnav</exclude>
               </excludes>
             </configuration>
           </plugin>


### PR DESCRIPTION
Fixes #1577.

## Problem
The dependency check in qulice was disabled via a global `<exclude>dependencies:.*</exclude>` because of yegor256/qulice#1145 (see the `@todo #30:30min` puzzle at `pom.xml:443-450`). The qulice issue has since been closed (COMPLETED, 2026-04-22), so the puzzle can now be resolved.

## Solution
Enable the dependency check and make the build pass it:

1. **Declare used dependencies explicitly**: `org.ow2.asm:asm-tree` and `org.ow2.asm:asm-analysis` are used directly in the code (e.g. `VerifiedBytecode`, `representation/asm/*`) but were only pulled transitively via `asm-util`.
2. **Remove unused dependencies**: `com.github.volodya-lombrozo:jsmith` and `com.yegor256:jhome` are declared but not referenced anywhere in the code.
3. **Replace the global exclude with targeted ones** for the three remaining transitive dependencies that the analyzer flags in bytecode but are not referenced directly (`byte-buddy` ← mockito, `junit-platform-commons` ← junit-jupiter, `xnav` ← objectionary/lints).
4. **Fix the `mvn-qulice` CI workflow**: it ran `mvn qulice:check` standalone, where the project's bytecode is absent, so the analyzer reported *all* declared dependencies as unused. Now it runs `mvn clean test-compile qulice:check ...` so the dependency analysis has real classes to inspect.
5. Remove the `@todo #30` puzzle.

## Verification
- `mvn clean install -Pqulice --errors` — **"No dependency problems found"**, 962 tests, 0 failures.
- `mvn clean test-compile qulice:check -Pqulice` (the new CI sequence) — **"No dependency problems found"**, BUILD SUCCESS.