### PR TITLE
#1470: compile the globs once, when the filter is built

### DIFF
--- a/src/main/java/org/eolang/jeo/GlobFilter.java
+++ b/src/main/java/org/eolang/jeo/GlobFilter.java
@@ -33,14 +33,49 @@ public final class GlobFilter implements Predicate<Path> {
     private final Set<String> excludes;
 
     /**
+     * Compiled include patterns.
+     */
+    private final Set<PathMatcher> whitelist;
+
+    /**
+     * Compiled exclude patterns.
+     */
+    private final Set<PathMatcher> blacklist;
+
+    /**
      * Ctor.
      *
      * @param includes Glob patterns to include
      * @param excludes Glob patterns to exclude
      */
     GlobFilter(final Set<String> includes, final Set<String> excludes) {
+        this(
+            includes,
+            excludes,
+            includes.stream().map(GlobFilter::matcher).collect(Collectors.toSet()),
+            excludes.stream().map(GlobFilter::matcher).collect(Collectors.toSet())
+        );
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param includes Glob patterns to include
+     * @param excludes Glob patterns to exclude
+     * @param whitelist The include patterns, compiled
+     * @param blacklist The exclude patterns, compiled
+     * @checkstyle ParameterNumberCheck (10 lines)
+     */
+    private GlobFilter(
+        final Set<String> includes,
+        final Set<String> excludes,
+        final Set<PathMatcher> whitelist,
+        final Set<PathMatcher> blacklist
+    ) {
         this.includes = includes;
         this.excludes = excludes;
+        this.whitelist = whitelist;
+        this.blacklist = blacklist;
     }
 
     @Override
@@ -74,17 +109,11 @@ public final class GlobFilter implements Predicate<Path> {
 
     @Override
     public boolean test(final Path path) {
-        final Set<PathMatcher> whitelist = this.includes.stream()
-            .map(GlobFilter::matcher)
-            .collect(Collectors.toSet());
-        final Set<PathMatcher> blacklist = this.excludes.stream()
-            .map(GlobFilter::matcher)
-            .collect(Collectors.toSet());
         final boolean included;
-        if (blacklist.stream().anyMatch(m -> m.matches(path))) {
+        if (this.blacklist.stream().anyMatch(m -> m.matches(path))) {
             included = false;
         } else {
-            included = whitelist.isEmpty() || whitelist.stream()
+            included = this.whitelist.isEmpty() || this.whitelist.stream()
                 .anyMatch(matcher -> matcher.matches(path));
         }
         return included;

--- a/src/test/java/org/eolang/jeo/GlobFilterTest.java
+++ b/src/test/java/org/eolang/jeo/GlobFilterTest.java
@@ -7,10 +7,13 @@ package org.eolang.jeo;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -20,6 +23,19 @@ import org.junit.jupiter.params.provider.MethodSource;
  * @since 0.13.0
  */
 final class GlobFilterTest {
+
+    @Test
+    @DisplayName("Refuses a broken glob pattern when the filter is built")
+    void refusesBrokenGlobPattern() {
+        MatcherAssert.assertThat(
+            "A broken glob must be refused when the filter is built, not when it is first applied",
+            Assertions.assertThrows(
+                PatternSyntaxException.class,
+                () -> new GlobFilter(Set.of("**/{"), Set.of())
+            ),
+            Matchers.notNullValue()
+        );
+    }
 
     /**
      * Applies the glob filter to a path and checks if it matches the expected result.


### PR DESCRIPTION
`test` compiled every include and every exclude pattern on each call, and the plugin calls it once
per class file, so a build over a few thousand classes compiled the same patterns a few thousand
times and threw the result away each time. The patterns come from two final sets and never change.

They are compiled when the filter is built now. The include and exclude strings stay as they were,
`toString` still reads them.

One thing changes for a caller: a broken glob is refused when the filter is made rather than when
it is first applied. The new test pins that down, since it is the only observable difference.

Closes #1470
