### PR TITLE
fix(#1608): quote XPath literals in DirectivesClassTest so the assertion is not vacuous

### DIFF
--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -97,19 +97,29 @@ final class DirectivesClassTest {
     @Test
     void appendsFullyQualifiedName() throws ImpossibleModificationException {
         final String name = "org.eolang.jeo.representation.directives.DirectivesClassTest";
+        final String xml = new Xembler(
+            new DirectivesClass(
+                new ClassName(name),
+                new DirectivesClassProperties(name)
+            )
+        ).xml();
         MatcherAssert.assertThat(
             "Can't append fully qualified class name",
-            new Xembler(
-                new DirectivesClass(
-                    new ClassName(name),
-                    new DirectivesClassProperties(name)
-                )
-            ).xml(),
+            xml,
             XhtmlMatchers.hasXPath(
                 String.format(
                     "./o[contains(@name,DirectivesClassTest)]/o[contains(@name, 'name')]/o/o[text()='%s']",
                     new DirectivesValue(0, new Format(), name.replace('.', '/'))
                         .hex(new JavaCodec())
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            "Wrong class name must not match the class predicate",
+            xml,
+            Matchers.not(
+                XhtmlMatchers.hasXPath(
+                    "./o[contains(@name,WrongClass)]/o[contains(@name, 'name')]/o/o"
                 )
             )
         );

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java
@@ -108,7 +108,7 @@ final class DirectivesClassTest {
             xml,
             XhtmlMatchers.hasXPath(
                 String.format(
-                    "./o[contains(@name,DirectivesClassTest)]/o[contains(@name, 'name')]/o/o[text()='%s']",
+                    "./o[contains(@name,'DirectivesClassTest')]/o[contains(@name, 'name')]/o/o[text()='%s']",
                     new DirectivesValue(0, new Format(), name.replace('.', '/'))
                         .hex(new JavaCodec())
                 )
@@ -119,7 +119,7 @@ final class DirectivesClassTest {
             xml,
             Matchers.not(
                 XhtmlMatchers.hasXPath(
-                    "./o[contains(@name,WrongClass)]/o[contains(@name, 'name')]/o/o"
+                    "./o[contains(@name,'WrongClass')]/o[contains(@name, 'name')]/o/o"
                 )
             )
         );


### PR DESCRIPTION
Fixes #1608.

## Problem
`DirectivesClassTest#appendsFullyQualifiedName` builds the XPath with an **unquoted** literal:

```java
String.format(
    "./o[contains(@name,DirectivesClassTest)]/o[contains(@name, 'name')]/o/o[text()='%s']",
    ...
)
```

The jcabi/XPath engine treats the bare token `DirectivesClassTest` as an unknown function reference,
evaluates it to an empty string, so the predicate becomes `contains(@name,'')` — **always true**.
The test passed regardless of the actual class name in the XML, silently asserting nothing.

## Solution / What
- Quoted the literal in the positive path: `contains(@name,'DirectivesClassTest')`, so the predicate
  verifies the fully-qualified name is actually present.
- Added a negative assertion proving the predicate is now sensitive: `contains(@name,'WrongClass')`
  must NOT match. This assertion fails on the old code (vacuous match) and passes after the fix.

## Changes
- `src/test/java/org/eolang/jeo/representation/directives/DirectivesClassTest.java` — quoted XPath
  literals + sensitivity guard; XML is now evaluated once into a local variable.

## Tests
- `DirectivesClassTest#appendsFullyQualifiedName` — reproduces the vacuity (fails on `master` with
  the negative assertion) and passes after quoting. Full `mvn clean install -Pqulice` is green
  (all tests + jacoco + qulice + jtcop).