### PR TITLE
fix(#1622): use a plain string tag in .0pdd.yaml

### DIFF
--- a/.0pdd.yaml
+++ b/.0pdd.yaml
@@ -5,4 +5,4 @@ format:
   - short-title
 tags:
   - pdd
-  - bug:
+  - bug


### PR DESCRIPTION
Fixes #1622.

## Problem
`.0pdd.yaml` declares `- bug:` (with a trailing colon). YAML parses that as a mapping
`{bug: null}` instead of a plain string, so the PDD bot does not attach the `bug` label
to puzzles it creates.

## Solution / What
Removed the trailing colon: `- bug` (plain string, as documented by 0pdd).

## Changes
- `.0pdd.yaml` — `tags` list entry `- bug:` → `- bug`.

## Tests
- Verified with `ruby -e 'require "yaml"; p YAML.load_file(".0pdd.yaml")'`
  → `{"format" => ["short-title"], "tags" => ["pdd", "bug"]}`.
- `yamllint .0pdd.yaml` passes.