### PR TITLE
fix(#1607): use -DskipTests instead of the non-existent -PskipTests profile in hone.yml

### DIFF
--- a/.github/workflows/hone.yml
+++ b/.github/workflows/hone.yml
@@ -26,5 +26,5 @@ jobs:
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-
-      - run: mvn install -PskipTests -Phone
+      - run: mvn install -DskipTests -Phone
       - run: mvn test -Phone


### PR DESCRIPTION
Fixes #1607.

## Problem
`.github/workflows/hone.yml:29` runs `mvn install -PskipTests -Phone`. `-PskipTests` is a **profile**,
but no such profile exists in `pom.xml` (profiles: `qulice`, `quliceJava11`, `quliceJava8`, `long`,
`verify`, `benchmark`, `hone`) nor in the `com.jcabi:parent` 0.70.0 parent. Maven only warns about the
unknown profile, so tests are **not** skipped and line 30 (`mvn test -Phone`) runs the suite a second time.

## Solution / What
Use the property form: `mvn install -DskipTests -Phone`.

## Changes
- `.github/workflows/hone.yml` — `-PskipTests` → `-DskipTests`.

## Tests
- Verified there is no `skipTests` profile in `pom.xml` or `com.jcabi:parent` 0.70.0.
- `yamllint .github/workflows/hone.yml` passes.