### PR TITLE
fix(#1611): drop the non-existent -Pobjectionary profile from the rultor release script

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -24,4 +24,4 @@ release:
     mvn -ntp versions:set "-DnewVersion=${tag}"
     git commit -am "${tag}"
     mvn clean install -ntp -Pqulice --errors --batch-mode -Dinvoker.skip -DskipITs
-    mvn clean deploy -ntp -Pobjectionary -Psonatype --errors --settings ../settings.xml -Dstyle.color=never
+    mvn clean deploy -ntp -Psonatype --errors --settings ../settings.xml -Dstyle.color=never


### PR DESCRIPTION
Fixes #1611.

## Problem
The Rultor release script (`.rultor.yml:27`) deploys with `mvn clean deploy -Pobjectionary -Psonatype ...`.
There is no `objectionary` profile in `pom.xml` (existing profiles: `qulice`, `quliceJava11`, `quliceJava8`,
`long`, `verify`, `benchmark`, `hone`) and it never existed in the history. Maven silently ignores the
unknown profile (only a warning), so the deploy runs without whatever the profile was supposed to configure.

## Solution / What
Removed `-Pobjectionary` from the release command. `-Psonatype` is kept — it is a real profile defined in
the `com.jcabi:parent` 0.70.0 parent (`pom.xml:107` in parent).

## Changes
- `.rultor.yml` — release deploy command: `-Pobjectionary -Psonatype` → `-Psonatype`.

## Tests
- Confirmed no `objectionary` profile in `pom.xml`, in parent POM, or in git history (the only
  "objectionary" hits in history are comments about `objectionary/lints`).
- Confirmed `sonatype` profile exists in `com.jcabi:parent` 0.70.0.
- `yamllint .rultor.yml` passes.