### PR TITLE
fix(#1612): align site.yml cache key with the repo convention and remove stray spaces

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -20,9 +20,9 @@ jobs:
       - uses: actions/cache@v6
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }} -site-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-jdk-21-site-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-jdk-site-maven-
+            ${{ runner.os }}-jdk-21-site-maven-
       - run: mvn clean site -Psite
       - uses: JamesIves/github-pages-deploy-action@v4.9.0
         with:


### PR DESCRIPTION
Fixes #1612.

## Problem
`.github/workflows/site.yml:23-25` used:
- `key: ${{ runner.os }} -site-maven-${{ hashFiles('**/pom.xml') }}` — stray spaces around
  `-site-maven-`, so the key was `ubuntu-24.04 -site-maven-...`;
- `restore-keys: ${{ runner.os }}-jdk-site-maven-` — prefix `ubuntu-24.04-jdk-site-maven-`.

The prefixes did not match, so the cache was never restored (a cache miss on every run). The key also
omitted the JDK version, unlike every other Maven workflow in the repo
(`${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}`).

## Solution / What
Aligned the key with the repo convention. Since `site.yml` uses a fixed JDK 21 (no matrix), the JDK
segment is hardcoded: `${{ runner.os }}-jdk-21-site-maven-${{ hashFiles('**/pom.xml') }}`, with matching
restore-keys prefix.

## Changes
- `.github/workflows/site.yml` — cache key and restore-keys aligned (spaces removed, JDK version added).

## Tests
- `yamllint .github/workflows/site.yml` passes.
- Prefix of `key` now equals `restore-keys` exactly, so partial-key restore works.