### PR TITLE
fix(#1609): remove the GitHub context dump step from post-comment.yml

### DIFF
--- a/.github/workflows/post-comment.yml
+++ b/.github/workflows/post-comment.yml
@@ -15,10 +15,6 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
       - name: Download PR Number and Benchmark Comment
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
Fixes #1609.

## Problem
`.github/workflows/post-comment.yml:18-21` printed the entire `github` context to the workflow log:

```yaml
- name: Dump GitHub context
  env:
    GITHUB_CONTEXT: ${{ toJson(github) }}
  run: echo "$GITHUB_CONTEXT"
```

The `github` context includes sensitive fields such as `github.token`. It was a leftover debugging
step: the only value actually needed later (`PR_NUMBER`) is read from a downloaded artifact.

## Solution / What
Removed the "Dump GitHub context" step.

## Changes
- `.github/workflows/post-comment.yml` — deleted the debug step.

## Tests
- `yamllint .github/workflows/post-comment.yml` passes.