### PR TITLE
fix(#1613): drop sign-commits and make README version extraction stable in up.yml

### DIFF
--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -21,11 +21,10 @@ jobs:
       - run: |-
           git fetch --tags --force && \
           latest=$(git tag --sort=creatordate | tail -1) && \
-          prev=$(grep -oE '<version>[^<]+' README.md | sed 's/<version>//' | head -1) && \
+          prev=$(awk '/<artifactId>jeo-maven-plugin<\/artifactId>/{getline; print}' README.md | grep -oE '<version>[^<]+' | sed 's/<version>//') && \
           sed -i "s/${prev}/${latest}/g" README.md
       - uses: peter-evans/create-pull-request@v8
         with:
-          sign-commits: true
           branch: version-up
           commit-message: 'chore: new version in README'
           delete-branch: true


### PR DESCRIPTION
Fixes #1613

## Problem
`.github/workflows/up.yml` had two issues:

1. `sign-commits: true` was set on `peter-evans/create-pull-request` while using the default
   `GITHUB_TOKEN`, which is not backed by a signing key — commit signing cannot work
2. Version extraction took the **first** `<version>` occurrence in `README.md`:
   ```bash
   prev=$(grep -oE '<version>[^<]+' README.md | sed 's/<version>//' | head -1)
   ```
   Any `<version>` added above the plugin snippet would silently break the auto-bump

## Solution / What
1. Removed `sign-commits: true`
2. Extracted the version from the plugin block only — the line right after
   `<artifactId>jeo-maven-plugin</artifactId>`:
   ```bash
   prev=$(awk '/<artifactId>jeo-maven-plugin<\/artifactId>/{getline; print}' README.md | grep -oE '<version>[^<]+' | sed 's/<version>//')
   ```

## Changes
- `.github/workflows/up.yml` — dropped `sign-commits`, replaced the fragile `grep | head -1`
  extraction with an `awk`-based one anchored to the plugin artifactId

## Tests
- Verified the new extraction returns `0.15.2` on the current `README.md`
- Verified robustness with a synthetic input where a foreign `<version>` appears above the plugin block —
  the plugin version is still extracted correctly
- `yamllint .github/workflows/up.yml` passes