### PR TITLE
fix(#1631): format the phi-unphi App output with Locale.ROOT

### DIFF
--- a/src/it/phi-unphi/src/main/java/org/eolang/hone/App.java
+++ b/src/it/phi-unphi/src/main/java/org/eolang/hone/App.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.hone;
 
+import java.util.Locale;
 import org.eolang.hone.param.Parameter;
 
 /**
@@ -18,7 +19,7 @@ public class App {
     public static void main(String[] args) {
         double angle = 42.0;
         double sin = Math.sin(angle);
-        System.out.printf("sin(%f) = %f\n", angle, sin);
+        System.out.printf(Locale.ROOT, "sin(%f) = %f\n", angle, sin);
         System.out.println(Φ);
     }
 }


### PR DESCRIPTION
Fixes #1631.

## Problem
`src/it/phi-unphi/src/main/java/org/eolang/hone/App.java:21` printed the result with
`System.out.printf("sin(%f) = %f\n", angle, sin)`, which uses the JVM default locale. `verify.groovy:9`
asserts the exact English-formatted output `sin(42.000000) = -0.916522`. In a non-English locale the
decimal separator becomes `,` and the assertion fails despite a correct pipeline.

## Solution / What
Format with a fixed locale:
```java
System.out.printf(Locale.ROOT, "sin(%f) = %f\n", angle, sin);
```

## Changes
- `src/it/phi-unphi/src/main/java/org/eolang/hone/App.java` — added `java.util.Locale` import and
  passed `Locale.ROOT` to `printf`.

## Tests
- Compiled and ran `App` under the default, `ru_RU`, and `de_DE` locales — output is identical:
  `sin(42.000000) = -0.916522`, matching the `verify.groovy` assertion.