### PR TITLE
test(#1615): assert only the stable error count instead of the full XSD message

### DIFF
--- a/src/test/java/org/eolang/jeo/XmirFilesTest.java
+++ b/src/test/java/org/eolang/jeo/XmirFilesTest.java
@@ -171,7 +171,7 @@ final class XmirFilesTest {
                 () -> new XmirFiles(temp).verify()
             ).getMessage(),
             Matchers.containsString(
-                "1 error(s) in XML document: cvc-complex-type.2.4.a: Invalid content was found starting with element 'tail'. One of '{head}' is expected."
+                "1 error(s) in XML document"
             )
         );
     }


### PR DESCRIPTION
Fixes #1615

## Problem
`XmirFilesTest.java:173-175` asserted the exact, vendor-specific XSD validation message:
`1 error(s) in XML document: cvc-complex-type.2.4.a: Invalid content was found starting with
element 'tail'. One of '{head}' is expected.` The wording comes from the underlying XML validator
(jcabi/XML + XSD schema), not from the plugin, so a dependency upgrade could break the test without
any real regression

## Solution / What
Assert only the stable error-count fragment (`1 error(s) in XML document`), which still verifies that
the schema validation runs and reports a single error for the invalid XMIR, while being resilient to
changes in the validator's message wording

## Changes
- `src/test/java/org/eolang/jeo/XmirFilesTest.java` — shortened the asserted fragment

## Tests
- `XmirFilesTest` passes (9 tests)