### PR TITLE
fix(#1628): remove the redundant global JAXP TransformerFactory registration

### DIFF
--- a/src/main/resources/META-INF/services/javax.xml.transform.TransformerFactory
+++ b/src/main/resources/META-INF/services/javax.xml.transform.TransformerFactory
@@ -1,1 +1,0 @@
-net.sf.saxon.TransformerFactoryImpl


### PR DESCRIPTION
Fixes #1628

## Problem
`src/main/resources/META-INF/services/javax.xml.transform.TransformerFactory` force-registered Saxon
as the **global JAXP `TransformerFactory`** for the whole classpath. The plugin's own code does not use
JAXP transformers directly (it uses `org.xembly.Transformers` and eo-parser's `StrictXmir`), so the
registration only affected unrelated JAXP consumers in the same classloader

## Solution / What
Removed the service file. It was redundant: both **Saxon-HE 12.9** and **eo-parser 0.63.3** already ship
`META-INF/services/javax.xml.transform.TransformerFactory` = `net.sf.saxon.TransformerFactoryImpl`
(verified in their jars), and Saxon-HE is on the runtime classpath both directly and transitively via
eo-parser. JAXP `TransformerFactory.newInstance()` still resolves to Saxon

## Changes
- Removed `src/main/resources/META-INF/services/javax.xml.transform.TransformerFactory`

## Tests
- Verified the same registration exists in `Saxon-HE-12.9.jar` and `eo-parser-0.63.0.jar`
- Full `mvn clean install -Pqulice` green (all tests + qulice + jacoco + jtcop, no dependency problems)