### PR TITLE
fix(#1632): correct the misleading 'long' profile comment about integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -577,7 +577,8 @@
             <artifactId>maven-invoker-plugin</artifactId>
             <configuration combine.self="override">
               <!--
-              All integration tests are enabled in the 'long' profile.
+              All integration tests except 'phi-unphi' and 'jna' are enabled
+              in the 'long' profile.
               -->
               <pomExcludes>
                 <exclude>phi-unphi/pom.xml</exclude>


### PR DESCRIPTION
Fixes #1632.

## Problem
The `long` profile comment in `pom.xml` claimed "All integration tests are enabled in the 'long'
profile", while the `pomExcludes` still excluded `phi-unphi/pom.xml` and `jna/pom.xml` (only
`spring-fat` is re-enabled). See also #1605 and #1606.

## Solution / What
Made the comment match reality: all integration tests except `phi-unphi` and `jna` are enabled in the
`long` profile. Re-enabling the two ITs is a separate concern (#1605, #1606), so only the misleading
comment is corrected here.

## Changes
- `pom.xml` — fixed the `long` profile comment.

## Tests
- XML well-formed; no behavior change.