### PR TITLE
fix(#1601): compute the LDC stack impact from the constant kind without NPE

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java
@@ -274,14 +274,13 @@ public final class BytecodeInstruction implements BytecodeEntry {
                 result = 2;
                 break;
             case LDC: {
-                final Class<?> clazz = this.args.get(0).getClass();
-                if (clazz == Long.class || clazz == Double.class) {
+                final Object arg = this.args.get(0);
+                if (arg instanceof Long || arg instanceof Double) {
                     result = 2;
-                    break;
                 } else {
-                    result = BytecodeInstruction.size(Type.getType(clazz));
-                    break;
+                    result = 1;
                 }
+                break;
             }
             case GETSTATIC:
                 result = BytecodeInstruction.size(Type.getType(String.valueOf(this.args.get(2))));

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionTest.java
@@ -9,6 +9,7 @@ import org.eolang.jeo.representation.directives.Format;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Handle;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.xembly.ImpossibleModificationException;
@@ -40,6 +41,81 @@ final class BytecodeInstructionTest {
                     )
                 ).xml()
             )
+        );
+    }
+
+    @Test
+    void calculatesImpactForLdcLong() {
+        MatcherAssert.assertThat(
+            "LDC with a long constant pushes two slots",
+            new BytecodeInstruction(Opcodes.LDC, 42L).impact(),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
+    void calculatesImpactForLdcDouble() {
+        MatcherAssert.assertThat(
+            "LDC with a double constant pushes two slots",
+            new BytecodeInstruction(Opcodes.LDC, 42.0d).impact(),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
+    void calculatesImpactForLdcInteger() {
+        MatcherAssert.assertThat(
+            "LDC with an int constant pushes one slot",
+            new BytecodeInstruction(Opcodes.LDC, 42).impact(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void calculatesImpactForLdcFloat() {
+        MatcherAssert.assertThat(
+            "LDC with a float constant pushes one slot",
+            new BytecodeInstruction(Opcodes.LDC, 42.0f).impact(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void calculatesImpactForLdcString() {
+        MatcherAssert.assertThat(
+            "LDC with a string constant pushes one slot",
+            new BytecodeInstruction(Opcodes.LDC, "answer").impact(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void calculatesImpactForLdcType() {
+        MatcherAssert.assertThat(
+            "LDC with a class constant pushes one slot",
+            new BytecodeInstruction(Opcodes.LDC, Type.getType(Integer.class)).impact(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void calculatesImpactForLdcHandle() {
+        MatcherAssert.assertThat(
+            "LDC with a method handle pushes one slot",
+            new BytecodeInstruction(
+                Opcodes.LDC,
+                new Handle(Opcodes.H_INVOKESTATIC, "java/lang/Math", "abs", "(I)I", false)
+            ).impact(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void calculatesImpactForLdcNull() {
+        MatcherAssert.assertThat(
+            "LDC with a null constant pushes one slot",
+            new BytecodeInstruction(Opcodes.LDC, (Object) null).impact(),
+            Matchers.equalTo(1)
         );
     }
 }


### PR DESCRIPTION
Fixes #1601.

## Problem
`BytecodeInstruction.impact()` computed the `LDC` stack effect from the **runtime class** of the
constant (`BytecodeInstruction.java:276-285`):
```java
final Class<?> clazz = this.args.get(0).getClass();
if (clazz == Long.class || clazz == Double.class) {
    result = 2;
} else {
    result = BytecodeInstruction.size(Type.getType(clazz));
}
```
This crashes or misbehaves for operands `LDC` can actually hold:
- `null` literal → `NullPointerException` (`getClass()` on `null`);
- `Type` / `Handle` constants → size derived from the wrong runtime class (works only by luck);
- `ConstantDynamic` → not handled.

`impact()` feeds `MaxStack`/`MaxLocals` via `InstructionsFlow`, so a wrong value silently corrupts
the computed `max_stack`/`max_locals` (or crashes) during `assemble`. There was no direct unit test
for `impact()`.

## Solution / What
Derive the size from the JVM semantics of `LDC`: only `Long`/`Double` constants push two slots;
every other constant (`Integer`, `Float`, `String`, `Type`, `Handle`, `ConstantDynamic`, `null`)
pushes one reference slot:
```java
final Object arg = this.args.get(0);
if (arg instanceof Long || arg instanceof Double) {
    result = 2;
} else {
    result = 1;
}
```

## Changes
- `src/main/java/org/eolang/jeo/representation/bytecode/BytecodeInstruction.java` — fixed the `LDC` case.
- `src/test/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionTest.java` — added 8 tests
  for `impact()` covering `Long`, `Double`, `Integer`, `Float`, `String`, `Type`, `Handle`, and `null`.

## Tests
- `calculatesImpactForLdcNull` fails on `master` with `NullPointerException` and passes after the fix.
- Full `mvn clean install -Pqulice` green (971 tests, qulice + jacoco + jtcop).