### PR TITLE
test(#1630): clarify class signature vs supername with realistic data and a generic round-trip test

### DIFF
--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlClassPropertiesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlClassPropertiesTest.java
@@ -4,7 +4,10 @@
  */
 package org.eolang.jeo.representation.xmir;
 
+import java.util.ArrayList;
+import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.eolang.jeo.representation.bytecode.BytecodeClassProperties;
+import org.eolang.jeo.representation.bytecode.BytecodeObject;
 import org.eolang.jeo.representation.directives.DirectivesClassProperties;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -20,9 +23,9 @@ final class XmlClassPropertiesTest {
     @Test
     void createsXmirWithCorrectProperties() {
         final int access = Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT | Opcodes.ACC_SUPER;
-        final String signature = "Ljava/util/List<Ljava/lang/String;>;";
-        final String supername = "some/custom/Supername";
-        final String[] interfaces = {"java/util/List", "java/util/Collection"};
+        final String signature = "Ljava/util/ArrayList<Ljava/lang/String;>;";
+        final String supername = "java/util/ArrayList";
+        final String[] interfaces = {"java/util/List"};
         MatcherAssert.assertThat(
             "We expect that the properties will be created correctly and contain the correct values",
             new XmlClass(
@@ -42,6 +45,29 @@ final class XmlClassPropertiesTest {
                     interfaces
                 )
             )
+        );
+    }
+
+    @Test
+    void keepsClassSignatureSeparateFromSupername() {
+        final int access = Opcodes.ACC_PUBLIC;
+        final String supername = "java/util/ArrayList";
+        final String signature = "<T::Ljava/lang/Number;>Ljava/util/ArrayList<TT;>;";
+        final BytecodeClassProperties expected = new BytecodeClassProperties(
+            access, signature, supername
+        );
+        MatcherAssert.assertThat(
+            "We expect that the generic class signature and the supername survive the XMIR round-trip separately",
+            new XmlObject(
+                new BytecodeObject(
+                    new BytecodeClass(
+                        "Foo",
+                        new ArrayList<>(0),
+                        expected
+                    )
+                ).xml()
+            ).bytecode().top().properties(),
+            Matchers.equalTo(expected)
         );
     }
 }


### PR DESCRIPTION
Fixes #1630

## Problem
`XmlClassPropertiesTest` used a **type** signature (`Ljava/util/List<Ljava/lang/String;>;`) as the class
signature together with an unrelated supername (`some/custom/Supername`), which obscured the difference
between the two JVM concepts (class generic signature vs direct superclass). The data model itself keeps
them as separate fields (`BytecodeClassProperties.signature()` / `supername()`, threaded separately into
`ClassVisitor.visit`), so the fix is to document and verify that separation properly

## Solution / What
- Fixed the existing test to use a realistic, consistent class: `class Foo extends ArrayList<String>
  implements List<String>` → signature `Ljava/util/ArrayList<Ljava/lang/String;>;`, supername
  `java/util/ArrayList`, interfaces `{java/util/List}`
- Added a full round-trip test with a generic class including a type parameter:
  `class Foo<T extends Number> extends ArrayList<T>` → signature `<T::Ljava/lang/Number;>Ljava/util/ArrayList<TT;>;`
  The test builds a `BytecodeObject`, serializes it to XMIR, parses it back via `XmlObject`, and asserts
  the signature and supername survive separately

## Changes
- `src/test/java/org/eolang/jeo/representation/xmir/XmlClassPropertiesTest.java` — realistic data in
  `createsXmirWithCorrectProperties` + new `keepsClassSignatureSeparateFromSupername`

## Tests
- `XmlClassPropertiesTest` passes (2 tests), including the generic round-trip
- Full `mvn clean install -Pqulice` green