### PR TITLE
test(#1623): cover AsmInstruction's switch branches and BytecodeInstruction's impact/jumps/is/var helpers

### DIFF
--- a/src/test/java/org/eolang/jeo/representation/asm/AsmInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/asm/AsmInstructionTest.java
@@ -1,0 +1,236 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.asm;
+
+import org.eolang.jeo.representation.bytecode.BytecodeFrame;
+import org.eolang.jeo.representation.bytecode.BytecodeInstruction;
+import org.eolang.jeo.representation.bytecode.BytecodeLabel;
+import org.eolang.jeo.representation.bytecode.BytecodeLine;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.FrameNode;
+import org.objectweb.asm.tree.IincInsnNode;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.IntInsnNode;
+import org.objectweb.asm.tree.InvokeDynamicInsnNode;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.LdcInsnNode;
+import org.objectweb.asm.tree.LineNumberNode;
+import org.objectweb.asm.tree.LookupSwitchInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MultiANewArrayInsnNode;
+import org.objectweb.asm.tree.TableSwitchInsnNode;
+import org.objectweb.asm.tree.TypeInsnNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
+/**
+ * Test cases for {@link AsmInstruction}.
+ * @since 0.6
+ */
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
+final class AsmInstructionTest {
+
+    @Test
+    void convertsPlainInstruction() {
+        MatcherAssert.assertThat(
+            "We expect that a plain instruction is converted to a bytecode instruction",
+            new AsmInstruction(new InsnNode(Opcodes.NOP)).bytecode(),
+            Matchers.equalTo(new BytecodeInstruction(Opcodes.NOP))
+        );
+    }
+
+    @Test
+    void convertsIntInstruction() {
+        MatcherAssert.assertThat(
+            "We expect that an int instruction is converted with its operand",
+            new AsmInstruction(new IntInsnNode(Opcodes.BIPUSH, 5)).bytecode(),
+            Matchers.equalTo(new BytecodeInstruction(Opcodes.BIPUSH, 5))
+        );
+    }
+
+    @Test
+    void convertsVarInstruction() {
+        MatcherAssert.assertThat(
+            "We expect that a var instruction is converted with its index",
+            new AsmInstruction(new VarInsnNode(Opcodes.ILOAD, 2)).bytecode(),
+            Matchers.equalTo(new BytecodeInstruction(Opcodes.ILOAD, 2))
+        );
+    }
+
+    @Test
+    void convertsTypeInstruction() {
+        MatcherAssert.assertThat(
+            "We expect that a type instruction is converted with its descriptor",
+            new AsmInstruction(new TypeInsnNode(Opcodes.NEW, "java/lang/String")).bytecode(),
+            Matchers.equalTo(new BytecodeInstruction(Opcodes.NEW, "java/lang/String"))
+        );
+    }
+
+    @Test
+    void convertsFieldInstruction() {
+        MatcherAssert.assertThat(
+            "We expect that a field instruction is converted with owner, name and descriptor",
+            new AsmInstruction(
+                new FieldInsnNode(Opcodes.GETFIELD, "owner", "name", "I")
+            ).bytecode(),
+            Matchers.equalTo(new BytecodeInstruction(Opcodes.GETFIELD, "owner", "name", "I"))
+        );
+    }
+
+    @Test
+    void convertsMethodInstruction() {
+        MatcherAssert.assertThat(
+            "We expect that a method instruction is converted with owner, name and descriptor",
+            new AsmInstruction(
+                new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "owner", "name", "()V", false)
+            ).bytecode(),
+            Matchers.equalTo(
+                new BytecodeInstruction(Opcodes.INVOKEVIRTUAL, "owner", "name", "()V", false)
+            )
+        );
+    }
+
+    @Test
+    void convertsInvokeDynamicInstruction() {
+        final Handle bsm = new Handle(Opcodes.H_INVOKESTATIC, "owner", "bsm", "()V", false);
+        MatcherAssert.assertThat(
+            "We expect that an invoke dynamic instruction is converted with name, descriptor, bsm and arguments",
+            new AsmInstruction(
+                new InvokeDynamicInsnNode("name", "()V", bsm, 42)
+            ).bytecode(),
+            Matchers.equalTo(
+                new BytecodeInstruction(Opcodes.INVOKEDYNAMIC, "name", "()V", bsm, 42)
+            )
+        );
+    }
+
+    @Test
+    void convertsJumpInstruction() {
+        final LabelNode label = new LabelNode();
+        MatcherAssert.assertThat(
+            "We expect that a jump instruction is converted with its target label",
+            new AsmInstruction(new JumpInsnNode(Opcodes.GOTO, label)).bytecode(),
+            Matchers.equalTo(
+                new BytecodeInstruction(
+                    Opcodes.GOTO,
+                    new BytecodeLabel(label.getLabel().toString())
+                )
+            )
+        );
+    }
+
+    @Test
+    void convertsLabel() {
+        final LabelNode label = new LabelNode();
+        MatcherAssert.assertThat(
+            "We expect that a label is converted to a bytecode label",
+            new AsmInstruction(label).bytecode(),
+            Matchers.equalTo(new BytecodeLabel(label.getLabel().toString()))
+        );
+    }
+
+    @Test
+    void convertsLdcInstruction() {
+        MatcherAssert.assertThat(
+            "We expect that an LDC instruction is converted with its constant",
+            new AsmInstruction(new LdcInsnNode("const")).bytecode(),
+            Matchers.equalTo(new BytecodeInstruction(Opcodes.LDC, "const"))
+        );
+    }
+
+    @Test
+    void convertsIincInstruction() {
+        MatcherAssert.assertThat(
+            "We expect that an IINC instruction is converted with its index and increment",
+            new AsmInstruction(new IincInsnNode(1, 2)).bytecode(),
+            Matchers.equalTo(new BytecodeInstruction(Opcodes.IINC, 1, 2))
+        );
+    }
+
+    @Test
+    void convertsTableSwitchInstruction() {
+        final LabelNode dflt = new LabelNode();
+        final LabelNode single = new LabelNode();
+        MatcherAssert.assertThat(
+            "We expect that a table switch instruction is converted with min, max and labels",
+            new AsmInstruction(
+                new TableSwitchInsnNode(0, 1, dflt, single)
+            ).bytecode(),
+            Matchers.equalTo(
+                new BytecodeInstruction(
+                    Opcodes.TABLESWITCH,
+                    0,
+                    1,
+                    new BytecodeLabel(dflt.getLabel().toString()),
+                    new BytecodeLabel(single.getLabel().toString())
+                )
+            )
+        );
+    }
+
+    @Test
+    void convertsLookupSwitchInstruction() {
+        final LabelNode dflt = new LabelNode();
+        final LabelNode first = new LabelNode();
+        final LabelNode second = new LabelNode();
+        MatcherAssert.assertThat(
+            "We expect that a lookup switch instruction is converted with its keys and labels",
+            new AsmInstruction(
+                new LookupSwitchInsnNode(
+                    dflt,
+                    new int[] {1, 2},
+                    new LabelNode[] {first, second}
+                )
+            ).bytecode(),
+            Matchers.equalTo(
+                new BytecodeInstruction(
+                    Opcodes.LOOKUPSWITCH,
+                    new BytecodeLabel(dflt.getLabel().toString()),
+                    1,
+                    2,
+                    new BytecodeLabel(first.getLabel().toString()),
+                    new BytecodeLabel(second.getLabel().toString())
+                )
+            )
+        );
+    }
+
+    @Test
+    void convertsMultiAnNewArrayInstruction() {
+        MatcherAssert.assertThat(
+            "We expect that a multi array instruction is converted with its descriptor and dimensions",
+            new AsmInstruction(new MultiANewArrayInsnNode("[[I", 2)).bytecode(),
+            Matchers.equalTo(new BytecodeInstruction(Opcodes.MULTIANEWARRAY, "[[I", 2))
+        );
+    }
+
+    @Test
+    void convertsFrame() {
+        MatcherAssert.assertThat(
+            "We expect that a frame is converted to a bytecode frame",
+            new AsmInstruction(
+                new FrameNode(Opcodes.F_NEW, 0, null, 0, null)
+            ).bytecode(),
+            Matchers.equalTo(new BytecodeFrame(Opcodes.F_NEW, 0, new Object[0], 0))
+        );
+    }
+
+    @Test
+    void convertsLine() {
+        final LabelNode label = new LabelNode();
+        MatcherAssert.assertThat(
+            "We expect that a line number is converted to a bytecode line",
+            new AsmInstruction(new LineNumberNode(10, label)).bytecode(),
+            Matchers.equalTo(
+                new BytecodeLine(10, new BytecodeLabel(label.getLabel().toString()))
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionTest.java
@@ -4,10 +4,13 @@
  */
 package org.eolang.jeo.representation.bytecode;
 
+import java.util.Arrays;
+import java.util.Collections;
 import org.eolang.jeo.representation.directives.DirectivesInstruction;
 import org.eolang.jeo.representation.directives.Format;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Opcodes;
@@ -19,6 +22,7 @@ import org.xembly.Xembler;
  * Test cases for {@link BytecodeInstruction}.
  * @since 0.11.0
  */
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals"})
 final class BytecodeInstructionTest {
 
     @Test
@@ -116,6 +120,238 @@ final class BytecodeInstructionTest {
             "LDC with a null constant pushes one slot",
             new BytecodeInstruction(Opcodes.LDC, (Object) null).impact(),
             Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void calculatesImpactForGetstatic() {
+        MatcherAssert.assertThat(
+            "GETSTATIC of an int field pushes one slot",
+            new BytecodeInstruction(
+                Opcodes.GETSTATIC,
+                "owner",
+                "name",
+                "I"
+            ).impact(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void calculatesImpactForPutstatic() {
+        MatcherAssert.assertThat(
+            "PUTSTATIC of an int field pops one slot",
+            new BytecodeInstruction(
+                Opcodes.PUTSTATIC,
+                "owner",
+                "name",
+                "I"
+            ).impact(),
+            Matchers.equalTo(-1)
+        );
+    }
+
+    @Test
+    void calculatesImpactForGetfield() {
+        MatcherAssert.assertThat(
+            "GETFIELD pops the reference and pushes an int field",
+            new BytecodeInstruction(
+                Opcodes.GETFIELD,
+                "owner",
+                "name",
+                "I"
+            ).impact(),
+            Matchers.equalTo(0)
+        );
+    }
+
+    @Test
+    void calculatesImpactForPutfield() {
+        MatcherAssert.assertThat(
+            "PUTFIELD pops the reference and the int field",
+            new BytecodeInstruction(
+                Opcodes.PUTFIELD,
+                "owner",
+                "name",
+                "I"
+            ).impact(),
+            Matchers.equalTo(-2)
+        );
+    }
+
+    @Test
+    void calculatesImpactForInvokestatic() {
+        MatcherAssert.assertThat(
+            "INVOKESTATIC with (I)I pops one argument and pushes one result",
+            new BytecodeInstruction(
+                Opcodes.INVOKESTATIC,
+                "owner",
+                "name",
+                "(I)I"
+            ).impact(),
+            Matchers.equalTo(0)
+        );
+    }
+
+    @Test
+    void calculatesImpactForInvokevirtual() {
+        MatcherAssert.assertThat(
+            "INVOKEVIRTUAL with (I)I additionally pops the receiver",
+            new BytecodeInstruction(
+                Opcodes.INVOKEVIRTUAL,
+                "owner",
+                "name",
+                "(I)I"
+            ).impact(),
+            Matchers.equalTo(-1)
+        );
+    }
+
+    @Test
+    void calculatesImpactForMultiAnNewArray() {
+        MatcherAssert.assertThat(
+            "MULTIANEWARRAY with two dimensions pops two ints and pushes a reference",
+            new BytecodeInstruction(Opcodes.MULTIANEWARRAY, "[[I", 2).impact(),
+            Matchers.equalTo(-1)
+        );
+    }
+
+    @Test
+    void returnsJumpsForGoto() {
+        final BytecodeLabel label = new BytecodeLabel("target");
+        MatcherAssert.assertThat(
+            "GOTO jumps to a single label",
+            new BytecodeInstruction(Opcodes.GOTO, label).jumps(),
+            Matchers.equalTo(Collections.singletonList(label))
+        );
+    }
+
+    @Test
+    void returnsJumpsForConditionalBranch() {
+        final BytecodeLabel label = new BytecodeLabel("branch");
+        MatcherAssert.assertThat(
+            "IFEQ jumps to a single label",
+            new BytecodeInstruction(Opcodes.IFEQ, label).jumps(),
+            Matchers.equalTo(Collections.singletonList(label))
+        );
+    }
+
+    @Test
+    void returnsJumpsForTableSwitch() {
+        final BytecodeLabel dflt = new BytecodeLabel("dflt");
+        final BytecodeLabel single = new BytecodeLabel("single");
+        MatcherAssert.assertThat(
+            "TABLESWITCH jumps to the default and every case label",
+            new BytecodeInstruction(Opcodes.TABLESWITCH, 0, 1, dflt, single).jumps(),
+            Matchers.equalTo(Arrays.asList(dflt, single))
+        );
+    }
+
+    @Test
+    void recognizesGotoAsJump() {
+        MatcherAssert.assertThat(
+            "GOTO is a jump instruction",
+            new BytecodeInstruction(Opcodes.GOTO, new BytecodeLabel("x")).isJump(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void doesNotRecognizeNopAsJump() {
+        MatcherAssert.assertThat(
+            "NOP is not a jump instruction",
+            new BytecodeInstruction(Opcodes.NOP).isJump(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void recognizesIfeqAsIf() {
+        MatcherAssert.assertThat(
+            "IFEQ is a conditional branch",
+            new BytecodeInstruction(Opcodes.IFEQ, new BytecodeLabel("x")).isIf(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void doesNotRecognizeGotoAsIf() {
+        MatcherAssert.assertThat(
+            "GOTO is not a conditional branch",
+            new BytecodeInstruction(Opcodes.GOTO, new BytecodeLabel("x")).isIf(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void recognizesTableSwitchAsSwitch() {
+        MatcherAssert.assertThat(
+            "TABLESWITCH is a switch instruction",
+            new BytecodeInstruction(Opcodes.TABLESWITCH).isSwitch(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void recognizesIreturnAsReturn() {
+        MatcherAssert.assertThat(
+            "IRETURN is a return instruction",
+            new BytecodeInstruction(Opcodes.IRETURN).isReturn(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void doesNotRecognizeNopAsReturn() {
+        MatcherAssert.assertThat(
+            "NOP is not a return instruction",
+            new BytecodeInstruction(Opcodes.NOP).isReturn(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void recognizesLoadAsVarInstruction() {
+        MatcherAssert.assertThat(
+            "ILOAD is a variable instruction",
+            new BytecodeInstruction(Opcodes.ILOAD, 2).isVarInstruction(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void retrievesVarIndex() {
+        MatcherAssert.assertThat(
+            "The variable index of ILOAD is its second argument",
+            new BytecodeInstruction(Opcodes.ILOAD, 2).varIndex(),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
+    void retrievesVarSizeForInt() {
+        MatcherAssert.assertThat(
+            "An int local variable occupies one slot",
+            new BytecodeInstruction(Opcodes.ILOAD, 2).varSize(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void retrievesVarSizeForLong() {
+        MatcherAssert.assertThat(
+            "A long local variable occupies two slots",
+            new BytecodeInstruction(Opcodes.LLOAD, 2).varSize(),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
+    void rejectsVarIndexForNonVarInstruction() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new BytecodeInstruction(Opcodes.NOP).varIndex(),
+            "Expected an exception for a non-variable instruction"
         );
     }
 }


### PR DESCRIPTION
Fixes #1623

## Problem
Two central pieces of the bytecode pipeline had no direct unit coverage:
- `AsmInstruction` — a 16-branch `switch` over `AbstractInsnNode.getType()` with no `AsmInstructionTest`;
- `BytecodeInstruction.impact()` / `jumps()` / `isJump()` / `isIf()` / `isSwitch()` / `isReturn()` /
  `varIndex()` / `varSize()` — the stack-effect and CFG helpers feeding `MaxStack`/`MaxLocals`.

## Solution / What
Added:
- **`AsmInstructionTest`** (16 tests): one per switch branch — INSN, INT_INSN, VAR_INSN, TYPE_INSN,
  FIELD_INSN, METHOD_INSN, INVOKE_DYNAMIC_INSN, JUMP_INSN, LABEL, LDC_INSN, IINC_INSN, TABLESWITCH_INSN,
  LOOKUPSWITCH_INSN, MULTIANEWARRAY_INSN, FRAME, LINE.
- **`BytecodeInstructionTest`** (22 new tests): `impact()` for GETSTATIC/PUTSTATIC/GETFIELD/PUTFIELD
  (single and two-slot fields), INVOKESTATIC/INVOKEVIRTUAL, MULTIANEWARRAY; `jumps()` for GOTO/IFEQ/
  TABLESWITCH; `isJump()`/`isIf()`/`isSwitch()`/`isReturn()` positive and negative cases; `varIndex()`,
  `varSize()` (int=1, long=2), `isVarInstruction()`, and the non-variable exception.

Note: the LDC `impact()` tests are tracked separately in #1601 (PR #1648). The test methods here use
distinct names to keep the merge clean.

## Changes
- `src/test/java/org/eolang/jeo/representation/asm/AsmInstructionTest.java` — new.
- `src/test/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionTest.java` — expanded.

## Tests
- 39 tests pass (16 + 23). Full `mvn clean install -Pqulice` green (qulice + jtcop + jacoco).