### PR TITLE
test(#1624): cover the 16 untested Directives* classes and the module-info round-trip

### DIFF
--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesDefaultValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesDefaultValueTest.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link DirectivesDefaultValue}.
+ * @since 0.15.0
+ */
+final class DirectivesDefaultValueTest {
+
+    @Test
+    void convertsDefaultValueToDirectives() throws ImpossibleModificationException {
+        final Format format = new Format();
+        final String xml = new Xembler(
+            new DirectivesDefaultValue(new DirectivesValue(format, "v", 42))
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect the default value to be represented as an annotation-defvalue object",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "annotation-default-value").toXpath(),
+                "/o[contains(@name,'annotation-defvalue')]",
+                "/o/o[@name='v']"
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesEnclosingMethodTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesEnclosingMethodTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link DirectivesEnclosingMethod}.
+ * @since 0.15.0
+ */
+final class DirectivesEnclosingMethodTest {
+
+    @Test
+    void convertsEnclosingMethodToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesEnclosingMethod(new Format(), "owner", "method", "(I)V")
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect the enclosing method attribute to keep owner, name and descriptor",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "enclosing-method").toXpath(),
+                "/o[contains(@name,'enclosing-method')]",
+                "/o/o[@name='owner']",
+                "/o/o[@name='name']",
+                "/o/o[@name='descriptor']"
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesEoObjectTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesEoObjectTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link DirectivesEoObject}.
+ * @since 0.15.0
+ */
+final class DirectivesEoObjectTest {
+
+    @Test
+    void convertsEoObjectToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesEoObject(
+                "string",
+                "name",
+                new DirectivesValue(new Format(), "v", 42)
+            )
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect an EO object to carry its base and inner objects",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                "/o[contains(@base,'Φ.string')]",
+                "/o[@name='name']",
+                "/o/o[@name='v']"
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesGlobalObjectTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesGlobalObjectTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link DirectivesGlobalObject}.
+ * @since 0.8
+ */
+final class DirectivesGlobalObjectTest {
+
+    @Test
+    void convertsGlobalObjectToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesGlobalObject(
+                "class",
+                "j$Foo",
+                new DirectivesValue(new Format(), "v", 42)
+            )
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect a global object to carry its base, name and inner objects",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "class").toXpath(),
+                "/o[contains(@name,'j$Foo')]",
+                "/o/o[@name='v']"
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesJeoObjectTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesJeoObjectTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link DirectivesJeoObject}.
+ * @since 0.15.0
+ */
+final class DirectivesJeoObjectTest {
+
+    @Test
+    void convertsJeoObjectToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesJeoObject(
+                "foo",
+                "name",
+                new DirectivesValue(new Format(), "v", 42)
+            )
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect a jeo object to carry its base and inner objects",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "foo").toXpath(),
+                "/o[contains(@name,'name')]",
+                "/o/o[@name='v']"
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMaxsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMaxsTest.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link DirectivesMaxs}.
+ * @since 0.15.0
+ */
+final class DirectivesMaxsTest {
+
+    @Test
+    void convertsMaxsToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(new DirectivesMaxs(new Format(), 1, 2)).xml();
+        MatcherAssert.assertThat(
+            "We expect max stack and max locals to be represented",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "maxs").toXpath(),
+                "/o[contains(@name,'maxs')]",
+                "/o/o[@name='m1']",
+                "/o/o[@name='m2']"
+            )
+        );
+    }
+
+    @Test
+    void convertsUndefinedMaxsToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(new DirectivesMaxs()).xml();
+        MatcherAssert.assertThat(
+            "We expect undefined max stack and max locals to be represented",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "maxs").toXpath(),
+                "/o[contains(@name,'maxs')]",
+                "/o/o[@name='m1']",
+                "/o/o[@name='m2']"
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesModuleTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesModuleTest.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import java.util.Arrays;
+import org.cactoos.io.ResourceOf;
+import org.eolang.jeo.VerifiedBytecode;
+import org.eolang.jeo.representation.BytecodeRepresentation;
+import org.eolang.jeo.representation.xmir.XmlObject;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for the module directives and the module-info round-trip.
+ * @since 0.15.0
+ */
+final class DirectivesModuleTest {
+
+    @Test
+    void convertsRequiredModuleToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesModuleRequired(new Format(), "module", 1, "0.1.0")
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect the required module to keep its access, version and name",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "required").toXpath(),
+                "/o[contains(@name,'required')]",
+                "/o/o[@name='access']",
+                "/o/o[@name='version']",
+                "/o/o[@name='module']"
+            )
+        );
+    }
+
+    @Test
+    void convertsExportedModuleToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesModuleExported(new Format(), "com.example", 1, Arrays.asList("m1"))
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect the exported module to keep its package, access and target modules",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "exported").toXpath(),
+                "/o[contains(@name,'exported')]",
+                "/o/o[@name='package']",
+                "/o/o[@name='access']",
+                "/o/o[@name='modules']"
+            )
+        );
+    }
+
+    @Test
+    void convertsOpenedModuleToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesModuleOpened(new Format(), "com.example", 1, Arrays.asList("m1"))
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect the opened module to keep its package, access and target modules",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "opened").toXpath(),
+                "/o[contains(@name,'opened')]",
+                "/o/o[@name='package']",
+                "/o/o[@name='access']",
+                "/o/o[@name='modules']"
+            )
+        );
+    }
+
+    @Test
+    void convertsProvidedModuleToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesModuleProvided(new Format(), "service", Arrays.asList("p1"))
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect the provided module to keep its service and providers",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "provided").toXpath(),
+                "/o[contains(@name,'provided')]",
+                "/o/o[@name='service']",
+                "/o/o[@name='providers']"
+            )
+        );
+    }
+
+    @Test
+    void convertsModuleInfoInRoundTrip() {
+        final byte[] converted = new XmlObject(
+            new BytecodeRepresentation(new ResourceOf("open-module-info.class")).toXmir()
+        ).bytecode().bytecode().bytes();
+        Assertions.assertDoesNotThrow(
+            () -> new VerifiedBytecode(converted).verify(),
+            "We expect the round-tripped module-info to pass JVM verification"
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesNestHostTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesNestHostTest.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link DirectivesNestHost}.
+ * @since 0.15.0
+ */
+final class DirectivesNestHostTest {
+
+    @Test
+    void convertsNestHostToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesNestHost(new Format(), "com/example/Host")
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect the nest host attribute to contain the host name",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "nest-host").toXpath(),
+                "/o[contains(@name,'nest-host')]",
+                "/o/o[@name='host']"
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesNestMembersTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesNestMembersTest.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import java.util.Arrays;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link DirectivesNestMembers}.
+ * @since 0.15.0
+ */
+final class DirectivesNestMembersTest {
+
+    @Test
+    void convertsNestMembersToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesNestMembers(new Format(), Arrays.asList("a", "b"))
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect the nest members attribute to contain the member list",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "nest-members").toXpath(),
+                "/o[contains(@name,'nest-members')]",
+                "/o/o[@name='members']"
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesOperandTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesOperandTest.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.eolang.jeo.representation.bytecode.BytecodeLabel;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.Type;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link DirectivesOperand}.
+ * @since 0.15.0
+ */
+final class DirectivesOperandTest {
+
+    @Test
+    void convertsValueOperandToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(new DirectivesOperand(0, new Format(), 42)).xml();
+        MatcherAssert.assertThat(
+            "We expect a plain value operand to be represented as a number",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                "/o[contains(@base,'number') and @name='v0']"
+            )
+        );
+    }
+
+    @Test
+    void convertsTypeOperandToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesOperand(0, new Format(), Type.getType("I"))
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect a type operand to be represented as a jeo type",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "type").toXpath(),
+                "/o[@name='t0']",
+                "/o/o[@name='v0']"
+            )
+        );
+    }
+
+    @Test
+    void convertsHandleOperandToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesOperand(
+                0,
+                new Format(),
+                new Handle(1, "owner", "name", "()V", false)
+            )
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect a handle operand to be represented as a jeo handle",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "handle").toXpath(),
+                "/o[@name='h0']"
+            )
+        );
+    }
+
+    @Test
+    void convertsLabelOperandToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesOperand(0, new Format(), new BytecodeLabel("target"))
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect a label operand to be represented as a jeo label",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "label").toXpath()
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesPermittedSubclassesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesPermittedSubclassesTest.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import java.util.Arrays;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link DirectivesPermittedSubclasses}.
+ * @since 0.15.0
+ */
+final class DirectivesPermittedSubclassesTest {
+
+    @Test
+    void convertsPermittedSubclassesToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesPermittedSubclasses(new Format(), Arrays.asList("a"))
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect the permitted subclasses attribute to contain the subclass list",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "permitted-subclasses").toXpath(),
+                "/o[contains(@name,'permitted-subclasses')]",
+                "/o/o[@name='subclasses']"
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesSourceFileTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesSourceFileTest.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link DirectivesSourceFile}.
+ * @since 0.15.0
+ */
+final class DirectivesSourceFileTest {
+
+    @Test
+    void convertsSourceFileToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(
+            new DirectivesSourceFile(new Format(), "Foo.java", "debug")
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect the source file attribute to keep the source name and the debug string",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "source-file").toXpath(),
+                "/o[contains(@name,'source-file')]",
+                "/o/o[@name='source']",
+                "/o/o[@name='debug']"
+            )
+        );
+    }
+}

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesTypeAnnotationsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesTypeAnnotationsTest.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.directives;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link DirectivesTypeAnnotations}.
+ * @since 0.15.0
+ */
+final class DirectivesTypeAnnotationsTest {
+
+    @Test
+    void convertsEmptyTypeAnnotationsToDirectives() throws ImpossibleModificationException {
+        final String xml = new Xembler(new DirectivesTypeAnnotations()).xml();
+        MatcherAssert.assertThat(
+            "We expect empty type annotations to be an empty sequence",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "seq.of0").toXpath(),
+                "/o[contains(@name,'type-annotations')]"
+            )
+        );
+    }
+
+    @Test
+    void convertsTypeAnnotationsToDirectives() throws ImpossibleModificationException {
+        final Format format = new Format();
+        final String xml = new Xembler(
+            new DirectivesTypeAnnotations(new DirectivesValue(format, "v", 42))
+        ).xml();
+        MatcherAssert.assertThat(
+            "We expect non-empty type annotations to be a sequence of one element",
+            xml,
+            XhtmlMatchers.hasXPaths(
+                new JeoBaseXpath("/o", "seq.of1").toXpath(),
+                "/o[contains(@name,'type-annotations')]",
+                "/o/o[@name='v']"
+            )
+        );
+    }
+}


### PR DESCRIPTION
Fixes #1624.

## Problem
Sixteen `Directives*` classes (XMIR generation) had no unit tests, and the module-info XMIR
generation (a 0.15.0 feature) was only covered indirectly via `XmlModuleTest` (reading) and
`XmirFilesTest` (lints verification), never with a disassemble → XMIR → assemble round-trip.

## Solution / What
Added 13 test classes (22 tests) covering all 16 listed classes:

- `DirectivesDefaultValueTest`, `DirectivesEnclosingMethodTest`, `DirectivesGlobalObjectTest`,
  `DirectivesNestHostTest`, `DirectivesNestMembersTest`, `DirectivesPermittedSubclassesTest`,
  `DirectivesSourceFileTest`, `DirectivesTypeAnnotationsTest`, `DirectivesMaxsTest`,
  `DirectivesOperandTest` (value/type/handle/label operands), `DirectivesEoObjectTest`,
  `DirectivesJeoObjectTest`.
- `DirectivesModuleTest` — `DirectivesModuleRequired`, `DirectivesModuleExported`,
  `DirectivesModuleOpened`, `DirectivesModuleProvided`, plus a real **module-info round-trip**:
  `open-module-info.class` → disassemble → XMIR → `XmlObject` → assemble → `VerifiedBytecode.verify()`.

Each directive test asserts the XMIR structure via `XhtmlMatchers` (`JeoBaseXpath` for the base +
root name + child objects).

## Changes
- 13 new test files under `src/test/java/org/eolang/jeo/representation/directives/`.

## Tests
- 22 tests pass. Full `mvn clean install -Pqulice` green (qulice + jtcop + jacoco).