### PR TITLE
test(#1625): cover ParallelTranslator auto threads, BytecodeClasses.all, annotation defaults, frames and matchers

### DIFF
--- a/src/test/java/org/eolang/jeo/BytecodeClassesTest.java
+++ b/src/test/java/org/eolang/jeo/BytecodeClassesTest.java
@@ -4,12 +4,18 @@
  */
 package org.eolang.jeo;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.eolang.jeo.representation.bytecode.BytecodeClass;
+import org.eolang.jeo.representation.bytecode.BytecodeObject;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Tests for {@link BytecodeClasses}.
@@ -62,4 +68,27 @@ final class BytecodeClassesTest {
             Matchers.equalTo(0L)
         );
     }
+
+    @Test
+    void findsAllClassFilesInDirectory(@TempDir final Path temp) throws IOException {
+        Files.createDirectories(temp.resolve("com"));
+        Files.write(
+            temp.resolve("com").resolve("Foo.class"),
+            new BytecodeObject(new BytecodeClass("Foo")).bytecode().bytes()
+        );
+        Files.write(
+            temp.resolve("Bar.class"),
+            new BytecodeObject(new BytecodeClass("Bar")).bytecode().bytes()
+        );
+        Files.write(
+            temp.resolve("note.txt"),
+            "not a class file".getBytes(StandardCharsets.UTF_8)
+        );
+        MatcherAssert.assertThat(
+            "all() must return only the .class files from the whole directory tree",
+            new BytecodeClasses(temp).all().count(),
+            Matchers.equalTo(2L)
+        );
+    }
 }
+

--- a/src/test/java/org/eolang/jeo/ParallelTranslatorTest.java
+++ b/src/test/java/org/eolang/jeo/ParallelTranslatorTest.java
@@ -105,6 +105,54 @@ final class ParallelTranslatorTest {
     }
 
     @Test
+    void processesAllFilesWithAutoThreads(@TempDir final Path temp) throws IOException {
+        for (int index = 0; index < 3; ++index) {
+            final String name = String.format("Class%d", index);
+            Files.write(
+                temp.resolve(String.format("%s.class", name)),
+                new BytecodeObject(new BytecodeClass(name)).bytecode().bytes()
+            );
+        }
+        new ParallelTranslator(ParallelTranslatorTest::transform, 0)
+            .apply(
+                Stream.of(1, 2, 3)
+                    .map(index -> temp.resolve(String.format("Class%d.class", index - 1)))
+            )
+            .collect(Collectors.toList());
+        for (int index = 0; index < 3; ++index) {
+            MatcherAssert.assertThat(
+                String.format("Class%d must be transformed with the auto thread count", index),
+                temp.resolve(String.format("Class%d.xmir", index)).toFile(),
+                FileMatchers.anExistingFile()
+            );
+        }
+    }
+
+    @Test
+    void processesAllFilesWithPositiveThreads(@TempDir final Path temp) throws IOException {
+        for (int index = 0; index < 3; ++index) {
+            final String name = String.format("Class%d", index);
+            Files.write(
+                temp.resolve(String.format("%s.class", name)),
+                new BytecodeObject(new BytecodeClass(name)).bytecode().bytes()
+            );
+        }
+        new ParallelTranslator(ParallelTranslatorTest::transform, 2)
+            .apply(
+                Stream.of(1, 2, 3)
+                    .map(index -> temp.resolve(String.format("Class%d.class", index - 1)))
+            )
+            .collect(Collectors.toList());
+        for (int index = 0; index < 3; ++index) {
+            MatcherAssert.assertThat(
+                String.format("Class%d must be transformed with the given thread count", index),
+                temp.resolve(String.format("Class%d.xmir", index)).toFile(),
+                FileMatchers.anExistingFile()
+            );
+        }
+    }
+
+    @Test
     void rejectsNegativeThreads() {
         final IllegalArgumentException exception = Assertions.assertThrows(
             IllegalArgumentException.class,
@@ -148,3 +196,4 @@ final class ParallelTranslatorTest {
         return result;
     }
 }
+

--- a/src/test/java/org/eolang/jeo/matchers/SameXmlTest.java
+++ b/src/test/java/org/eolang/jeo/matchers/SameXmlTest.java
@@ -54,4 +54,17 @@ final class SameXmlTest {
             new IsEqual<>(true)
         );
     }
+
+    @Test
+    void doesNotMatchDistinctXmls() {
+        final XML first = new XMLDocument("<root><a/></root>");
+        final XML second = new XMLDocument("<root><b/></root>");
+        final boolean matches = new SameXml(first).matchesSafely(second.toString());
+        MatcherAssert.assertThat(
+            "Distinct XML documents must not match",
+            matches,
+            new IsEqual<>(false)
+        );
+    }
 }
+

--- a/src/test/java/org/eolang/jeo/matchers/WithoutLinesTest.java
+++ b/src/test/java/org/eolang/jeo/matchers/WithoutLinesTest.java
@@ -7,6 +7,7 @@ package org.eolang.jeo.matchers;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 
@@ -53,4 +54,17 @@ final class WithoutLinesTest {
             new IsEqual<>(expected)
         );
     }
+
+    @Test
+    void removesLineAttributes() {
+        final XML lineless = new WithoutLines(
+            new XMLDocument("<root><o line=\"val\">data</o></root>")
+        ).value();
+        MatcherAssert.assertThat(
+            "The transformed XML must not contain any line attributes",
+            lineless.toString(),
+            Matchers.not(Matchers.containsString("line="))
+        );
+    }
 }
+

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesFrameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesFrameTest.java
@@ -10,6 +10,8 @@ import org.eolang.jeo.representation.xmir.XmlFrame;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.objectweb.asm.Opcodes;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
@@ -37,4 +39,27 @@ final class DirectivesFrameTest {
             Matchers.equalTo(new BytecodeFrame(type, nlocal, locals, nstack, stack))
         );
     }
+
+    @ParameterizedTest
+    @ValueSource(ints = {Opcodes.F_APPEND, Opcodes.F_CHOP, Opcodes.F_SAME, Opcodes.F_SAME1})
+    void convertsDifferentFrameTypes(final int type) throws ImpossibleModificationException {
+        final Object[] locals = {Opcodes.INTEGER};
+        final Object[] stack = {Opcodes.LONG};
+        final BytecodeFrame expected = new BytecodeFrame(
+            type,
+            locals.length,
+            locals,
+            stack.length,
+            stack
+        );
+        final String xml = new Xembler(
+            new DirectivesFrame(0, new Format(), type, locals, stack)
+        ).xml();
+        MatcherAssert.assertThat(
+            String.format("We failed to round-trip the frame of type %d", type),
+            new XmlFrame(new NativeXmlNode(xml)).bytecode(),
+            Matchers.equalTo(expected)
+        );
+    }
 }
+

--- a/src/test/java/org/eolang/jeo/representation/directives/FormatTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/FormatTest.java
@@ -6,6 +6,7 @@ package org.eolang.jeo.representation.directives;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -29,6 +30,78 @@ final class FormatTest {
             "Comments property is added successfully",
             new Format(new Format(Format.PRETTY, false), Format.COMMENTS, true).comments(),
             Matchers.is(true)
+        );
+    }
+
+    @Test
+    void returnsDefaultMode() {
+        MatcherAssert.assertThat(
+            "The default mode should be 'short'",
+            new Format().mode(),
+            Matchers.equalTo("short")
+        );
+    }
+
+    @Test
+    void returnsMode() {
+        MatcherAssert.assertThat(
+            "The mode should be readable from the format",
+            new Format(Format.MODE, "full").mode(),
+            Matchers.equalTo("full")
+        );
+    }
+
+    @Test
+    void returnsListing() {
+        MatcherAssert.assertThat(
+            "The listing should be readable from the format",
+            new Format(Format.LISTING, "listing-content").listing(),
+            Matchers.equalTo("listing-content")
+        );
+    }
+
+    @Test
+    void returnsWithListing() {
+        MatcherAssert.assertThat(
+            "The with-listings flag should be readable from the format",
+            new Format(Format.WITH_LISTING, true).withListing(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void rejectsNonBooleanProperty() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new Format(Format.PRETTY, "yes").pretty(),
+            "Expected an exception for a non-boolean property"
+        );
+    }
+
+    @Test
+    void rejectsNonStringProperty() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new Format(Format.MODE, 42).mode(),
+            "Expected an exception for a non-string property"
+        );
+    }
+
+    @Test
+    void rejectsOddNumberOfProperties() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new Format(Format.MODE),
+            "Expected an exception for an odd number of properties"
+        );
+    }
+
+    @Test
+    void rejectsNonStringPropertyName() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new Format(42, "x"),
+            "Expected an exception for a non-string property name"
         );
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlAnnotationValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlAnnotationValueTest.java
@@ -7,8 +7,10 @@ package org.eolang.jeo.representation.xmir;
 import java.util.Collections;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotation;
 import org.eolang.jeo.representation.bytecode.BytecodeArrayAnnotationValue;
+import org.eolang.jeo.representation.bytecode.BytecodeEnumAnnotationValue;
 import org.eolang.jeo.representation.directives.DirectivesAnnotation;
 import org.eolang.jeo.representation.directives.DirectivesArrayAnnotationValue;
+import org.eolang.jeo.representation.directives.DirectivesEnumAnnotationValue;
 import org.eolang.jeo.representation.directives.Format;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -49,4 +51,31 @@ final class XmlAnnotationValueTest {
             )
         );
     }
+
+    @Test
+    void createsEnumAnnotationProperty() throws ImpossibleModificationException {
+        final String name = "color";
+        final String descriptor = "java/lang/Color";
+        final String value = "RED";
+        MatcherAssert.assertThat(
+            "Incorrect enum annotation property",
+            new XmlAnnotationValue(
+                new NativeXmlNode(
+                    new Xembler(
+                        new DirectivesEnumAnnotationValue(
+                            0,
+                            new Format(),
+                            name,
+                            descriptor,
+                            value
+                        )
+                    ).xml()
+                )
+            ).bytecode(),
+            Matchers.equalTo(
+                new BytecodeEnumAnnotationValue(name, descriptor, value)
+            )
+        );
+    }
 }
+

--- a/src/test/java/org/eolang/jeo/representation/xmir/XmlDefaultValueTest.java
+++ b/src/test/java/org/eolang/jeo/representation/xmir/XmlDefaultValueTest.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo.representation.xmir;
+
+import org.eolang.jeo.representation.bytecode.BytecodeDefaultValue;
+import org.eolang.jeo.representation.bytecode.BytecodePlainAnnotationValue;
+import org.eolang.jeo.representation.directives.Format;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.ImpossibleModificationException;
+import org.xembly.Xembler;
+
+/**
+ * Test cases for {@link XmlDefaultValue}.
+ * @since 0.15.0
+ */
+final class XmlDefaultValueTest {
+
+    @Test
+    void parsesDefaultValue() throws ImpossibleModificationException {
+        final BytecodeDefaultValue original = new BytecodeDefaultValue(
+            new BytecodePlainAnnotationValue("name", "value")
+        );
+        final String xml = new Xembler(original.directives(new Format())).xml();
+        MatcherAssert.assertThat(
+            "We expect the annotation default value to survive the XMIR round-trip",
+            new XmlDefaultValue(new NativeXmlNode(xml)).bytecode().orElseThrow(),
+            Matchers.equalTo(original)
+        );
+    }
+}


### PR DESCRIPTION
Fixes #1625

## Problem
Seven code paths had no direct coverage: `ParallelTranslator` parallel/auto execution, `BytecodeClasses.all()`
against a real directory, the `ENUM` branch of `XmlAnnotationValue`, annotation default values
(`BytecodeDefaultValue`/`XmlDefaultValue`), `Format` accessors and its `IllegalArgumentException` branches,
non-`F_NEW` frame types, and negative cases for `SameXml`/`WithoutLines`

## Solution / What
- `ParallelTranslatorTest` — `processesAllFilesWithAutoThreads` (threads=0) and `processesAllFilesWithPositiveThreads` (threads=2): 3 real `.class` files transformed to `.xmir` each
- `BytecodeClassesTest` — `findsAllClassFilesInDirectory`: a real tree with `.class` files and a `.txt` that must be ignored; `all()` count == 2
- `XmlAnnotationValueTest` — `createsEnumAnnotationProperty`: `DirectivesEnumAnnotationValue` → XMIR → `XmlAnnotationValue` → `BytecodeEnumAnnotationValue` round-trip
- `XmlDefaultValueTest` (new) — annotation method default value XMIR round-trip via `XmlDefaultValue.bytecode()`
- `FormatTest` — `mode()` (default `short` and explicit), `listing()`, `withListing()`, and the three `IllegalArgumentException` branches (non-boolean value, non-string value, odd property count, non-string property name)
- `DirectivesFrameTest` — parameterized `convertsDifferentFrameTypes` for `F_APPEND`/`F_CHOP`/`F_SAME`/`F_SAME1`
- `SameXmlTest` / `WithoutLinesTest` — negative cases (distinct XML → `false`; transformed XML contains no `line=`)

## Changes
- 1 new test file; 7 existing test files extended

## Tests
- 33 focused tests pass; full `mvn clean install -Pqulice` green (qulice + jtcop + jacoco)