### PR TITLE
feat(#1604): make the generated XMIR 'time' attribute reproducible

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesObject.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesObject.java
@@ -5,10 +5,12 @@
 package org.eolang.jeo.representation.directives;
 
 import com.jcabi.manifests.Manifests;
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
+import java.util.Optional;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -86,8 +88,9 @@ public final class DirectivesObject implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        final String now = ZonedDateTime.now(ZoneOffset.UTC)
-            .format(DateTimeFormatter.ISO_INSTANT);
+        final String now = DirectivesObject.time(
+            this.format, System.getenv("SOURCE_DATE_EPOCH")
+        );
         final Directives directives = new Directives()
             .add("object")
             .attr("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")
@@ -105,5 +108,37 @@ public final class DirectivesObject implements Iterable<Directive> {
         directives.append(this.klass);
         directives.up();
         return directives.iterator();
+    }
+
+    /**
+     * Timestamp of the generated XMIR.
+     * <p>The timestamp is reproducible: when the {@link Format#TIME} property is set it is used
+     * as is; otherwise the standard {@code SOURCE_DATE_EPOCH} environment variable (Unix epoch in
+     * seconds) is honored; only when neither is available the current wall-clock time is used.</p>
+     * @param format Format to read the configured timestamp from.
+     * @param epoch Value of the {@code SOURCE_DATE_EPOCH} environment variable, may be null.
+     * @return Timestamp in the ISO-8601 instant format.
+     */
+    static String time(final Format format, final String epoch) {
+        final String result;
+        final Optional<String> fromepoch = Optional.ofNullable(epoch)
+            .filter(value -> !value.isEmpty())
+            .map(Long::parseLong)
+            .map(Instant::ofEpochSecond)
+            .map(Instant::toString);
+        if (format.time().isEmpty()) {
+            result = fromepoch.orElseGet(DirectivesObject::current);
+        } else {
+            result = format.time();
+        }
+        return result;
+    }
+
+    /**
+     * Current wall-clock timestamp.
+     * @return Current timestamp in the ISO-8601 instant format.
+     */
+    private static String current() {
+        return ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/directives/Format.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/Format.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Output format of the XMIR representation.
  * @since 0.14.0
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class Format {
 
     /**
@@ -56,6 +57,15 @@ public final class Format {
      */
     @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
     public static final String MODE = "mode";
+
+    /**
+     * Fixed timestamp of the generated XMIR.
+     * Expected to be a string value in the ISO-8601 format. When set, it is used as the
+     * 'time' attribute of the generated object; otherwise the current time (or the
+     * {@code SOURCE_DATE_EPOCH} environment variable) is used.
+     */
+    @SuppressWarnings("PMD.AvoidFieldNameMatchingMethodName")
+    public static final String TIME = "time";
 
     /**
      * All properties of the format.
@@ -133,6 +143,14 @@ public final class Format {
      */
     public String mode() {
         return this.string(Format.MODE);
+    }
+
+    /**
+     * Fixed timestamp of the generated XMIR.
+     * @return Timestamp value of the property, empty when not configured.
+     */
+    public String time() {
+        return this.string(Format.TIME);
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesObjectTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesObjectTest.java
@@ -118,4 +118,40 @@ final class DirectivesObjectTest {
             XhtmlMatchers.hasXPath("/object[@ms='10']")
         );
     }
+
+    @Test
+    void usesConfiguredTime() throws ImpossibleModificationException {
+        final ClassName clazz = new ClassName("Some");
+        MatcherAssert.assertThat(
+            "We expect that the configured time is used as the 'time' attribute",
+            new Xembler(
+                new DirectivesObject(
+                    new Format(Format.TIME, "2024-01-01T00:00:00Z"),
+                    0,
+                    new DirectivesClass(clazz),
+                    new DirectivesMetas(clazz)
+                )
+            ).xml(),
+            XhtmlMatchers.hasXPath("/object[@time='2024-01-01T00:00:00Z']")
+        );
+    }
+
+    @Test
+    void usesSourceDateEpoch() {
+        MatcherAssert.assertThat(
+            "We expect that the SOURCE_DATE_EPOCH value is used when no time is configured",
+            DirectivesObject.time(new Format(), "1704067200"),
+            Matchers.equalTo("2024-01-01T00:00:00Z")
+        );
+    }
+
+    @Test
+    void usesCurrentTimeByDefault() {
+        final String actual = DirectivesObject.time(new Format(), null);
+        MatcherAssert.assertThat(
+            "We expect that the current time is used when nothing is configured",
+            actual,
+            Matchers.not(Matchers.emptyString())
+        );
+    }
 }


### PR DESCRIPTION
Fixes #1604

## Problem
`DirectivesObject` wrote a wall-clock timestamp into every generated XMIR (`<program time="...">`),
so the `disassemble` output was not byte-reproducible between runs

## Solution / What
Made the timestamp configurable, with three sources in priority order:
1. **`Format.TIME`** property — an explicit ISO-8601 timestamp (full control, testable);
2. **`SOURCE_DATE_EPOCH`** environment variable — the standard for reproducible builds (Unix epoch
   in seconds), honored automatically when present;
3. current wall-clock time — unchanged default behavior

Implementation:
- `Format` — new `TIME` constant and `time()` accessor
- `DirectivesObject` — new package-private `time(Format, String epoch)` helper (used by `iterator()`)
  plus `current()` for the default

## Changes
- `src/main/java/org/eolang/jeo/representation/directives/Format.java`
- `src/main/java/org/eolang/jeo/representation/directives/DirectivesObject.java`

## Tests
- `DirectivesObjectTest` — `usesConfiguredTime` (XMIR has `time="2024-01-01T00:00:00Z"`),
  `usesSourceDateEpoch` (`time(new Format(), "1704067200")` → `2024-01-01T00:00:00Z`),
  `usesCurrentTimeByDefault`
- Full `mvn clean install -Pqulice` green