### PR TITLE
fix(#1610): align the README Maven version requirement with the actual minimum

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,4 +597,4 @@ It might take significantly more time to build,
 but it will ensure that all transformations are correct and aligned with
 the XMIR specification.
 
-You will need [Maven 3.3+](https://maven.apache.org) and Java 11+ installed.
+You will need [Maven 3.1+](https://maven.apache.org) and Java 11+ installed.


### PR DESCRIPTION
Fixes #1610

## Problem
The README contradicted itself about the minimum Maven version:
- `README.md:20` — "Maven 3.1+";
- `README.md:600` (the `-Pverify` section) — "Maven 3.3+"

Meanwhile the plugin is compiled against `maven-plugin-api:4.0.0-alpha-7` (an intentional choice for
Java 8 compatibility, see the `pom.xml` comment)

## Investigation
The plugin only uses the **base** Maven API (`AbstractMojo`, `MojoExecutionException`, `@Mojo`,
`@Parameter`, `LifecyclePhase`, and `MavenProject#get*ClasspathElements()` from `maven-core`), all of
which exist and are stable in the Maven 3.x line. Nothing specific to the Maven 4 API is used, so the
plugin runs on Maven 3.x (the whole build and IT suite are executed on Maven 3.9.16 locally and in CI)

## Solution / What
Unified the documented minimum to **Maven 3.1+** in both places (matching the primary statement)
`maven-plugin-api:4.0.0-alpha-7` is kept unchanged — switching it would risk the Java 8
compatibility the `pom.xml` comment explicitly warns about

## Changes
- `README.md` — `README:600` now says "Maven 3.1+" instead of "Maven 3.3+"

## Tests
- Documentation-only change; no tests required