### PR TITLE
fix(#1619): rename EncodedString/DecodedString to UrlDecoder/UrlEncoder

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/NamedDescriptor.java
+++ b/src/main/java/org/eolang/jeo/representation/NamedDescriptor.java
@@ -51,7 +51,7 @@ public final class NamedDescriptor {
         return String.format(
             "%s-%s",
             this.original,
-            new DecodedString(this.descr).encode()
+            new UrlEncoder(this.descr).encode()
         );
     }
 
@@ -93,6 +93,6 @@ public final class NamedDescriptor {
      * @return The decoded method descriptor
      */
     private static String suffix(final String encoded) {
-        return new EncodedString(encoded.substring(encoded.indexOf('-') + 1)).decode();
+        return new UrlDecoder(encoded.substring(encoded.indexOf('-') + 1)).decode();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/UrlDecoder.java
+++ b/src/main/java/org/eolang/jeo/representation/UrlDecoder.java
@@ -16,7 +16,7 @@ import java.nio.charset.StandardCharsets;
  * throws IllegalStateException if decoding fails.</p>
  * @since 0.6.0
  */
-public final class EncodedString {
+public final class UrlDecoder {
 
     /**
      * Original string to decode.
@@ -27,7 +27,7 @@ public final class EncodedString {
      * Constructor.
      * @param encoded The URL-encoded string to be decoded
      */
-    public EncodedString(final String encoded) {
+    public UrlDecoder(final String encoded) {
         this.original = encoded;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/UrlEncoder.java
+++ b/src/main/java/org/eolang/jeo/representation/UrlEncoder.java
@@ -16,7 +16,7 @@ import java.nio.charset.StandardCharsets;
  * throws IllegalStateException if encoding fails.</p>
  * @since 0.6.0
  */
-public final class DecodedString {
+public final class UrlEncoder {
 
     /**
      * Original string to encode.
@@ -27,7 +27,7 @@ public final class DecodedString {
      * Constructor.
      * @param decoded The original decoded string to be encoded
      */
-    public DecodedString(final String decoded) {
+    public UrlEncoder(final String decoded) {
         this.original = decoded;
     }
 

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethodParam.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethodParam.java
@@ -5,7 +5,7 @@
 package org.eolang.jeo.representation.xmir;
 
 import java.util.Optional;
-import org.eolang.jeo.representation.EncodedString;
+import org.eolang.jeo.representation.UrlDecoder;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodParameter;
 import org.eolang.jeo.representation.directives.JeoFqn;
 import org.objectweb.asm.Type;
@@ -63,7 +63,7 @@ public final class XmlMethodParam {
      * @return Type.
      */
     private Type type() {
-        return Type.getType(new EncodedString(this.child("type").string()).decode());
+        return Type.getType(new UrlDecoder(this.child("type").string()).decode());
     }
 
     /**

--- a/src/test/java/org/eolang/jeo/representation/UrlDecoderTest.java
+++ b/src/test/java/org/eolang/jeo/representation/UrlDecoderTest.java
@@ -10,10 +10,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 /**
- * Test case for {@link EncodedString}.
+ * Test case for {@link UrlDecoder}.
  * @since 0.6
  */
-final class EncodedStringTest {
+final class UrlDecoderTest {
 
     @ParameterizedTest
     @CsvSource({
@@ -23,10 +23,10 @@ final class EncodedStringTest {
         "org%2Feolang%2Fjeo%2FMethodByte, org/eolang/jeo/MethodByte",
         "String%5B%5D, String[]"
     })
-    void encodesString(final String original, final String expected) {
+    void decodesString(final String original, final String expected) {
         MatcherAssert.assertThat(
             "Decoded string is not as expected",
-            new EncodedString(original).decode(),
+            new UrlDecoder(original).decode(),
             Matchers.equalTo(expected)
         );
     }

--- a/src/test/java/org/eolang/jeo/representation/UrlEncoderTest.java
+++ b/src/test/java/org/eolang/jeo/representation/UrlEncoderTest.java
@@ -10,10 +10,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 /**
- * Test case for {@link DecodedString}.
+ * Test case for {@link UrlEncoder}.
  * @since 0.6
  */
-final class DecodedStringTest {
+final class UrlEncoderTest {
 
     @ParameterizedTest
     @CsvSource({
@@ -26,7 +26,7 @@ final class DecodedStringTest {
     void encodesString(final String original, final String expected) {
         MatcherAssert.assertThat(
             "Encoded string is not as expected",
-            new DecodedString(original).encode(),
+            new UrlEncoder(original).encode(),
             Matchers.equalTo(expected)
         );
     }


### PR DESCRIPTION
Fixes #1619

## Problem
Two helper classes had misleading names: `EncodedString` wrapped an **encoded** string but its only
method was `decode()`, and `DecodedString` wrapped a **decoded** string but its only method was
`encode()`. The test names even copied the confusion (`encodesString` calling `decode()`). This invites
misuse by future contributors.

## Solution / What
Renamed the classes to describe what they actually do:
- `EncodedString` → `UrlDecoder` (method `decode()`);
- `DecodedString` → `UrlEncoder` (method `encode()`).

Updated the usages in `NamedDescriptor` and `XmlMethodParam`, the test files (renamed to
`UrlDecoderTest`/`UrlEncoderTest`, and the decoder test method renamed to `decodesString`).

## Changes
- `src/main/java/org/eolang/jeo/representation/EncodedString.java` → `UrlDecoder.java`
- `src/main/java/org/eolang/jeo/representation/DecodedString.java` → `UrlEncoder.java`
- `src/main/java/org/eolang/jeo/representation/NamedDescriptor.java`, `.../xmir/XmlMethodParam.java` — usages
- `src/test/java/org/eolang/jeo/representation/{EncodedString,DecodedString}Test.java` → `{UrlDecoder,UrlEncoder}Test.java`

## Tests
- `UrlDecoderTest`/`UrlEncoderTest` (5 parameterized cases each) + `NamedDescriptorTest` +
  `XmlMethodParamTest` pass. Full `mvn clean install -Pqulice` green.