### PR TITLE
fix(#1626): update stale docs across README, site and IT tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![logo](https://www.objectionary.com/cactus-100.svg)](https://www.objectionary.com)
 
-[![Maven Central](https://img.shields.io/maven-central/v/org.eolang/jeo-maven-plugin.svg)](https://maven-badges.herokuapp.com/maven-central/org.eolang/jeo-maven-plugin)
+[![Maven Central](https://img.shields.io/maven-central/v/org.eolang/jeo-maven-plugin.svg)](https://central.sonatype.com/artifact/org.eolang/jeo-maven-plugin)
 [![Javadoc](https://www.javadoc.io/badge/org.eolang/jeo-maven-plugin.svg)](https://www.javadoc.io/doc/org.eolang/jeo-maven-plugin)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE.txt)
 [![Hits-of-Code](https://hitsofcode.com/github/objectionary/jeo-maven-plugin?branch=master&label=Hits-of-Code)](https://hitsofcode.com/github/objectionary/jeo-maven-plugin/view?branch=master&label=Hits-of-Code)
@@ -250,8 +250,8 @@ with the following bytecode representation:
          5: invokevirtual #15                 // Method java/io/PrintStream.println:(Ljava/lang/String;)V
          8: return
       LineNumberTable:
-        line 5: 0
-        line 6: 8
+        line 9: 0
+        line 10: 8
       LocalVariableTable:
         Start  Length  Slot  Name   Signature
             0       9     0  args   [Ljava/lang/String;
@@ -571,7 +571,12 @@ variables:
 
 ```bash
 PROFILER=/path/to/async-profiler/profiler.sh
+DURATION=1000000
 ```
+
+`PROFILER` is the path to the async-profiler script.
+`DURATION` (optional) is the profiling duration in microseconds; it defaults
+to `1000000` (one second) when not set.
 
 ## How to Contribute
 

--- a/src/it/bytecode-to-eo/src/main/java/WithoutPackage.java
+++ b/src/it/bytecode-to-eo/src/main/java/WithoutPackage.java
@@ -2,6 +2,5 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
  * SPDX-License-Identifier: MIT
  */
-package org.eolang.jeo;
 public class WithoutPackage {
 }

--- a/src/it/bytecode-to-eo/verify.groovy
+++ b/src/it/bytecode-to-eo/verify.groovy
@@ -20,4 +20,5 @@ app.eachLine { line ->
   }
 }
 assert app.text.contains("<!--") : "We enabled comments in the XMIR file using 'omitComments=false' option, but they are absent"
+assert new File(basedir, 'target/generated-sources/jeo-xmir/WithoutPackage.xmir').exists() : "The package-less class XMIR was not generated"
 true

--- a/src/it/exceptions/verify.groovy
+++ b/src/it/exceptions/verify.groovy
@@ -15,39 +15,6 @@ assert log.contains("Exception in try-catch-with-resources statement with suppre
 assert log.contains("Exception during closing resource")
 
 //Check that we have generated EO object files.
-//assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/exceptions/Application.xmir').exists()
-/**
- * @todo #320:30min Enable 'exceptions' Integration Test.
- *  First of all, we have to implement all the features required for correct
- *  transformation of exceptions. Then, we need to add JEO plugin into pom.xml
- *  of that test. The plugin setup you can find below. After that we need to add
- *  some assertions to this file. For example, we need to check that we have
- *  generated EO object files (see commented checks above).
- *  Right now this test just compiles java as is without any transformations.
- *
- * <p>{@code
- * <plugin>
- *   <groupId>org.eolang</groupId>
- *   <artifactId>jeo-maven-plugin</artifactId>
- *   <version>@project.version@</version>
- *   <executions>
- *     <execution>
- *       <id>bytecode-to-eo</id>
- *       <goals>
- *         <goal>disassemble</goal>
- *       </goals>
- *     </execution>
- *     <execution>
- *       <id>eo-to-bytecode</id>
- *       <goals>
- *         <goal>assemble</goal>
- *       </goals>
- *     </execution>
- *   </executions>
- * </plugin>
- *
- *}
- * </p>
- */
+assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/exceptions/Application.xmir').exists()
 
 true

--- a/src/it/phi-unphi/README.md
+++ b/src/it/phi-unphi/README.md
@@ -1,9 +1,7 @@
 # "Phi" and "Unphi" Integration Test
 
-This test resembles
-the [hone-maven-plugin](https://github.com/objectionary/hone-maven-plugin/tree/master)
-integration test that can be
-found [here](https://github.com/objectionary/hone-maven-plugin/tree/master/src/it/simple).
+This test resembles the
+[hone-maven-plugin integration test](https://github.com/objectionary/hone-maven-plugin/tree/master/src/it/simple).
 When it is needed, I will update this test according
 to the changes made in the hone-maven-plugin integration test.
 
@@ -17,10 +15,10 @@ mvn clean integration-test -Dinvoker.test=phi-unphi -DskipTests
 
 This integration test comprises the following steps:
 
-1. Disasseble bytecode of a class file. `jeo:disassemble` goal.
-2. Transform the disassembled code to `phi`. `eo:xmir-to-phi` goal.
-3. Transform the `phi` code back to the disassembled code. `eo:phi-to-xmir`
-   goal.
-4. Assemble the disassembled code. `jeo:assemble` goal.
+1. Disassemble bytecode of a class file. `jeo:disassemble` goal.
+2. Transform the disassembled XMIR code to `phi` and back using the external
+   `phino` CLI (see `phino.sh`). The `phino` binary must be installed and
+   available on the `PATH`.
+3. Assemble the disassembled code. `jeo:assemble` goal.
 
 Detailed steps and configurations can be found in the [pom.xml](pom.xml) file.

--- a/src/it/spring/README.md
+++ b/src/it/spring/README.md
@@ -1,4 +1,4 @@
-# Spring Fat Jar Integration Test
+# Spring Integration Test
 
 Integration test that checks the correct transformation of an application
 written with using of the Springs Framework. This integration test starts the

--- a/src/it/takes/verify.groovy
+++ b/src/it/takes/verify.groovy
@@ -11,38 +11,6 @@ assert log.contains("Request time: ")
 //Check that we have generated EO object files.
 //assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/takes/Application.xmir').exists()
 //assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/takes/Application$TimeLog.xmir').exists()
-//assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/takes/Application$RequestCounter.xmir').exists()
-/**
- * @todo #189:30min Enable Integration Test for Takes Framework.
- *  First of all, we have to implement all the features required for correct
- *  transformation. Then, we need to add JEO plugin into pom.xml of that test,
- *  the plugin setup you can find below. After that we need to add some
- *  assertions to this file. For example, we need to check that we have
- *  generated EO object files (see commented checks above).
- *
- * <p>{@code
- * <plugin>
- *   <groupId>org.eolang</groupId>
- *   <artifactId>jeo-maven-plugin</artifactId>
- *   <version>@project.version@</version>
- *   <executions>
- *     <execution>
- *       <id>bytecode-to-eo</id>
- *       <goals>
- *         <goal>disassemble</goal>
- *       </goals>
- *     </execution>
- *     <execution>
- *       <id>eo-to-bytecode</id>
- *       <goals>
- *         <goal>assemble</goal>
- *       </goals>
- *     </execution>
- *   </executions>
- * </plugin>
- *
- *}
- * </p>
- */
+assert new File(basedir, 'target/generated-sources/jeo-xmir/org/eolang/jeo/takes/Application$RequestCounter.xmir').exists()
 
 true

--- a/src/it/without-pom-same-dir/README.md
+++ b/src/it/without-pom-same-dir/README.md
@@ -7,7 +7,7 @@ file.
 The purpose of this test is to verify that the jeo-maven-plugin can be used in a
 project without a POM file. Moreover, in this particular test we don't specify
 `disassemble` `outputDir` parameter, so the plugin should use the default value,
-which is the directory where the command is executed.
+which is `target/generated-sources/jeo-xmir`.
 
 To run only this test, use the following command:
 

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -1,9 +1,9 @@
   ---
   JEO Maven Plugin
   ---
-  Yegor Bugayenko
+  Volodya Lombrozo
   ---
-  2023-12-21
+  2026-09-08
   ---
 
 JEO Maven Plugin
@@ -19,7 +19,7 @@ JEO Maven Plugin
     <plugin>
       <groupId>org.eolang</groupId>
       <artifactId>jeo-maven-plugin</artifactId>
-      <version>0.1.5</version>
+      <version>${project.version}</version>
       <executions>
         <execution>
           <id>bytecode-to-eo</id>


### PR DESCRIPTION
Fixes #1626

## Problem
Several documentation pieces contradicted the actual behavior (the Maven version mismatch was already
fixed in #1660)

## Solution / What
- `README.md`:
  - bytecode listing example now matches the generated EO (`line 9`/`line 10` instead of `5`/`6`);
  - Maven Central badge link → `central.sonatype.com` (the old `maven-badges.herokuapp.com` is deprecated);
  - benchmark `.env` documents `DURATION` in addition to `PROFILER` (read by `benchmark.groovy`)
- `src/site/apt/index.apt.vm` — author → Volodya Lombrozo (per `pom.xml`), version `0.1.5` → `${project.version}`, date updated
- `src/it/exceptions/verify.groovy` and `src/it/takes/verify.groovy` — removed the stale `@todo #320`/`@todo #189`
  ("JEO plugin is not yet connected" — it is connected) and enabled the actual XMIR-existence assertions.
- `src/it/bytecode-to-eo/src/main/java/WithoutPackage.java` — removed the `package org.eolang.jeo;` declaration so
  the class is genuinely package-less, and added a corresponding XMIR assertion in `verify.groovy`
- `src/it/phi-unphi/README.md` — described the real pipeline (`phino` CLI) instead of the non-existent
  `eo:xmir-to-phi`/`eo:phi-to-xmir` goals; also fixed a `MD059` link-text issue
- `src/it/spring/README.md` — fixed the copied "Spring Fat Jar" title
- `src/it/without-pom-same-dir/README.md` — default `outputDir` is `target/generated-sources/jeo-xmir`,
  not "the directory where the command is executed"

## Changes
- `README.md`, `src/site/apt/index.apt.vm`, and 7 IT files

## Tests
- `markdownlint-cli2` on all touched README files — 0 issues
- ITs `bytecode-to-eo`, `exceptions`, `takes` pass
- Full `mvn clean install -Pqulice` green (site generation included)