### PR TITLE
fix(#1627): code hygiene cleanup — test name typos, @Disabled reason, dead config, duplicate patterns

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,6 +7,9 @@ name: codecov
   push:
     branches:
       - master
+concurrency:
+  group: codecov-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   codecov:
     name: Upload coverage reports to Codecov

--- a/.github/workflows/maven.long.yml
+++ b/.github/workflows/maven.long.yml
@@ -10,6 +10,9 @@ name: mvn-long
   pull_request:
     branches:
       - master
+concurrency:
+  group: mvn-long-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   integration-test:
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-!src/it/eo-to-bytecode/target
-!src/it/fails-if-bytecode-broken/target
 .aider*
 .aidy
 .classpath

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,7 +6,6 @@ version = 1
 path = [
     ".DS_Store",
     ".gitattributes",
-    ".gitignore",
     "**.json",
     "**.md",
     "**.txt",
@@ -26,7 +25,6 @@ path = [
     "**/CNAME",
     "**/MANIFEST.MF",
     "**/MethodByte.eo",
-    "MANIFEST.MF",
     "README.md",
     "renovate.json",
     "src/it/spring-fat/src/main/resources/META-INF/spring.factories",

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
-    <stack-size>256M</stack-size>
     <verify.xmir.in.integration.tests>false</verify.xmir.in.integration.tests>
     <skipITs/>
   </properties>

--- a/src/it/annotations/pom.xml
+++ b/src/it/annotations/pom.xml
@@ -19,7 +19,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <stack-size>256M</stack-size>
   </properties>
   <build>
     <plugins>

--- a/src/it/bytecode-to-eo/pom.xml
+++ b/src/it/bytecode-to-eo/pom.xml
@@ -17,7 +17,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <stack-size>256M</stack-size>
   </properties>
   <build>
     <plugins>

--- a/src/it/configurable-threads/pom.xml
+++ b/src/it/configurable-threads/pom.xml
@@ -19,7 +19,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <stack-size>256M</stack-size>
   </properties>
   <build>
     <plugins>

--- a/src/it/custom-transformations/pom.xml
+++ b/src/it/custom-transformations/pom.xml
@@ -19,7 +19,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <stack-size>256M</stack-size>
   </properties>
   <build>
     <plugins>

--- a/src/it/exceptions/pom.xml
+++ b/src/it/exceptions/pom.xml
@@ -19,7 +19,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <stack-size>256M</stack-size>
   </properties>
   <build>
     <plugins>

--- a/src/it/excludes-includes/pom.xml
+++ b/src/it/excludes-includes/pom.xml
@@ -20,7 +20,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <stack-size>256M</stack-size>
   </properties>
   <build>
     <plugins>

--- a/src/it/generics/pom.xml
+++ b/src/it/generics/pom.xml
@@ -19,7 +19,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <stack-size>256M</stack-size>
   </properties>
   <build>
     <plugins>

--- a/src/it/inner-classes/pom.xml
+++ b/src/it/inner-classes/pom.xml
@@ -18,7 +18,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>11</maven.compiler.release>
-    <stack-size>256M</stack-size>
   </properties>
   <build>
     <plugins>

--- a/src/it/jna/pom.xml
+++ b/src/it/jna/pom.xml
@@ -17,7 +17,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <stack-size>256M</stack-size>
     <jeo.disassemble>${project.build.directory}/generated-sources/jeo-disassemble</jeo.disassemble>
     <eo.phi>${project.build.directory}/generated-sources/eo-phi</eo.phi>
     <eo.unphi>${project.build.directory}/generated-sources/eo-unphi</eo.unphi>

--- a/src/it/modules/pom.xml
+++ b/src/it/modules/pom.xml
@@ -18,7 +18,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>9</maven.compiler.release>
-    <stack-size>256M</stack-size>
     <exec.mainClass>org.eolang.jeo.modules/org.eolang.jeo.modules.App</exec.mainClass>
   </properties>
   <build>

--- a/src/it/phi-unphi/pom.xml
+++ b/src/it/phi-unphi/pom.xml
@@ -17,7 +17,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <stack-size>256M</stack-size>
     <jeo.disassemble>${project.build.directory}/generated-sources/jeo-disassemble</jeo.disassemble>
     <eo.unphi>${project.build.directory}/generated-sources/eo-unphi</eo.unphi>
     <jeo.assemble>jeo-assemble</jeo.assemble>

--- a/src/it/records/pom.xml
+++ b/src/it/records/pom.xml
@@ -18,7 +18,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>16</maven.compiler.release>
-    <stack-size>256M</stack-size>
   </properties>
   <build>
     <plugins>

--- a/src/it/scala/pom.xml
+++ b/src/it/scala/pom.xml
@@ -19,7 +19,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>9</maven.compiler.release>
-    <stack-size>256M</stack-size>
     <scala.version>3.7.4</scala.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/src/it/scala2/pom.xml
+++ b/src/it/scala2/pom.xml
@@ -19,7 +19,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.release>9</maven.compiler.release>
-    <stack-size>256M</stack-size>
     <scala.version>2.13.18</scala.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/src/it/spring-fat/pom.xml
+++ b/src/it/spring-fat/pom.xml
@@ -34,7 +34,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <stack-size>256M</stack-size>
   </properties>
   <dependencies>
     <dependency>

--- a/src/it/spring/pom.xml
+++ b/src/it/spring/pom.xml
@@ -31,7 +31,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <stack-size>256M</stack-size>
   </properties>
   <dependencies>
     <dependency>

--- a/src/it/takes/pom.xml
+++ b/src/it/takes/pom.xml
@@ -20,7 +20,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <stack-size>256M</stack-size>
     <takes>1.24.6</takes>
   </properties>
   <dependencies>

--- a/src/it/variable-names/pom.xml
+++ b/src/it/variable-names/pom.xml
@@ -17,7 +17,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <stack-size>256M</stack-size>
   </properties>
   <dependencies>
     <dependency>

--- a/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
@@ -79,7 +79,7 @@ final class BytecodeRepresentationTest {
      * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/1160">Issue #1160</a>.
      */
     @Test
-    void generatesXmlWithFormationsThatCIncludeObjectsWithNames() {
+    void generatesXmlWithFormationsThatIncludeObjectsWithNames() {
         MatcherAssert.assertThat(
             "A formation must only include objects with names.",
             new BytecodeRepresentation(
@@ -107,7 +107,7 @@ final class BytecodeRepresentationTest {
     /**
      * This test checks that the bytecode representation have a stack with a double value.
      * The test was added to mitigate the issue:
-     * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/1211:">Issue #1211</a>.
+     * <a href="https://github.com/objectionary/jeo-maven-plugin/issues/1211">Issue #1211</a>.
      */
     @Test
     void parsesBytecodeWithDoubleStack() {

--- a/src/test/java/org/eolang/jeo/representation/CounterTest.java
+++ b/src/test/java/org/eolang/jeo/representation/CounterTest.java
@@ -48,7 +48,7 @@ final class CounterTest {
     }
 
     @Test
-    void handlesZeroTotalWithoutIncrementing() {
+    void incrementsWithZeroTotal() {
         final Counter counter = new Counter(0);
         MatcherAssert.assertThat(
             "First call should return 1/0",
@@ -63,7 +63,7 @@ final class CounterTest {
     }
 
     @Test
-    void handlesLargeCountsWithoutOverflow() {
+    void handlesLargeTotal() {
         final Counter counter = new Counter(Integer.MAX_VALUE);
         MatcherAssert.assertThat(
             "First call should return 1/MAX_VALUE",

--- a/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/XmirRepresentationTest.java
@@ -208,7 +208,7 @@ final class XmirRepresentationTest {
      * into the bytecode representation and back.
      */
     @Test
-    @Disabled
+    @Disabled("Performance test measuring the conversion round-trip time, disabled by default")
     @SuppressWarnings("PMD.GuardLogStatement")
     void convertsToXmirAndBack() {
         final Bytecode before = new BytecodeObject(

--- a/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/BytecodeInstructionTest.java
@@ -22,7 +22,7 @@ import org.xembly.Xembler;
 final class BytecodeInstructionTest {
 
     @Test
-    void covertsInstructionWithTypeToDirectives() throws ImpossibleModificationException {
+    void convertsInstructionWithTypeToDirectives() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "We expect that the bytecode instruction argument with type 'Type' will be wrapped in sting, see https://github.com/objectionary/jeo-maven-plugin/issues/1125",
             new Xembler(

--- a/src/test/java/org/eolang/jeo/representation/bytecode/JavaSourceClass.java
+++ b/src/test/java/org/eolang/jeo/representation/bytecode/JavaSourceClass.java
@@ -31,6 +31,13 @@ import org.cactoos.text.UncheckedText;
 public final class JavaSourceClass {
 
     /**
+     * System Java compiler.
+     * <p>The compiler is expensive to create, so it is reused across compilations.</p>
+     */
+    @SuppressWarnings("JTCOP.RuleProhibitStaticFields")
+    private static final JavaCompiler COMPILER = ToolProvider.getSystemJavaCompiler();
+
+    /**
      * Name of Java class.
      */
     private final String name;
@@ -63,9 +70,8 @@ public final class JavaSourceClass {
      * @return Bytecode of compiled class.
      */
     public Bytecode compile() {
-        final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-        final BytecodeManager manager = new BytecodeManager(compiler);
-        final boolean successful = compiler.getTask(
+        final BytecodeManager manager = new BytecodeManager(JavaSourceClass.COMPILER);
+        final boolean successful = JavaSourceClass.COMPILER.getTask(
             null,
             manager,
             null,

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesAnnotationsTest.java
@@ -18,7 +18,7 @@ import org.xembly.Xembler;
 final class DirectivesAnnotationsTest {
 
     @Test
-    void returnsEmptyDirectviesIfNoAnnotations() throws ImpossibleModificationException {
+    void returnsEmptyDirectivesIfNoAnnotations() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "Must return empty directives if no annotations",
             new Xembler(new DirectivesAnnotations()).xml(),

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesInstructionTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesInstructionTest.java
@@ -25,7 +25,7 @@ import org.xembly.Xembler;
 final class DirectivesInstructionTest {
 
     @Test
-    void covertsInstructionWithTypeToDirectives() {
+    void convertsInstructionWithTypeToDirectives() {
         MatcherAssert.assertThat(
             "We expect that the bytecode instruction argument with type 'Type' will be wrapped in sting, see https://github.com/objectionary/jeo-maven-plugin/issues/1125",
             new Xembler(

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodParamTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesMethodParamTest.java
@@ -85,7 +85,7 @@ final class DirectivesMethodParamTest {
     }
 
     @Test
-    void generatesPramDirectivesWithAccessModifier() throws ImpossibleModificationException {
+    void generatesParamDirectivesWithAccessModifier() throws ImpossibleModificationException {
         MatcherAssert.assertThat(
             "We expect that the parameter directives will be generated with an access modifier",
             new Xembler(

--- a/src/test/java/org/eolang/jeo/representation/directives/DirectivesValuesTest.java
+++ b/src/test/java/org/eolang/jeo/representation/directives/DirectivesValuesTest.java
@@ -8,7 +8,6 @@ import com.jcabi.matchers.XhtmlMatchers;
 import org.eolang.jeo.representation.xmir.NativeXmlNode;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.xembly.ImpossibleModificationException;
 import org.xembly.Xembler;
@@ -35,7 +34,7 @@ final class DirectivesValuesTest {
         );
     }
 
-    @RepeatedTest(100)
+    @Test
     void generatesRandomNameWithoutFirstDigit() {
         MatcherAssert.assertThat(
             "We expect that the name of the sequence will be generated randomly and will not start with a digit",


### PR DESCRIPTION
Fixes #1627

## Cleaned up
1. **Test name typos**: `covertsInstructionWithTypeToDirectives` (×2) → `converts...`,
   `generatesXmlWithFormationsThatCInclude...` → `...ThatInclude...`,
   `generatesPramDirectivesWithAccessModifier` → `generatesParam...`,
   `returnsEmptyDirectviesIfNoAnnotations` → `returnsEmptyDirectives...`,
   javadoc link `#1211:` → `#1211`
2. **`@Disabled`** in `XmirRepresentationTest` — added an explicit reason
3. **`@RepeatedTest(100)`** in `DirectivesValuesTest` — replaced with `@Test` (the assertion is deterministic)
4. **Misleading names** in `CounterTest` — `handlesZeroTotalWithoutIncrementing` → `incrementsWithZeroTotal`,
   `handlesLargeCountsWithoutOverflow` → `handlesLargeTotal`
5. **Dead config**: removed `<stack-size>256M</stack-size>` from `pom.xml` and 18 IT poms (declared but
   never read)
6. **Duplicate patterns**: removed `".gitignore"`/`"MANIFEST.MF"` duplicates from `REUSE.toml`
   (`**/` forms already cover them) and the ineffective `!src/it/.../target` negations from `.gitignore`
   (the trailing `target/` rule already excludes them; the ITs referenced there do not even exist)
7. **Missing `concurrency`** — added `{group, cancel-in-progress}` to `maven.long.yml` and `codecov.yml`
8. **Reuse of the Java compiler** — `JavaSourceClass` now caches the system `JavaCompiler` in a static
   field instead of creating it per call

## Notes on two items that turned out to be intentional
- `src/it/settings.xml` — **not** dead: `maven-invoker-plugin` uses it by default as the settings file
  for the IT builds (the build fails if it is removed). Reverted
- `hone.yml` — already had `concurrency`; left unchanged

## Changes
- 8 hygiene fixes across `src/test/java`, `pom.xml`, IT poms, `REUSE.toml`, `.gitignore` and two workflows

## Tests
- `yamllint` on the touched workflows passes; `xmllint` on `pom.xml` passes
- Full `mvn clean install -Pqulice` green