### PR TITLE
fix(#1633): split CI into unit tests on the full matrix and integration tests on one combination

### DIFF
--- a/.github/workflows/maven.test.yml
+++ b/.github/workflows/maven.test.yml
@@ -16,6 +16,10 @@ jobs:
       matrix:
         os: [ ubuntu-24.04, macos-15, windows-2022 ]
         java: [ 11, 23 ]
+        include:
+          - os: ubuntu-24.04
+            java: 23
+            it: true
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -29,4 +33,8 @@ jobs:
           key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
-      - run: mvn clean install -ntp --errors --batch-mode
+      - name: Run unit tests
+        run: mvn clean test -ntp --errors --batch-mode
+      - name: Run integration tests
+        if: matrix.it
+        run: mvn clean install -ntp --errors --batch-mode -DskipTests


### PR DESCRIPTION
Fixes #1613 

## Problem
`maven.test.yml` ran `mvn clean install` — including the full invoker IT suite (20+ projects) — on all
six OS×JDK combinations (`ubuntu-24.04`/`macos-15`/`windows-2022` × `11`/`23`). The IT suite is the slow
part and mostly exercises JDK-independent bytecode logic, so this burned CI minutes on every runner

## Solution / What
Split the build:
- **Unit tests** (`mvn clean test`) run on the full OS×JDK matrix (all six combinations)
- **Integration tests** (`mvn clean install -DskipTests`, which still executes the invoker ITs) run only
  on a single representative combination (`ubuntu-24.04` + JDK 23), added via a matrix `include`

The ITs remain fully covered on the representative runner (and additionally by `maven.long.yml` on
ubuntu)

## Changes
- `.github/workflows/maven.test.yml` — two steps with the `it` matrix flag

## Tests
- `yamllint .github/workflows/maven.test.yml` passes; `actionlint` is run by the CI (`actionlint.yml`)