### PR TITLE
#1674: split the encoded signature at its last dash

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/NamedDescriptor.java
+++ b/src/main/java/org/eolang/jeo/representation/NamedDescriptor.java
@@ -45,13 +45,18 @@ public final class NamedDescriptor {
 
     /**
      * Encoded method name with descriptor.
+     *
+     * <p>A dash of the descriptor is escaped, so the last dash of the result
+     * is the separator. A method name may hold a dash of its own - Kotlin
+     * emits "box-impl" for a value class - and splitting on the first one
+     * landed inside the name.</p>
      * @return Encoded method name with descriptor.
      */
     public String encoded() {
         return String.format(
             "%s-%s",
             this.original,
-            new DecodedString(this.descr).encode()
+            new DecodedString(this.descr).encode().replace("-", "%2D")
         );
     }
 
@@ -78,7 +83,7 @@ public final class NamedDescriptor {
      */
     private static String prefix(final String encoded) {
         try {
-            return encoded.substring(0, encoded.indexOf('-'));
+            return encoded.substring(0, encoded.lastIndexOf('-'));
         } catch (final StringIndexOutOfBoundsException exception) {
             throw new IllegalArgumentException(
                 String.format("Invalid encoded method name: %s", encoded),
@@ -93,6 +98,6 @@ public final class NamedDescriptor {
      * @return The decoded method descriptor
      */
     private static String suffix(final String encoded) {
-        return new EncodedString(encoded.substring(encoded.indexOf('-') + 1)).decode();
+        return new EncodedString(encoded.substring(encoded.lastIndexOf('-') + 1)).decode();
     }
 }

--- a/src/test/java/org/eolang/jeo/representation/NamedDescriptorTest.java
+++ b/src/test/java/org/eolang/jeo/representation/NamedDescriptorTest.java
@@ -64,7 +64,10 @@ final class NamedDescriptorTest {
                 "baz",
                 "(Ljava/lang/String;Ljava/lang/String;)V",
                 "baz-%28Ljava%2Flang%2FString%3BLjava%2Flang%2FString%3B%29V"
-            )
+            ),
+            Arguments.of("box-impl", "()V", "box-impl-%28%29V"),
+            Arguments.of("annotation-0", "()V", "annotation-0-%28%29V"),
+            Arguments.of("foo", "(LFoo-impl;)V", "foo-%28LFoo%2Dimpl%3B%29V")
         );
     }
 }


### PR DESCRIPTION
The name and the descriptor were joined with a dash and split back on the first
one. A dash is legal in a JVM method name and Kotlin emits `box-impl`,
`unbox-impl` and `constructor-impl` for value classes, so the split landed
inside the name and both halves came back wrong with no exception. The
`annotation-N` names this plugin makes itself had the same problem.

The descriptor's own dashes are escaped now, so the last dash is the separator,
and the split uses it.

Closes #1674
