### PR TITLE
#1673: keep a trailing group that is no number in the name

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/NumberedName.java
+++ b/src/main/java/org/eolang/jeo/representation/NumberedName.java
@@ -4,6 +4,8 @@
  */
 package org.eolang.jeo.representation;
 
+import java.util.regex.Pattern;
+
 /**
  * Name representation with optional numeric suffix.
  *
@@ -13,6 +15,15 @@ package org.eolang.jeo.representation;
  * @since 0.9.0
  */
 public final class NumberedName {
+
+    /**
+     * A trailing group that is a number of a name.
+     *
+     * <p>A dash is legal in a JVM method name and Kotlin emits "box-impl" for
+     * a value class, so a trailing group that is not a number belongs to the
+     * name. The digits are bounded to keep the number inside an int.</p>
+     */
+    private static final Pattern NUMBER = Pattern.compile("[1-9][0-9]{0,8}");
 
     /**
      * Number of the name.
@@ -72,18 +83,10 @@ public final class NumberedName {
     private static int suffix(final String encoded) {
         final int result;
         final int index = encoded.lastIndexOf('-');
-        if (index == -1) {
+        if (index == -1 || !NumberedName.NUMBER.matcher(encoded.substring(index + 1)).matches()) {
             result = 1;
         } else {
-            final String number = encoded.substring(index + 1);
-            try {
-                result = Integer.parseInt(number);
-            } catch (final NumberFormatException ex) {
-                throw new IllegalArgumentException(
-                    String.format("Invalid number in name: %s", number),
-                    ex
-                );
-            }
+            result = Integer.parseInt(encoded.substring(index + 1));
         }
         return result;
     }
@@ -96,7 +99,7 @@ public final class NumberedName {
     private static String prefix(final String encoded) {
         final String result;
         final int index = encoded.lastIndexOf('-');
-        if (index == -1) {
+        if (index == -1 || !NumberedName.NUMBER.matcher(encoded.substring(index + 1)).matches()) {
             result = encoded;
         } else {
             result = encoded.substring(0, index);

--- a/src/test/java/org/eolang/jeo/representation/NumberedNameTest.java
+++ b/src/test/java/org/eolang/jeo/representation/NumberedNameTest.java
@@ -39,6 +39,15 @@ final class NumberedNameTest {
     }
 
     @Test
+    void readsBackAKotlinValueClassMethod() {
+        MatcherAssert.assertThat(
+            "a name the disassembler emits must be readable back, but it wasnt",
+            new NumberedName(new NumberedName(1, "box-impl").toString()).toString(),
+            Matchers.equalTo("box-impl")
+        );
+    }
+
+    @Test
     void throwsExceptionWhenNumberIsLessThanOne() {
         MatcherAssert.assertThat(
             "We expect that exception message will be human-readable",
@@ -56,7 +65,10 @@ final class NumberedNameTest {
         "foo, foo",
         "foo-2, foo",
         "bar-3, bar",
-        "foobar-4, foobar"
+        "foobar-4, foobar",
+        "box-impl, box-impl",
+        "constructor-impl, constructor-impl",
+        "get-x, get-x"
     })
     void decodesName(final String encoded, final String expected) {
         MatcherAssert.assertThat(


### PR DESCRIPTION
`NumberedName` split a name on the last dash and insisted the tail was a
number, while the disassembler writes such a name out unchanged. So
`jeo:disassemble` succeeded on a Kotlin value class and `jeo:assemble` then
refused the XMIR it had just produced, with a message naming only the fragment
`impl`.

A trailing group that is not a number is part of the name now, the way it is on
the way out.

Closes #1673
