### PR TITLE
#1672: close the stream even when logging a file fails

### DIFF
--- a/src/main/java/org/eolang/jeo/Disassembler.java
+++ b/src/main/java/org/eolang/jeo/Disassembler.java
@@ -122,15 +122,15 @@ public final class Disassembler {
         final String process = "Disassembling";
         final String disassembled = "disassembled";
         final Counter counter = new Counter(this.classes.total());
-        final Stream<Path> stream = new Summary(
+        try (Stream<Path> stream = new Summary(
             process,
             disassembled,
             this.classes.toString(),
             this.target,
             new ParallelTranslator(path -> this.disassemble(path, counter), this.threads)
-        ).apply(this.classes.all());
-        stream.forEach(this::log);
-        stream.close();
+        ).apply(this.classes.all())) {
+            stream.forEach(this::log);
+        }
     }
 
     /**


### PR DESCRIPTION
The stream was closed by a plain statement after it was consumed, and `log`
throws when the size of a file cannot be read. The summary line lives in the
close handler, so that failure took the count of what was disassembled with it.

The stream is closed by try-with-resources now, so the summary is printed
either way.

Closes #1672
