### PR TITLE
#1669: do not report a cached file as disassembled

### DIFF
--- a/src/main/java/org/eolang/jeo/Disassembler.java
+++ b/src/main/java/org/eolang/jeo/Disassembler.java
@@ -140,16 +140,16 @@ public final class Disassembler {
      * @return Path to the disassembled XMIR file
      */
     private Path disassemble(final Path path, final Counter counter) {
-        final Transformation trans = new Logging(
-            "Disassembling",
-            "disassembled",
-            new Caching(
+        final Transformation trans = new Caching(
+            new Logging(
+                "Disassembling",
+                "disassembled",
                 new Informative(
                     new Disassembling(this.classes.root(), this.target, path, this.params)
-                )
-            ),
-            this.debug,
-            counter
+                ),
+                this.debug,
+                counter
+            )
         );
         trans.transform();
         return trans.target();


### PR DESCRIPTION
The logging decorator sat outside the caching one, so a file served from the
cache printed both "already transformed ... Skipping" and "N/M ... disassembled
in 1ms", and the progress counter counted files that were only read back from
disk.

Caching is the outer decorator now, so a cached file says only that it was
reused and the counter follows the actual work.

Closes #1669
