### PR TITLE
#1670: Read file size outside counter lock

### DIFF
--- a/src/main/java/org/eolang/jeo/Logging.java
+++ b/src/main/java/org/eolang/jeo/Logging.java
@@ -114,6 +114,7 @@ public final class Logging implements Transformation {
      * @param time Time spent in milliseconds
      */
     private void logEndWithSize(final Path source, final Path after, final long time) {
+        final long size = Logging.size(after);
         synchronized (this.counter) {
             if (this.debug) {
                 Logger.info(
@@ -123,7 +124,7 @@ public final class Logging implements Transformation {
                     source,
                     this.participle,
                     after,
-                    Logging.size(after),
+                    size,
                     time
                 );
             } else {
@@ -132,7 +133,7 @@ public final class Logging implements Transformation {
                     "%s %[file]s (%[size]s) %s in %[ms]s",
                     this.counter.next(),
                     after.getFileName(),
-                    Logging.size(after),
+                    size,
                     this.participle,
                     time
                 );


### PR DESCRIPTION
Closes #1670.

`Logging.logEndWithSize()` used to call `Files.exists()` / `Files.size()` through `Logging.size(after)` while synchronized on the shared `Counter`. Every per-file `Logging` instance in the parallel run shares that counter, so filesystem I/O became part of the global serial section.

This computes the target size once before taking the counter lock and reuses the value in either logging branch. The synchronized block is now limited to advancing the shared counter and emitting the ordered progress line.

The log format, counter behavior, error handling, and measured file are unchanged; only the lock scope is reduced. `git diff --check` is clean.
