### PR TITLE
#1668: Traverse inputs once per run

### DIFF
--- a/src/main/java/org/eolang/jeo/Assembler.java
+++ b/src/main/java/org/eolang/jeo/Assembler.java
@@ -8,6 +8,8 @@ import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.Counter;
 
@@ -77,14 +79,15 @@ public final class Assembler {
         final String assembling = "Assembling";
         final String assembled = "assembled";
         final XmirFiles files = new XmirFiles(this.input);
-        final Counter counter = new Counter(files.total());
+        final List<Path> paths = files.all().collect(Collectors.toList());
+        final Counter counter = new Counter(paths.size());
         final Stream<Path> all = new Summary(
             assembling,
             assembled,
             this.input.toString(),
             this.output,
             new ParallelTranslator(path -> this.assemble(path, counter), this.threads)
-        ).apply(files.all());
+        ).apply(paths.stream());
         all.forEach(this::log);
         all.close();
     }

--- a/src/main/java/org/eolang/jeo/Disassembler.java
+++ b/src/main/java/org/eolang/jeo/Disassembler.java
@@ -8,6 +8,8 @@ import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.Counter;
 import org.eolang.jeo.representation.directives.Format;
@@ -121,14 +123,15 @@ public final class Disassembler {
     public void disassemble() {
         final String process = "Disassembling";
         final String disassembled = "disassembled";
-        final Counter counter = new Counter(this.classes.total());
+        final List<Path> paths = this.classes.all().collect(Collectors.toList());
+        final Counter counter = new Counter(paths.size());
         final Stream<Path> stream = new Summary(
             process,
             disassembled,
             this.classes.toString(),
             this.target,
             new ParallelTranslator(path -> this.disassemble(path, counter), this.threads)
-        ).apply(this.classes.all());
+        ).apply(paths.stream());
         stream.forEach(this::log);
         stream.close();
     }


### PR DESCRIPTION
Closes #1668.

Both top-level pipelines counted their inputs with a full traversal and then requested the same inputs again for processing:

- `Disassembler`: `classes.total()` -> `classes.all().count()`, then `classes.all()` again.
- `Assembler`: `files.total()` -> `files.all().count()`, then `files.all()` again.

This materializes each input stream once, initializes the progress `Counter` from the resulting list size, and feeds the same list into `Summary`/`ParallelTranslator`. For `FilteredClasses`, this also means its filtering and `Found N files ...` log run once instead of twice.

No ordering, filtering, transformation, or progress-total semantics change. `git diff --check` is clean; the repository CI/JMH jobs can measure the traversal reduction on the supported build environment.
