### PR TITLE
#1671: Index labels once per flow

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/bytecode/InstructionsFlow.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/InstructionsFlow.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -33,6 +34,11 @@ public final class InstructionsFlow<T extends InstructionsFlow.Reducible<T>> {
     private final List<BytecodeTryCatchBlock> blocks;
 
     /**
+     * Instruction indexes of labels.
+     */
+    private final Map<BytecodeLabel, Integer> labels;
+
+    /**
      * Constructor.
      * @param instr Instructions.
      * @param catches Try-catch blocks.
@@ -42,6 +48,13 @@ public final class InstructionsFlow<T extends InstructionsFlow.Reducible<T>> {
     ) {
         this.instructions = instr;
         this.blocks = new ArrayList<>(catches);
+        this.labels = new HashMap<>(0);
+        for (int pos = 0; pos < instr.size(); ++pos) {
+            final BytecodeEntry entry = instr.get(pos);
+            if (entry.isLabel()) {
+                this.labels.putIfAbsent((BytecodeLabel) entry, pos);
+            }
+        }
     }
 
     /**
@@ -119,12 +132,11 @@ public final class InstructionsFlow<T extends InstructionsFlow.Reducible<T>> {
      * @return Index.
      */
     private int index(final BytecodeLabel label) {
-        for (int index = 0; index < this.instructions.size(); ++index) {
-            if (this.instructions.get(index).equals(label)) {
-                return index;
-            }
+        final Integer index = this.labels.get(label);
+        if (index == null) {
+            throw new IllegalStateException(String.format("Label %s not found", label));
         }
-        throw new IllegalStateException(String.format("Label %s not found", label));
+        return index;
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/InstructionsFlow.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/InstructionsFlow.java
@@ -48,13 +48,7 @@ public final class InstructionsFlow<T extends InstructionsFlow.Reducible<T>> {
     ) {
         this.instructions = instr;
         this.blocks = new ArrayList<>(catches);
-        this.labels = new HashMap<>(0);
-        for (int pos = 0; pos < instr.size(); ++pos) {
-            final BytecodeEntry entry = instr.get(pos);
-            if (entry.isLabel()) {
-                this.labels.putIfAbsent((BytecodeLabel) entry, pos);
-            }
-        }
+        this.labels = InstructionsFlow.indexes(instr);
     }
 
     /**
@@ -137,6 +131,24 @@ public final class InstructionsFlow<T extends InstructionsFlow.Reducible<T>> {
             throw new IllegalStateException(String.format("Label %s not found", label));
         }
         return index;
+    }
+
+    /**
+     * Build instruction indexes of labels.
+     * @param instructions Method instructions.
+     * @return Label indexes.
+     */
+    private static Map<BytecodeLabel, Integer> indexes(
+        final List<? extends BytecodeEntry> instructions
+    ) {
+        final Map<BytecodeLabel, Integer> labels = new HashMap<>(0);
+        for (int pos = 0; pos < instructions.size(); ++pos) {
+            final BytecodeEntry entry = instructions.get(pos);
+            if (entry.isLabel()) {
+                labels.putIfAbsent((BytecodeLabel) entry, pos);
+            }
+        }
+        return labels;
     }
 
     /**


### PR DESCRIPTION
Closes #1671.

`InstructionsFlow.index()` previously scanned the complete instruction list on every branch lookup and on each try/catch boundary lookup. The same labels are immutable for the lifetime of one flow, so these repeated linear searches multiply inside the worklist analysis.

This builds a `BytecodeLabel -> instruction index` map once in the constructor and makes `index()` a constant-time lookup. `BytecodeLabel` already has `@EqualsAndHashCode`, so its existing equality semantics are preserved as map-key semantics. `putIfAbsent` deliberately keeps the first equal label, matching the previous forward linear search if duplicate-equivalent labels ever appear.

Missing labels still throw the same `IllegalStateException("Label ... not found")`; flow traversal and max-value logic are unchanged. `git diff --check` is clean. The repository's max-stack/max-locals and integration CI will exercise the functional behavior on the supported build environment.
