### PR TITLE
#1666: Exit disabled goals before initialization

### DIFF
--- a/src/it/disabled/invoker.properties
+++ b/src/it/disabled/invoker.properties
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+invoker.goals=clean process-classes
+invoker.java.version = 17+

--- a/src/it/disabled/pom.xml
+++ b/src/it/disabled/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eolang</groupId>
+  <artifactId>jeo-disabled-it</artifactId>
+  <version>@project.version@</version>
+  <packaging>jar</packaging>
+  <description>Disabled goals exit before validating or initializing anything.</description>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.eolang</groupId>
+        <artifactId>jeo-maven-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>disabled-disassemble</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>disassemble</goal>
+            </goals>
+            <configuration>
+              <disabled>true</disabled>
+              <threads>-1</threads>
+            </configuration>
+          </execution>
+          <execution>
+            <id>disabled-assemble</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>assemble</goal>
+            </goals>
+            <configuration>
+              <disabled>true</disabled>
+              <threads>-1</threads>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/disabled/verify.groovy
+++ b/src/it/disabled/verify.groovy
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+String log = new File(basedir, 'build.log').text
+assert log.contains('BUILD SUCCESS')
+assert log.contains('Disassemble mojo is disabled, skipping')
+assert log.contains('Assemble mojo is disabled, skipping')
+assert !log.contains('The number of threads must be 0 or positive')
+true

--- a/src/main/java/org/eolang/jeo/AssembleMojo.java
+++ b/src/main/java/org/eolang/jeo/AssembleMojo.java
@@ -148,32 +148,32 @@ public final class AssembleMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        if (this.disabled) {
+            Logger.info(this, "Assemble mojo is disabled, skipping");
+            return;
+        }
         this.checkedThreads();
         final Path src = new MavenPath(this.sourcesDir).resolve();
         final Path out = new MavenPath(this.outputDir).resolve();
         try {
-            if (this.disabled) {
-                Logger.info(this, "Assemble mojo is disabled, skipping");
+            if (this.xmirVerification) {
+                Logger.info(this, "Verifying all the XMIR files before assembling...");
+                new XmirFiles(src).verify();
             } else {
-                if (this.xmirVerification) {
-                    Logger.info(this, "Verifying all the XMIR files before assembling...");
-                    new XmirFiles(src).verify();
-                } else {
-                    Logger.info(this, "XMIR verification before assembling is disabled, skipping");
-                }
-                new Assembler(
-                    src,
-                    out,
-                    this.debug,
-                    this.threads
-                ).assemble();
-                if (this.skipVerification) {
-                    Logger.info(this, "Bytecode verification is disabled, skipping");
-                } else {
-                    Logger.info(this, "Verifying bytecode of all the generated classes...");
-                    new PluginStartup(this.project, out).init();
-                    new BytecodeClasses(out).verify();
-                }
+                Logger.info(this, "XMIR verification before assembling is disabled, skipping");
+            }
+            new Assembler(
+                src,
+                out,
+                this.debug,
+                this.threads
+            ).assemble();
+            if (this.skipVerification) {
+                Logger.info(this, "Bytecode verification is disabled, skipping");
+            } else {
+                Logger.info(this, "Verifying bytecode of all the generated classes...");
+                new PluginStartup(this.project, out).init();
+                new BytecodeClasses(out).verify();
             }
         } catch (final DependencyResolutionRequiredException exception) {
             throw new MojoExecutionException(exception);

--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -247,49 +247,49 @@ public final class DisassembleMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+        if (this.disabled) {
+            Logger.info(this, "Disassemble mojo is disabled, skipping");
+            return;
+        }
         this.checkedThreads();
         final Path src = new MavenPath(this.sourcesDir).resolve();
         final Path out = new MavenPath(this.outputDir).resolve();
         try {
             new PluginStartup(this.project, src).init();
-            if (this.disabled) {
-                Logger.info(this, "Disassemble mojo is disabled, skipping");
+            final boolean listings = !this.omitListings;
+            final boolean comments = !this.omitComments;
+            Logger.info(
+                this,
+                "Disassembling is started with mode '%s' (with listings = '%b', comments = '%b', modifiers = '%b', pretty = '%b')",
+                this.mode,
+                listings,
+                comments,
+                this.modifiers,
+                this.prettyXmir
+            );
+            new Disassembler(
+                new FilteredClasses(
+                    new BytecodeClasses(src),
+                    new GlobFilter(this.includes, this.excludes)
+                ),
+                out,
+                new Format(
+                    Format.MODIFIERS, this.modifiers,
+                    Format.COMMENTS, comments,
+                    Format.WITH_LISTING, listings,
+                    Format.PRETTY, this.prettyXmir,
+                    Format.MODE, this.mode
+                ),
+                this.debug,
+                this.threads
+            ).disassemble();
+            if (this.xmirVerification) {
+                Logger.info(this, "Verifying all the XMIR files after disassembling");
+                new XmirFiles(out).verify();
             } else {
-                final boolean listings = !this.omitListings;
-                final boolean comments = !this.omitComments;
                 Logger.info(
-                    this,
-                    "Disassembling is started with mode '%s' (with listings = '%b', comments = '%b', modifiers = '%b', pretty = '%b')",
-                    this.mode,
-                    listings,
-                    comments,
-                    this.modifiers,
-                    this.prettyXmir
+                    this, "XMIR verification after disassembling is disabled, skipping"
                 );
-                new Disassembler(
-                    new FilteredClasses(
-                        new BytecodeClasses(src),
-                        new GlobFilter(this.includes, this.excludes)
-                    ),
-                    out,
-                    new Format(
-                        Format.MODIFIERS, this.modifiers,
-                        Format.COMMENTS, comments,
-                        Format.WITH_LISTING, listings,
-                        Format.PRETTY, this.prettyXmir,
-                        Format.MODE, this.mode
-                    ),
-                    this.debug,
-                    this.threads
-                ).disassemble();
-                if (this.xmirVerification) {
-                    Logger.info(this, "Verifying all the XMIR files after disassembling");
-                    new XmirFiles(out).verify();
-                } else {
-                    Logger.info(
-                        this, "XMIR verification after disassembling is disabled, skipping"
-                    );
-                }
             }
         } catch (final DependencyResolutionRequiredException exception) {
             throw new MojoExecutionException(


### PR DESCRIPTION
Closes #1666.

Both goals now return immediately when their `disabled` flag is true, before validating `threads`, resolving source/output paths, or initializing any classloader. This matches the existing parameter documentation that a disabled goal skips all processing and exits immediately.

The new Maven Invoker test configures both `disassemble` and `assemble` with:

- `disabled=true`
- deliberately invalid `threads=-1`

Before this change the build fails in `checkedThreads()` before reaching the disabled branch. With the early return both executions log their disabled message and the build succeeds. For `disassemble`, this also guarantees `PluginStartup.init()` is not reached while disabled.

I could not run the Maven Invoker suite locally because Maven is not installed in this Android/Termux environment; the fixture POM is XML-validated locally and repository CI is the integration validation source.
