### PR TITLE
#1599: Let debug XMIR pass validation

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -195,7 +195,9 @@ public final class JcabiXmlNode implements XmlNode {
             "sparse-decoration",
             "idempotent-attribute-is-not-first",
             "empty-object",
-            "object-has-data"
+            "object-has-data",
+            // Bytecode has no EO source-line contract (#1599).
+            "line-is-absent"
         );
         return Stream.concat(
             rules.stream(),

--- a/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/JcabiXmlNode.java
@@ -196,7 +196,6 @@ public final class JcabiXmlNode implements XmlNode {
             "idempotent-attribute-is-not-first",
             "empty-object",
             "object-has-data",
-            // Bytecode has no EO source-line contract (#1599).
             "line-is-absent"
         );
         return Stream.concat(

--- a/src/test/java/org/eolang/jeo/XmirFilesTest.java
+++ b/src/test/java/org/eolang/jeo/XmirFilesTest.java
@@ -15,6 +15,7 @@ import org.cactoos.io.ResourceOf;
 import org.eolang.jeo.representation.BytecodeRepresentation;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.eolang.jeo.representation.bytecode.BytecodeObject;
+import org.eolang.jeo.representation.directives.Format;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -124,6 +125,21 @@ final class XmirFilesTest {
         Assertions.assertDoesNotThrow(
             () -> new XmirFiles(temp).verify(),
             "We expected no exceptions when verifying the correct xmir files"
+        );
+    }
+
+    @Test
+    void verifiesDebugXmirGeneratedFromBytecode(@TempDir final Path temp) throws IOException {
+        Files.write(
+            temp.resolve("MethodByte.xmir"),
+            new BytecodeRepresentation(new ResourceOf("MethodByte.class"))
+                .toXmir(new Format(Format.MODE, "debug"))
+                .toString()
+                .getBytes(StandardCharsets.UTF_8)
+        );
+        Assertions.assertDoesNotThrow(
+            () -> new XmirFiles(temp).verify(),
+            "Debug XMIR generated from bytecode must pass verification"
         );
     }
 


### PR DESCRIPTION
Closes #1599.

JEO's validation already suppresses EO-source lints that are not valid invariants for its synthetic bytecode XMIR. `line-is-absent` is the same kind of false positive: bytecode does not have an EO source-line contract, and classes may omit `LineNumberTable` entirely. In debug mode JEO additionally materializes JVM line-number structures; requiring every synthetic `<o>` inside those structures to carry an EO `@line` makes the plugin reject its own valid output.

This adds `line-is-absent` (and, through the existing helper, its `/S` variant) to the central validation ignore set. It does not disable structural/XSD verification or unrelated lints.

A regression test now generates XMIR from the real `MethodByte.class` fixture in explicit `debug` mode and runs the same `XmirFiles.verify()` path used by the mojo. The existing short-mode validation tests remain unchanged.

This follows the existing validation design from #1467, where JEO-specific false-positive lints are centralized in `JcabiXmlNode.ignored()` instead of fabricating source metadata in generated XMIR.

Maven is not installed in this Android/Termux environment, so repository CI is the test execution source; `git diff --check` is clean locally.
