### PR TITLE
#1598: Preserve type annotations outside records

### DIFF
--- a/src/main/java/org/eolang/jeo/representation/asm/AsmClass.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmClass.java
@@ -54,6 +54,7 @@ public final class AsmClass {
             this.methods(),
             this.fields(),
             new AsmAnnotations(this.node).bytecode(),
+            new AsmTypeAnnotations(this.node).bytecode(),
             this.attributes(),
             new BytecodeClassProperties(
                 this.node.version,

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmField.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmField.java
@@ -38,7 +38,8 @@ final class AsmField {
             this.node.signature,
             this.node.value,
             this.node.access,
-            new AsmAnnotations(this.node).bytecode()
+            new AsmAnnotations(this.node).bytecode(),
+            new AsmTypeAnnotations(this.node).bytecode()
         );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmMethod.java
@@ -50,6 +50,7 @@ final class AsmMethod {
             this.tryblocks(),
             this.instructions(),
             new AsmAnnotations(this.node).bytecode(),
+            new AsmTypeAnnotations(this.node).bytecode(),
             new BytecodeMethodProperties(
                 this.node.access,
                 this.node.name,

--- a/src/main/java/org/eolang/jeo/representation/asm/AsmTypeAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/asm/AsmTypeAnnotations.java
@@ -9,6 +9,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotation;
 import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotations;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.FieldNode;
+import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.RecordComponentNode;
 import org.objectweb.asm.tree.TypeAnnotationNode;
 
@@ -34,6 +37,30 @@ final class AsmTypeAnnotations {
      */
     AsmTypeAnnotations(final RecordComponentNode comp) {
         this(comp.visibleTypeAnnotations, comp.invisibleTypeAnnotations);
+    }
+
+    /**
+     * Constructor.
+     * @param clazz Class node.
+     */
+    AsmTypeAnnotations(final ClassNode clazz) {
+        this(clazz.visibleTypeAnnotations, clazz.invisibleTypeAnnotations);
+    }
+
+    /**
+     * Constructor.
+     * @param field Field node.
+     */
+    AsmTypeAnnotations(final FieldNode field) {
+        this(field.visibleTypeAnnotations, field.invisibleTypeAnnotations);
+    }
+
+    /**
+     * Constructor.
+     * @param method Method node.
+     */
+    AsmTypeAnnotations(final MethodNode method) {
+        this(method.visibleTypeAnnotations, method.invisibleTypeAnnotations);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeClass.java
@@ -50,6 +50,11 @@ public final class BytecodeClass {
     private final BytecodeAnnotations annotations;
 
     /**
+     * Type annotations.
+     */
+    private final BytecodeTypeAnnotations types;
+
+    /**
      * Attributes.
      */
     private final BytecodeAttributes attributes;
@@ -136,10 +141,36 @@ public final class BytecodeClass {
         final BytecodeAttributes attributes,
         final BytecodeClassProperties props
     ) {
+        this(
+            name, methods, fields, annotations, new BytecodeTypeAnnotations(), attributes, props
+        );
+    }
+
+    /**
+     * Constructor.
+     * @param name The class name
+     * @param methods The class methods
+     * @param fields The class fields
+     * @param annotations The class annotations
+     * @param types The class type annotations
+     * @param attributes The class attributes
+     * @param props The class properties
+     * @checkstyle ParameterNumberCheck (10 lines)
+     */
+    public BytecodeClass(
+        final ClassName name,
+        final List<BytecodeMethod> methods,
+        final List<BytecodeField> fields,
+        final BytecodeAnnotations annotations,
+        final BytecodeTypeAnnotations types,
+        final BytecodeAttributes attributes,
+        final BytecodeClassProperties props
+    ) {
         this.name = name;
         this.cmethods = methods;
         this.fields = fields;
         this.annotations = annotations;
+        this.types = types;
         this.attributes = attributes;
         this.props = props;
     }
@@ -299,6 +330,7 @@ public final class BytecodeClass {
                 .collect(Collectors.toList()),
             this.props.signature(),
             this.annotations.directives(format),
+            this.types.directives(format),
             this.attributes.directives(format, "attributes")
         );
     }
@@ -318,6 +350,7 @@ public final class BytecodeClass {
                 this.props.interfaces()
             );
             this.annotations.write(visitor);
+            this.types.write(visitor);
             this.fields.forEach(field -> field.write(visitor));
             this.cmethods.forEach(method -> method.write(visitor));
             this.attributes.write(visitor);

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeField.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeField.java
@@ -50,6 +50,11 @@ public final class BytecodeField {
     private final BytecodeAnnotations annotations;
 
     /**
+     * Type annotations.
+     */
+    private final BytecodeTypeAnnotations types;
+
+    /**
      * Constructor.
      * @param name Name.
      * @param descr Descriptor.
@@ -86,12 +91,39 @@ public final class BytecodeField {
         final int access,
         final BytecodeAnnotations annotations
     ) {
+        this(
+            name, descriptor, signature, value, access, annotations,
+            new BytecodeTypeAnnotations()
+        );
+    }
+
+    /**
+     * Constructor.
+     * @param name Name.
+     * @param descriptor Descriptor.
+     * @param signature Signature.
+     * @param value Value.
+     * @param access Access.
+     * @param annotations Annotations.
+     * @param types Type annotations.
+     * @checkstyle ParameterNumberCheck (10 lines)
+     */
+    public BytecodeField(
+        final String name,
+        final String descriptor,
+        final String signature,
+        final Object value,
+        final int access,
+        final BytecodeAnnotations annotations,
+        final BytecodeTypeAnnotations types
+    ) {
         this.name = name;
         this.descriptor = descriptor;
         this.signature = signature;
         this.value = value;
         this.access = access;
         this.annotations = annotations;
+        this.types = types;
     }
 
     /**
@@ -108,6 +140,7 @@ public final class BytecodeField {
         );
         this.annotations.annotations()
             .forEach(annotation -> annotation.write(fvisitor));
+        this.types.write(fvisitor);
     }
 
     public DirectivesField directives(final Format format) {
@@ -118,7 +151,8 @@ public final class BytecodeField {
             this.descriptor,
             this.signature,
             this.value,
-            this.annotations.directives(format, String.format("annotations-%s", this.name))
+            this.annotations.directives(format, String.format("annotations-%s", this.name)),
+            this.types.directives(format)
         );
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeMethod.java
@@ -45,6 +45,11 @@ public final class BytecodeMethod {
     private final BytecodeAnnotations annotations;
 
     /**
+     * Method type annotations.
+     */
+    private final BytecodeTypeAnnotations types;
+
+    /**
      * Method properties.
      */
     private final BytecodeMethodProperties properties;
@@ -181,9 +186,38 @@ public final class BytecodeMethod {
         final BytecodeMaxs maxs,
         final BytecodeAttributes attributes
     ) {
+        this(
+            tryblocks, instructions, annotations, new BytecodeTypeAnnotations(), properties,
+            defvalues, maxs, attributes
+        );
+    }
+
+    /**
+     * Constructor.
+     * @param tryblocks Try-catch blocks.
+     * @param instructions Method instructions.
+     * @param annotations Method annotations.
+     * @param types Method type annotations.
+     * @param properties Method properties.
+     * @param defvalues Default values.
+     * @param maxs Max stack and locals.
+     * @param attributes Method attributes.
+     * @checkstyle ParameterNumberCheck (10 lines)
+     */
+    public BytecodeMethod(
+        final List<BytecodeEntry> tryblocks,
+        final List<BytecodeEntry> instructions,
+        final BytecodeAnnotations annotations,
+        final BytecodeTypeAnnotations types,
+        final BytecodeMethodProperties properties,
+        final List<BytecodeDefaultValue> defvalues,
+        final BytecodeMaxs maxs,
+        final BytecodeAttributes attributes
+    ) {
         this.tryblocks = tryblocks;
         this.entries = instructions;
         this.annotations = annotations;
+        this.types = types;
         this.properties = properties;
         this.defvalues = defvalues;
         this.maxs = maxs;
@@ -199,6 +233,7 @@ public final class BytecodeMethod {
             this.tryblocks,
             this.entries,
             this.annotations,
+            this.types,
             this.properties,
             this.defvalues,
             new BytecodeMaxs(),
@@ -303,6 +338,7 @@ public final class BytecodeMethod {
             this.tryblocks.stream().map(e -> e.directives(tcounter.getAndIncrement(), format))
                 .collect(Collectors.toList()),
             this.annotations.directives(format),
+            this.types.directives(format),
             this.defvalues.stream()
                 .map(v -> v.directives(format))
                 .collect(Collectors.toList()),
@@ -330,6 +366,7 @@ public final class BytecodeMethod {
                 this.maxs.compute()
             );
             this.annotations.write(mvisitor);
+            this.types.write(mvisitor);
             this.defvalues.forEach(defvalue -> defvalue.writeTo(mvisitor));
             final AsmLabels all = new AsmLabels();
             if (!this.properties.isAbstract()) {

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTypeAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTypeAnnotation.java
@@ -125,14 +125,6 @@ public final class BytecodeTypeAnnotation {
     }
 
     /**
-     * Write type annotation values.
-     * @param visitor Annotation visitor.
-     */
-    private void write(final AnnotationVisitor visitor) {
-        this.values.forEach(value -> value.writeTo(visitor));
-    }
-
-    /**
      * Convert to directives.
      * @param index Index of the annotation.
      * @param format Directives format.
@@ -150,5 +142,13 @@ public final class BytecodeTypeAnnotation {
                 .map(v -> v.directives(counter.getAndIncrement(), format))
                 .collect(Collectors.toList())
         );
+    }
+
+    /**
+     * Write type annotation values.
+     * @param visitor Annotation visitor.
+     */
+    private void write(final AnnotationVisitor visitor) {
+        this.values.forEach(value -> value.writeTo(visitor));
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTypeAnnotation.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTypeAnnotation.java
@@ -5,6 +5,7 @@
 package org.eolang.jeo.representation.bytecode;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
@@ -12,6 +13,9 @@ import lombok.ToString;
 import org.eolang.jeo.representation.directives.DirectivesTypeAnnotation;
 import org.eolang.jeo.representation.directives.Format;
 import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.RecordComponentVisitor;
 import org.objectweb.asm.TypePath;
 
@@ -66,7 +70,7 @@ public final class BytecodeTypeAnnotation {
         final List<BytecodeAnnotationValue> values
     ) {
         this.ref = ref;
-        this.path = path.toString();
+        this.path = Optional.ofNullable(path).map(TypePath::toString).orElse("");
         this.desc = desc;
         this.visible = visible;
         this.values = values;
@@ -77,10 +81,55 @@ public final class BytecodeTypeAnnotation {
      * @param visitor Visitor to write to.
      */
     public void write(final RecordComponentVisitor visitor) {
-        final AnnotationVisitor visited = visitor.visitTypeAnnotation(
-            this.ref, TypePath.fromString(this.path), this.desc, this.visible
+        this.write(
+            visitor.visitTypeAnnotation(
+                this.ref, TypePath.fromString(this.path), this.desc, this.visible
+            )
         );
-        this.values.forEach(v -> v.writeTo(visited));
+    }
+
+    /**
+     * Write type annotation.
+     * @param visitor Visitor to write to.
+     */
+    public void write(final ClassVisitor visitor) {
+        this.write(
+            visitor.visitTypeAnnotation(
+                this.ref, TypePath.fromString(this.path), this.desc, this.visible
+            )
+        );
+    }
+
+    /**
+     * Write type annotation.
+     * @param visitor Visitor to write to.
+     */
+    public void write(final FieldVisitor visitor) {
+        this.write(
+            visitor.visitTypeAnnotation(
+                this.ref, TypePath.fromString(this.path), this.desc, this.visible
+            )
+        );
+    }
+
+    /**
+     * Write type annotation.
+     * @param visitor Visitor to write to.
+     */
+    public void write(final MethodVisitor visitor) {
+        this.write(
+            visitor.visitTypeAnnotation(
+                this.ref, TypePath.fromString(this.path), this.desc, this.visible
+            )
+        );
+    }
+
+    /**
+     * Write type annotation values.
+     * @param visitor Annotation visitor.
+     */
+    private void write(final AnnotationVisitor visitor) {
+        this.values.forEach(value -> value.writeTo(visitor));
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTypeAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/bytecode/BytecodeTypeAnnotations.java
@@ -14,6 +14,9 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.eolang.jeo.representation.directives.DirectivesTypeAnnotations;
 import org.eolang.jeo.representation.directives.Format;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.RecordComponentVisitor;
 
 /**
@@ -57,6 +60,30 @@ public final class BytecodeTypeAnnotations {
      * @param visitor Visitor to write to.
      */
     public void write(final RecordComponentVisitor visitor) {
+        this.annotations.forEach(annotation -> annotation.write(visitor));
+    }
+
+    /**
+     * Write to visitor.
+     * @param visitor Visitor to write to.
+     */
+    public void write(final ClassVisitor visitor) {
+        this.annotations.forEach(annotation -> annotation.write(visitor));
+    }
+
+    /**
+     * Write to visitor.
+     * @param visitor Visitor to write to.
+     */
+    public void write(final FieldVisitor visitor) {
+        this.annotations.forEach(annotation -> annotation.write(visitor));
+    }
+
+    /**
+     * Write to visitor.
+     * @param visitor Visitor to write to.
+     */
+    public void write(final MethodVisitor visitor) {
         this.annotations.forEach(annotation -> annotation.write(visitor));
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesClass.java
@@ -84,6 +84,11 @@ public final class DirectivesClass implements Iterable<Directive> {
     private final DirectivesAnnotations annotations;
 
     /**
+     * Type annotations.
+     */
+    private final DirectivesTypeAnnotations types;
+
+    /**
      * Attributes.
      */
     private final DirectivesAttributes attributes;
@@ -155,6 +160,36 @@ public final class DirectivesClass implements Iterable<Directive> {
         final DirectivesAnnotations annotations,
         final DirectivesAttributes attributes
     ) {
+        this(
+            format, name, properties, fields, methods, signature, annotations,
+            new DirectivesTypeAnnotations(), attributes
+        );
+    }
+
+    /**
+     * Constructor.
+     * @param format The format of the directives
+     * @param name The class name
+     * @param properties The class properties
+     * @param fields The class fields
+     * @param methods The class methods
+     * @param signature The class signature
+     * @param annotations The annotations
+     * @param types The type annotations
+     * @param attributes The attributes
+     * @checkstyle ParameterNumberCheck (10 lines)
+     */
+    public DirectivesClass(
+        final Format format,
+        final ClassName name,
+        final DirectivesClassProperties properties,
+        final List<DirectivesField> fields,
+        final List<DirectivesMethod> methods,
+        final String signature,
+        final DirectivesAnnotations annotations,
+        final DirectivesTypeAnnotations types,
+        final DirectivesAttributes attributes
+    ) {
         this.format = format;
         this.name = name;
         this.properties = properties;
@@ -162,6 +197,7 @@ public final class DirectivesClass implements Iterable<Directive> {
         this.methods = methods;
         this.signature = signature;
         this.annotations = annotations;
+        this.types = types;
         this.attributes = attributes;
     }
 
@@ -224,6 +260,7 @@ public final class DirectivesClass implements Iterable<Directive> {
             this.methods.stream().map(Directives::new).reduce(new Directives(), Directives::append),
             new DirectivesValue(this.format, "signature", this.sign()),
             this.annotations,
+            this.types.optional(),
             this.attributes
         ).iterator();
     }

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesField.java
@@ -86,6 +86,11 @@ public final class DirectivesField implements Iterable<Directive> {
     private final DirectivesAnnotations annotations;
 
     /**
+     * Type annotations.
+     */
+    private final DirectivesTypeAnnotations types;
+
+    /**
      * Constructor.
      */
     public DirectivesField() {
@@ -155,6 +160,34 @@ public final class DirectivesField implements Iterable<Directive> {
         final Object value,
         final DirectivesAnnotations annotations
     ) {
+        this(
+            format, access, name, descriptor, signature, value, annotations,
+            new DirectivesTypeAnnotations()
+        );
+    }
+
+    /**
+     * Constructor.
+     * @param format Format
+     * @param access Access modifiers
+     * @param name Name
+     * @param descriptor Descriptor
+     * @param signature Signature
+     * @param value Initial value
+     * @param annotations Annotations
+     * @param types Type annotations
+     * @checkstyle ParameterNumberCheck (10 lines)
+     */
+    public DirectivesField(
+        final Format format,
+        final int access,
+        final String name,
+        final String descriptor,
+        final String signature,
+        final Object value,
+        final DirectivesAnnotations annotations,
+        final DirectivesTypeAnnotations types
+    ) {
         this.format = format;
         this.access = access;
         this.name = name;
@@ -162,6 +195,7 @@ public final class DirectivesField implements Iterable<Directive> {
         this.signature = Optional.ofNullable(signature).orElse("");
         this.value = value;
         this.annotations = annotations;
+        this.types = types;
     }
 
     @Override
@@ -174,7 +208,8 @@ public final class DirectivesField implements Iterable<Directive> {
             new DirectivesValue(this.format, DirectivesField.title("descriptor"), this.descriptor),
             new DirectivesValue(this.format, DirectivesField.title("signature"), this.signature),
             new DirectivesValue(this.format, DirectivesField.title("value"), this.value),
-            this.annotations
+            this.annotations,
+            this.types.optional()
         ).iterator();
     }
 

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesMethod.java
@@ -67,6 +67,11 @@ public final class DirectivesMethod implements Iterable<Directive> {
     private final DirectivesAnnotations annotations;
 
     /**
+     * Method type annotations.
+     */
+    private final DirectivesTypeAnnotations types;
+
+    /**
      * Default value.
      */
     private final List<Iterable<Directive>> dvalue;
@@ -127,12 +132,43 @@ public final class DirectivesMethod implements Iterable<Directive> {
         final List<Iterable<Directive>> dvalue,
         final DirectivesAttributes attributes
     ) {
+        this(
+            format, name, properties, instructions, tryblocks, annotations,
+            new DirectivesTypeAnnotations(), dvalue, attributes
+        );
+    }
+
+    /**
+     * Constructor.
+     * @param format Directives format
+     * @param name Method name
+     * @param properties Method properties
+     * @param instructions Method instructions
+     * @param tryblocks Method try-catch blocks
+     * @param annotations Method annotations
+     * @param types Method type annotations
+     * @param dvalue Annotation default value
+     * @param attributes Method attributes
+     * @checkstyle ParameterNumberCheck (10 lines)
+     */
+    public DirectivesMethod(
+        final Format format,
+        final NumberedName name,
+        final DirectivesMethodProperties properties,
+        final List<Iterable<Directive>> instructions,
+        final List<Iterable<Directive>> tryblocks,
+        final DirectivesAnnotations annotations,
+        final DirectivesTypeAnnotations types,
+        final List<Iterable<Directive>> dvalue,
+        final DirectivesAttributes attributes
+    ) {
         this.format = format;
         this.name = name;
         this.properties = properties;
         this.instructions = instructions;
         this.tryblocks = tryblocks;
         this.annotations = annotations;
+        this.types = types;
         this.dvalue = dvalue;
         this.attributes = attributes;
     }
@@ -170,6 +206,7 @@ public final class DirectivesMethod implements Iterable<Directive> {
                 Stream.of(
                     this.properties,
                     this.annotations,
+                    this.types.optional(),
                     new DirectivesSeq("body", this.instructions),
                     new DirectivesSeq("trycatchblocks", this.tryblocks)
                 ),

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesTypeAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesTypeAnnotations.java
@@ -5,6 +5,7 @@
 package org.eolang.jeo.representation.directives;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.xembly.Directive;
@@ -51,6 +52,20 @@ public final class DirectivesTypeAnnotations implements Iterable<Directive> {
         final String name, final List<Iterable<Directive>> annotations) {
         this.name = name;
         this.annotations = annotations;
+    }
+
+    /**
+     * Directives only when at least one type annotation exists.
+     * @return This object or empty directives.
+     */
+    Iterable<Directive> optional() {
+        final Iterable<Directive> result;
+        if (this.annotations.isEmpty()) {
+            result = Collections.emptyList();
+        } else {
+            result = this;
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/org/eolang/jeo/representation/directives/DirectivesTypeAnnotations.java
+++ b/src/main/java/org/eolang/jeo/representation/directives/DirectivesTypeAnnotations.java
@@ -54,6 +54,14 @@ public final class DirectivesTypeAnnotations implements Iterable<Directive> {
         this.annotations = annotations;
     }
 
+    @Override
+    public Iterator<Directive> iterator() {
+        return new DirectivesSeq(
+            this.name,
+            this.annotations
+        ).iterator();
+    }
+
     /**
      * Directives only when at least one type annotation exists.
      * @return This object or empty directives.
@@ -66,13 +74,5 @@ public final class DirectivesTypeAnnotations implements Iterable<Directive> {
             result = this;
         }
         return result;
-    }
-
-    @Override
-    public Iterator<Directive> iterator() {
-        return new DirectivesSeq(
-            this.name,
-            this.annotations
-        ).iterator();
     }
 }

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -134,9 +134,10 @@ public final class XmlClass {
      */
     private BytecodeTypeAnnotations typeAnnotations() {
         return this.node.children()
-            .map(XmlJeoObject::new)
-            .filter(XmlJeoObject::named)
-            .filter(object -> "type-annotations".equals(object.name()))
+            .filter(child -> new XmlJeoObject(child).named())
+            .filter(
+                child -> "type-annotations".equals(new XmlJeoObject(child).name())
+            )
             .findFirst()
             .map(XmlTypeAnnotations::new)
             .map(XmlTypeAnnotations::bytecode)

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -16,6 +16,7 @@ import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.eolang.jeo.representation.bytecode.BytecodeAttributes;
 import org.eolang.jeo.representation.bytecode.BytecodeClass;
 import org.eolang.jeo.representation.bytecode.BytecodeClassProperties;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotations;
 import org.eolang.jeo.representation.directives.DirectivesClass;
 import org.eolang.jeo.representation.directives.DirectivesClassProperties;
 import org.objectweb.asm.Opcodes;
@@ -97,6 +98,7 @@ public final class XmlClass {
                 this.annotations()
                     .map(XmlAnnotations::bytecode)
                     .orElse(new BytecodeAnnotations()),
+                this.typeAnnotations(),
                 this.attributes()
                     .map(XmlAttributes::attributes)
                     .orElseGet(BytecodeAttributes::new),
@@ -124,6 +126,21 @@ public final class XmlClass {
             .filter(object -> "annotations".equals(object.name()))
             .findFirst()
             .map(XmlAnnotations::new);
+    }
+
+    /**
+     * Class type annotations.
+     * @return Type annotations.
+     */
+    private BytecodeTypeAnnotations typeAnnotations() {
+        return this.node.children()
+            .map(XmlJeoObject::new)
+            .filter(XmlJeoObject::named)
+            .filter(object -> "type-annotations".equals(object.name()))
+            .findFirst()
+            .map(XmlTypeAnnotations::new)
+            .map(XmlTypeAnnotations::bytecode)
+            .orElseGet(BytecodeTypeAnnotations::new);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -134,9 +134,10 @@ public final class XmlClass {
      */
     private BytecodeTypeAnnotations typeAnnotations() {
         return this.node.children()
-            .map(XmlJeoObject::new)
-            .filter(XmlJeoObject::named)
-            .filter(object -> "type-annotations".equals(object.name()))
+            .filter(child -> {
+                final XmlJeoObject object = new XmlJeoObject(child);
+                return object.named() && "type-annotations".equals(object.name());
+            })
             .findFirst()
             .map(XmlTypeAnnotations::new)
             .map(XmlTypeAnnotations::bytecode)

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlClass.java
@@ -134,10 +134,9 @@ public final class XmlClass {
      */
     private BytecodeTypeAnnotations typeAnnotations() {
         return this.node.children()
-            .filter(child -> {
-                final XmlJeoObject object = new XmlJeoObject(child);
-                return object.named() && "type-annotations".equals(object.name());
-            })
+            .map(XmlJeoObject::new)
+            .filter(XmlJeoObject::named)
+            .filter(object -> "type-annotations".equals(object.name()))
             .findFirst()
             .map(XmlTypeAnnotations::new)
             .map(XmlTypeAnnotations::bytecode)

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -138,9 +138,10 @@ public class XmlField {
      */
     private BytecodeTypeAnnotations typeAnnotations() {
         return this.node.children()
-            .map(XmlJeoObject::new)
-            .filter(XmlJeoObject::named)
-            .filter(object -> "type-annotations".equals(object.name()))
+            .filter(child -> {
+                final XmlJeoObject object = new XmlJeoObject(child);
+                return object.named() && "type-annotations".equals(object.name());
+            })
             .findFirst()
             .map(XmlTypeAnnotations::new)
             .map(XmlTypeAnnotations::bytecode)

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -138,9 +138,10 @@ public class XmlField {
      */
     private BytecodeTypeAnnotations typeAnnotations() {
         return this.node.children()
-            .map(XmlJeoObject::new)
-            .filter(XmlJeoObject::named)
-            .filter(object -> "type-annotations".equals(object.name()))
+            .filter(child -> new XmlJeoObject(child).named())
+            .filter(
+                child -> "type-annotations".equals(new XmlJeoObject(child).name())
+            )
             .findFirst()
             .map(XmlTypeAnnotations::new)
             .map(XmlTypeAnnotations::bytecode)

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -138,10 +138,9 @@ public class XmlField {
      */
     private BytecodeTypeAnnotations typeAnnotations() {
         return this.node.children()
-            .filter(child -> {
-                final XmlJeoObject object = new XmlJeoObject(child);
-                return object.named() && "type-annotations".equals(object.name());
-            })
+            .map(XmlJeoObject::new)
+            .filter(XmlJeoObject::named)
+            .filter(object -> "type-annotations".equals(object.name()))
             .findFirst()
             .map(XmlTypeAnnotations::new)
             .map(XmlTypeAnnotations::bytecode)

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlField.java
@@ -10,6 +10,7 @@ import lombok.ToString;
 import org.eolang.jeo.representation.PrefixedName;
 import org.eolang.jeo.representation.bytecode.BytecodeAnnotations;
 import org.eolang.jeo.representation.bytecode.BytecodeField;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotations;
 import org.eolang.jeo.representation.directives.JeoFqn;
 
 /**
@@ -56,7 +57,8 @@ public class XmlField {
             this.signature(),
             this.value(),
             this.access(),
-            this.annotations().map(XmlAnnotations::bytecode).orElse(new BytecodeAnnotations())
+            this.annotations().map(XmlAnnotations::bytecode).orElse(new BytecodeAnnotations()),
+            this.typeAnnotations()
         );
     }
 
@@ -128,6 +130,21 @@ public class XmlField {
             .filter(object -> name.equals(object.name()))
             .findFirst()
             .map(XmlAnnotations::new);
+    }
+
+    /**
+     * Field type annotations.
+     * @return Type annotations.
+     */
+    private BytecodeTypeAnnotations typeAnnotations() {
+        return this.node.children()
+            .map(XmlJeoObject::new)
+            .filter(XmlJeoObject::named)
+            .filter(object -> "type-annotations".equals(object.name()))
+            .findFirst()
+            .map(XmlTypeAnnotations::new)
+            .map(XmlTypeAnnotations::bytecode)
+            .orElseGet(BytecodeTypeAnnotations::new);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -373,9 +373,10 @@ public final class XmlMethod {
      */
     private BytecodeTypeAnnotations typeAnnotations() {
         return this.node.children()
-            .map(XmlJeoObject::new)
-            .filter(XmlJeoObject::named)
-            .filter(object -> "type-annotations".equals(object.name()))
+            .filter(child -> {
+                final XmlJeoObject object = new XmlJeoObject(child);
+                return object.named() && "type-annotations".equals(object.name());
+            })
             .findFirst()
             .map(XmlTypeAnnotations::new)
             .map(XmlTypeAnnotations::bytecode)

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -373,10 +373,9 @@ public final class XmlMethod {
      */
     private BytecodeTypeAnnotations typeAnnotations() {
         return this.node.children()
-            .filter(child -> {
-                final XmlJeoObject object = new XmlJeoObject(child);
-                return object.named() && "type-annotations".equals(object.name());
-            })
+            .map(XmlJeoObject::new)
+            .filter(XmlJeoObject::named)
+            .filter(object -> "type-annotations".equals(object.name()))
             .findFirst()
             .map(XmlTypeAnnotations::new)
             .map(XmlTypeAnnotations::bytecode)

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -19,6 +19,7 @@ import org.eolang.jeo.representation.bytecode.BytecodeMaxs;
 import org.eolang.jeo.representation.bytecode.BytecodeMethod;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodParameters;
 import org.eolang.jeo.representation.bytecode.BytecodeMethodProperties;
+import org.eolang.jeo.representation.bytecode.BytecodeTypeAnnotations;
 import org.eolang.jeo.representation.directives.DirectivesMaxs;
 import org.eolang.jeo.representation.directives.DirectivesMethod;
 import org.eolang.jeo.representation.directives.DirectivesMethodParams;
@@ -124,6 +125,7 @@ public final class XmlMethod {
                     .map(XmlBytecodeEntry::bytecode)
                     .collect(Collectors.toList()),
                 this.annotations(),
+                this.typeAnnotations(),
                 this.properties(),
                 this.defvalue()
                     .map(XmlDefaultValue::bytecode)
@@ -363,6 +365,21 @@ public final class XmlMethod {
             .map(XmlAnnotations::new)
             .map(XmlAnnotations::bytecode)
             .orElse(new BytecodeAnnotations());
+    }
+
+    /**
+     * Method type annotations.
+     * @return Type annotations.
+     */
+    private BytecodeTypeAnnotations typeAnnotations() {
+        return this.node.children()
+            .map(XmlJeoObject::new)
+            .filter(XmlJeoObject::named)
+            .filter(object -> "type-annotations".equals(object.name()))
+            .findFirst()
+            .map(XmlTypeAnnotations::new)
+            .map(XmlTypeAnnotations::bytecode)
+            .orElseGet(BytecodeTypeAnnotations::new);
     }
 
     /**

--- a/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
+++ b/src/main/java/org/eolang/jeo/representation/xmir/XmlMethod.java
@@ -373,9 +373,10 @@ public final class XmlMethod {
      */
     private BytecodeTypeAnnotations typeAnnotations() {
         return this.node.children()
-            .map(XmlJeoObject::new)
-            .filter(XmlJeoObject::named)
-            .filter(object -> "type-annotations".equals(object.name()))
+            .filter(child -> new XmlJeoObject(child).named())
+            .filter(
+                child -> "type-annotations".equals(new XmlJeoObject(child).name())
+            )
             .findFirst()
             .map(XmlTypeAnnotations::new)
             .map(XmlTypeAnnotations::bytecode)

--- a/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
+++ b/src/test/java/org/eolang/jeo/representation/BytecodeRepresentationTest.java
@@ -5,6 +5,8 @@
 package org.eolang.jeo.representation;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import org.cactoos.bytes.BytesOf;
 import org.cactoos.io.ResourceOf;
 import org.eolang.jeo.VerifiedBytecode;
@@ -17,7 +19,14 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.TypeReference;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.TypeAnnotationNode;
 
 /**
  * Test cases for {@link BytecodeRepresentation}.
@@ -48,6 +57,12 @@ final class BytecodeRepresentationTest {
      */
     @SuppressWarnings("JTCOP.RuleProhibitStaticFields")
     private static final Format DEBUG = new Format(Format.MODE, "debug");
+
+    /**
+     * Descriptor of a synthetic TYPE_USE annotation.
+     */
+    @SuppressWarnings("JTCOP.RuleProhibitStaticFields")
+    private static final String TYPE_USE = "Lorg/eolang/jeo/TypeUse;";
 
     @Test
     void parsesBytecode() {
@@ -211,6 +226,42 @@ final class BytecodeRepresentationTest {
     }
 
     @Test
+    void preservesClassFieldAndMethodTypeAnnotations() {
+        final Bytecode source = new Bytecode(BytecodeRepresentationTest.typeAnnotated());
+        final ClassNode restored = new ClassNode();
+        new ClassReader(
+            new XmirRepresentation(
+                new BytecodeRepresentation(source).toXmir(BytecodeRepresentationTest.DEBUG)
+            ).toBytecode().bytes()
+        ).accept(restored, 0);
+        MatcherAssert.assertThat(
+            "Class, field, and method type annotations must survive the XMIR round-trip",
+            Arrays.asList(
+                restored.visibleTypeAnnotations.get(0),
+                restored.fields.get(0).visibleTypeAnnotations.get(0),
+                restored.methods.get(0).visibleTypeAnnotations.get(0)
+            ).stream().map(BytecodeRepresentationTest::typeAnnotation).collect(Collectors.toList()),
+            Matchers.contains(
+                String.format(
+                    "%s:%d:null",
+                    BytecodeRepresentationTest.TYPE_USE,
+                    TypeReference.newSuperTypeReference(-1).getValue()
+                ),
+                String.format(
+                    "%s:%d:null",
+                    BytecodeRepresentationTest.TYPE_USE,
+                    TypeReference.newTypeReference(TypeReference.FIELD).getValue()
+                ),
+                String.format(
+                    "%s:%d:null",
+                    BytecodeRepresentationTest.TYPE_USE,
+                    TypeReference.newTypeReference(TypeReference.METHOD_RETURN).getValue()
+                )
+            )
+        );
+    }
+
+    @Test
     void parsesAnnotationsAndConvertsThemBackToValidBytecode() throws Exception {
         final Bytecode original = new Bytecode(
             new BytesOf(new ResourceOf("AnnotationsApplication.class")).asBytes()
@@ -225,4 +276,64 @@ final class BytecodeRepresentationTest {
             Matchers.equalTo(original.toString())
         );
     }
+
+    /**
+     * Synthetic class with type-use annotations on class, field and method.
+     * @return Class bytecode.
+     */
+    private static byte[] typeAnnotated() {
+        final ClassWriter writer = new ClassWriter(0);
+        writer.visit(
+            Opcodes.V11,
+            Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT,
+            "TypeAnnotated",
+            null,
+            "java/lang/Object",
+            null
+        );
+        writer.visitTypeAnnotation(
+            TypeReference.newSuperTypeReference(-1).getValue(),
+            null,
+            BytecodeRepresentationTest.TYPE_USE,
+            true
+        ).visitEnd();
+        final FieldVisitor field = writer.visitField(
+            Opcodes.ACC_PRIVATE, "value", "Ljava/lang/String;", null, null
+        );
+        field.visitTypeAnnotation(
+            TypeReference.newTypeReference(TypeReference.FIELD).getValue(),
+            null,
+            BytecodeRepresentationTest.TYPE_USE,
+            true
+        ).visitEnd();
+        field.visitEnd();
+        final MethodVisitor method = writer.visitMethod(
+            Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT,
+            "value",
+            "()Ljava/lang/String;",
+            null,
+            null
+        );
+        method.visitTypeAnnotation(
+            TypeReference.newTypeReference(TypeReference.METHOD_RETURN).getValue(),
+            null,
+            BytecodeRepresentationTest.TYPE_USE,
+            true
+        ).visitEnd();
+        method.visitEnd();
+        writer.visitEnd();
+        return writer.toByteArray();
+    }
+
+    /**
+     * Compact identity of a type annotation used by the round-trip assertion.
+     * @param annotation Annotation.
+     * @return Descriptor, reference and path.
+     */
+    private static String typeAnnotation(final TypeAnnotationNode annotation) {
+        return String.format(
+            "%s:%d:%s", annotation.desc, annotation.typeRef, annotation.typePath
+        );
+    }
+
 }


### PR DESCRIPTION
Closes #1598.

JEO already had a complete type-annotation representation for record components (`AsmTypeAnnotations` → `BytecodeTypeAnnotations` → `DirectivesTypeAnnotations` → `XmlTypeAnnotations`), but class, field, and method nodes never connected to it. Their `visibleTypeAnnotations` / `invisibleTypeAnnotations` lists were therefore discarded at the ASM boundary.

This wires the existing representation through all three missing declaration kinds:

- `ClassNode` ↔ class XMIR ↔ `ClassVisitor.visitTypeAnnotation`
- `FieldNode` ↔ field XMIR ↔ `FieldVisitor.visitTypeAnnotation`
- `MethodNode` ↔ method XMIR ↔ `MethodVisitor.visitTypeAnnotation`

Existing public constructors are preserved as delegating overloads with an empty type-annotation set. Empty sets are omitted from class/field/method directives so bytecode without type-use annotations keeps its previous XMIR shape; record-component output is unchanged.

While connecting real ASM nodes, I also fixed the root type-path case: ASM legally represents an annotation directly on the referenced type with `typePath == null`. `BytecodeTypeAnnotation` previously called `path.toString()` unconditionally, so the common `@TypeUse String` form would have failed before it could be preserved. An empty stored path round-trips through `TypePath.fromString("")` to the root/null path.

Regression coverage constructs a valid abstract class in ASM with runtime-visible TYPE_USE annotations on its superclass, one field type, and one method return type (all root/null type paths), runs the full `bytecode → XMIR → bytecode` pipeline, reparses the result with ASM, and asserts all three descriptors, type references, and null paths survive.

Maven is not installed in this Android/Termux environment, so repository CI is the compile/test/quality validation source. `git diff --check` is clean locally.
