### PR TITLE
#1667: Validate disassembly mode before work

### DIFF
--- a/src/main/java/org/eolang/jeo/DisassembleMojo.java
+++ b/src/main/java/org/eolang/jeo/DisassembleMojo.java
@@ -16,6 +16,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.cactoos.set.SetOf;
+import org.eolang.jeo.representation.asm.DisassembleMode;
 import org.eolang.jeo.representation.directives.Format;
 
 /**
@@ -248,6 +249,7 @@ public final class DisassembleMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException {
         this.checkedThreads();
+        this.checkedMode();
         final Path src = new MavenPath(this.sourcesDir).resolve();
         final Path out = new MavenPath(this.outputDir).resolve();
         try {
@@ -296,6 +298,18 @@ public final class DisassembleMojo extends AbstractMojo {
                 String.format("Failed to transpile bytecode to EO, from '%s' to '%s'", src, out),
                 exception
             );
+        }
+    }
+
+    /**
+     * Check that the disassembly mode is valid.
+     * @throws MojoExecutionException If the mode is unknown
+     */
+    private void checkedMode() throws MojoExecutionException {
+        try {
+            DisassembleMode.fromString(this.mode);
+        } catch (final IllegalArgumentException exception) {
+            throw new MojoExecutionException(exception.getMessage(), exception);
         }
     }
 

--- a/src/test/java/org/eolang/jeo/DisassembleMojoTest.java
+++ b/src/test/java/org/eolang/jeo/DisassembleMojoTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.jeo;
+
+import java.lang.reflect.Field;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link DisassembleMojo}.
+ * @since 0.15.4
+ */
+final class DisassembleMojoTest {
+
+    @Test
+    void rejectsUnknownModeBeforeStartingWork() throws Exception {
+        final DisassembleMojo mojo = new DisassembleMojo();
+        DisassembleMojoTest.field("mode").set(mojo, "Debag");
+        DisassembleMojoTest.field("threads").setInt(mojo, 0);
+        MatcherAssert.assertThat(
+            "Unknown mode was not rejected before disassembly setup",
+            Assertions.assertThrows(MojoExecutionException.class, mojo::execute).getMessage(),
+            Matchers.containsString("Unknown disassemble mode: Debag")
+        );
+    }
+
+    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
+    private static Field field(final String name) throws NoSuchFieldException {
+        final Field field = DisassembleMojo.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field;
+    }
+}


### PR DESCRIPTION
Closes #1667.

`DisassembleMojo` now validates `jeo.disassemble.mode` immediately after validating `threads`, before resolving Maven paths, initializing the plugin classloader, logging that disassembly started, or creating parallel workers.

An invalid value from `DisassembleMode.fromString()` is converted to `MojoExecutionException` with the original diagnostic, so a typo such as `Debag` surfaces as a configuration error instead of being wrapped later as a parallel-translation failure.

Added a regression test that intentionally leaves the work paths unconfigured and sets only `mode=Debag`; it can pass only when the mode is rejected before disassembly setup. Reflection is confined to the test helper with the same targeted PMD suppression already used by the project for accessibility alteration.

`git diff --check` is clean. Maven is not installed in this Termux environment, so the repository CI matrix will run the Java tests.
